### PR TITLE
PintDex Rebrand: 3-Phase UI/UX Overhaul

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,7 +28,7 @@
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
-    --radius: 0.5rem;
+    --radius: 0.75rem;
   }
   .dark {
     --background: 0 0% 3.9%;
@@ -55,6 +55,24 @@
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
+  }
+}
+
+@layer base {
+  html {
+    font-size: 16px;
+  }
+  body {
+    @apply text-[17px] leading-relaxed;
+  }
+}
+
+@layer components {
+  .section-gap {
+    @apply py-12 sm:py-16 md:py-20;
+  }
+  .section-gap-sm {
+    @apply py-8 sm:py-12;
   }
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,30 +1,35 @@
 'use client'
-import Link from 'next/link'
-
 import { useState, useMemo, useEffect, useRef } from 'react'
-import { useRouter } from 'next/navigation'
-import dynamic from 'next/dynamic'
 import { Pub } from '@/types/pub'
-import SubmitPubForm from '@/components/SubmitPubForm'
-import CrowdBadge from '@/components/CrowdBadge'
-import CrowdReporter from '@/components/CrowdReporter'
+import { getPubs, getCrowdLevels, CrowdReport } from '@/lib/supabase'
+import { getHappyHourStatus } from '@/lib/happyHour'
+import { getDistanceKm } from '@/lib/location'
+import dynamic from 'next/dynamic'
+
+// Extracted components
+import HeroSection from '@/components/HeroSection'
+import StatsBar from '@/components/StatsBar'
+import TabBar, { TabId } from '@/components/TabBar'
 import { FilterSection } from '@/components/FilterSection'
+import PubListView from '@/components/PubListView'
+import PubCardsView from '@/components/PubCardsView'
+import PintIndexCompact from '@/components/PintIndexCompact'
 import PintIndex from '@/components/PintIndex'
-import PriceTicker from '@/components/PriceTicker'
-import SunsetSippers from '@/components/SunsetSippers'
-import BeerWeather from '@/components/BeerWeather'
 import SuburbLeague from '@/components/SuburbLeague'
-import CrowdPulse from '@/components/CrowdPulse'
 import TonightsMoves from '@/components/TonightsMoves'
 import VenueIntel from '@/components/VenueIntel'
+import CrowdPulse from '@/components/CrowdPulse'
+import BeerWeather from '@/components/BeerWeather'
+import SunsetSippers from '@/components/SunsetSippers'
 import PuntNPints from '@/components/PuntNPints'
 import DadBar from '@/components/DadBar'
-import TabBar, { TabId } from '@/components/TabBar'
-import PintIndexCompact from '@/components/PintIndexCompact'
-import PubCard from '@/components/PubCard'
-import { getDistanceKm, formatDistance } from '@/lib/location'
-import { getCrowdLevels, CrowdReport, CROWD_LEVELS, getPubs } from '@/lib/supabase'
-import { getHappyHourStatus } from '@/lib/happyHour'
+import PriceTicker from '@/components/PriceTicker'
+import HowItWorks from '@/components/HowItWorks'
+import SocialProof from '@/components/SocialProof'
+import FAQ from '@/components/FAQ'
+import Footer from '@/components/Footer'
+import SubmitPubForm from '@/components/SubmitPubForm'
+import CrowdReporter from '@/components/CrowdReporter'
 
 const Map = dynamic(() => import('@/components/Map'), {
   ssr: false,
@@ -38,209 +43,13 @@ const Map = dynamic(() => import('@/components/Map'), {
   )
 })
 
-const MiniMap = dynamic(() => import('@/components/MiniMap'), {
-  ssr: false,
-  loading: () => <div className="h-24 bg-stone-200 rounded-lg animate-pulse"></div>
-})
-
 function isHappyHour(happyHour: string | null | undefined): boolean {
   if (!happyHour) return false
   const status = getHappyHourStatus(happyHour)
   return status.isActive
 }
 
-function getPriceColor(price: number | null): string {
-  if (price === null) return 'from-stone-400 to-stone-500'
-  if (price <= 7) return 'from-green-600 to-green-700'
-  if (price <= 8) return 'from-yellow-600 to-yellow-700'
-  if (price <= 9) return 'from-orange-600 to-orange-700'
-  return 'from-red-600 to-red-700'
-}
-
-function getPriceBgColor(price: number | null): string {
-  if (price === null) return 'bg-stone-400'
-  if (price <= 7) return 'bg-green-700'
-  if (price <= 8) return 'bg-yellow-700'
-  if (price <= 9) return 'bg-orange-700'
-  return 'bg-red-700'
-}
-
-function getPriceTextColor(price: number | null): string {
-  if (price === null) return 'text-stone-400'
-  if (price <= 7) return 'text-green-700'
-  if (price <= 8) return 'text-yellow-700'
-  if (price <= 9) return 'text-orange-700'
-  return 'text-red-700'
-}
-
-
-function getDirectionsUrl(pub: Pub): string {
-  const query = encodeURIComponent(`${pub.name}, ${pub.address}`)
-  return `https://www.google.com/maps/dir/?api=1&destination=${query}`
-}
-
-function formatLastUpdated(dateStr: string | undefined): string {
-  if (!dateStr) return ''
-  const date = new Date(dateStr)
-  return date.toLocaleDateString('en-AU', { month: 'short', year: 'numeric' })
-}
-
-/* ═══════════════════════════════════════ */
-/* ═══  HOW IT WORKS SECTION            ═══ */
-/* ═══════════════════════════════════════ */
-function HowItWorks() {
-  const steps = [
-    {
-      num: '01',
-      title: 'Find pubs near you',
-      desc: 'Browse 200+ pubs across 90 Perth suburbs with real-time prices and happy hour info.',
-      icon: (
-        <svg className="w-8 h-8" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
-        </svg>
-      ),
-    },
-    {
-      num: '02',
-      title: 'Compare prices',
-      desc: 'See how every pub stacks up against the Perth average. Track happy hours and price changes.',
-      icon: (
-        <svg className="w-8 h-8" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
-        </svg>
-      ),
-    },
-    {
-      num: '03',
-      title: 'Go enjoy your pint',
-      desc: 'Get directions, check the vibe, and save money on your next round. Simple as.',
-      icon: (
-        <svg className="w-8 h-8" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M15.182 15.182a4.5 4.5 0 01-6.364 0M21 12a9 9 0 11-18 0 9 9 0 0118 0zM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75zm-.375 0h.008v.015h-.008V9.75zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75zm-.375 0h.008v.015h-.008V9.75z" />
-        </svg>
-      ),
-    },
-  ]
-
-  return (
-    <section className="py-16 border-t border-stone-200">
-      <div className="max-w-4xl mx-auto px-4">
-        <h2 className="text-3xl sm:text-4xl font-bold text-charcoal font-heading text-center mb-3">
-          How it works
-        </h2>
-        <p className="text-stone-500 text-center mb-12 text-lg">No app download. No sign-up. Just prices.</p>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-8 sm:gap-12">
-          {steps.map((step) => (
-            <div key={step.num} className="text-center">
-              <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-amber/10 text-amber mb-5">
-                {step.icon}
-              </div>
-              <div className="text-sm font-mono text-amber font-bold mb-2">{step.num}</div>
-              <h3 className="text-xl font-bold text-charcoal mb-2 font-heading">{step.title}</h3>
-              <p className="text-stone-500 leading-relaxed">{step.desc}</p>
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  )
-}
-
-/* ═══════════════════════════════════════ */
-/* ═══  FAQ SECTION                     ═══ */
-/* ═══════════════════════════════════════ */
-function FAQ() {
-  const [openIndex, setOpenIndex] = useState<number | null>(null)
-  const faqs = [
-    {
-      q: 'How are prices verified?',
-      a: 'Every price on PintDex is manually verified through pub menus, direct calls, and community submissions. We never estimate or guess — if we don\'t have a verified price, we show "Price TBC" until we confirm it.',
-    },
-    {
-      q: 'How often is the data updated?',
-      a: 'We run automated checks weekly and accept community submissions around the clock. Every price includes a "last verified" date so you know how fresh it is.',
-    },
-    {
-      q: 'What does the price represent?',
-      a: 'All prices shown are for a standard pint (570ml) of the cheapest tap beer available at each venue. Happy hour prices are shown when they\'re currently active.',
-    },
-    {
-      q: 'How can I submit a price?',
-      a: 'Tap the "Submit a Price" button at the top of the page. Tell us the pub name, suburb, and the pint price you paid. We\'ll verify and add it to the database.',
-    },
-    {
-      q: 'Why is a pub showing "Price TBC"?',
-      a: 'We only display prices we\'ve confirmed. "Price TBC" means we know the pub exists but haven\'t verified its current pint price yet. You can help by submitting it!',
-    },
-    {
-      q: 'Is PintDex free?',
-      a: 'Yep — completely free. No app download, no sign-up, no ads. Just Perth pint prices, sorted.',
-    },
-  ]
-
-  return (
-    <section className="py-16 border-t border-stone-200">
-      <div className="max-w-3xl mx-auto px-4">
-        <h2 className="text-3xl sm:text-4xl font-bold text-charcoal font-heading text-center mb-3">
-          Questions?
-        </h2>
-        <p className="text-stone-500 text-center mb-10 text-lg">Everything you need to know about PintDex.</p>
-        <div className="space-y-0">
-          {faqs.map((faq, i) => (
-            <div key={i} className="border-b border-stone-200">
-              <button
-                onClick={() => setOpenIndex(openIndex === i ? null : i)}
-                className="w-full flex items-center justify-between py-5 text-left group"
-              >
-                <span className="text-lg font-semibold text-charcoal group-hover:text-amber transition-colors pr-4">
-                  {faq.q}
-                </span>
-                <svg
-                  className={`w-5 h-5 text-stone-400 flex-shrink-0 transition-transform duration-200 ${openIndex === i ? 'rotate-180' : ''}`}
-                  fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-                </svg>
-              </button>
-              {openIndex === i && (
-                <div className="pb-5 text-stone-600 leading-relaxed -mt-1">
-                  {faq.a}
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  )
-}
-
-/* ═══════════════════════════════════════ */
-/* ═══  SOCIAL PROOF / STATS BAR        ═══ */
-/* ═══════════════════════════════════════ */
-function SocialProof({ stats }: { stats: { total: number; avgPrice: string } }) {
-  const proofs = [
-    { value: `${stats.total}+`, label: 'Venues tracked' },
-    { value: '90', label: 'Perth suburbs' },
-    { value: `$${stats.avgPrice}`, label: 'Perth average pint' },
-    { value: '100%', label: 'Verified prices' },
-  ]
-  return (
-    <section className="py-12 border-t border-stone-200 bg-cream-dark">
-      <div className="max-w-5xl mx-auto px-4">
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 text-center">
-          {proofs.map((p) => (
-            <div key={p.label}>
-              <div className="text-3xl sm:text-4xl font-black text-charcoal font-heading">{p.value}</div>
-              <div className="text-stone-500 text-sm mt-1">{p.label}</div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  )
-}
-
+const INITIAL_PUB_COUNT = 20
 
 export default function Home() {
   const [pubs, setPubs] = useState<Pub[]>([])
@@ -255,7 +64,6 @@ export default function Home() {
   const [crowdReports, setCrowdReports] = useState<Record<string, CrowdReport>>({})
   const [crowdReportPub, setCrowdReportPub] = useState<Pub | null>(null)
   const [currentTime, setCurrentTime] = useState(new Date())
-  const router = useRouter()
   const [activeTab, setActiveTab] = useState<TabId>('pubs')
   const [viewMode, setViewMode] = useState<'cards' | 'list'>('list')
   const [showMoreFilters, setShowMoreFilters] = useState(false)
@@ -263,7 +71,7 @@ export default function Home() {
   const [userLocation, setUserLocation] = useState<{lat: number, lng: number} | null>(null)
   const [locationState, setLocationState] = useState<'idle' | 'granted' | 'denied' | 'dismissed'>('idle')
   const [heroVisible, setHeroVisible] = useState(true)
-  const INITIAL_PUB_COUNT = 20
+  const [showMap, setShowMap] = useState(true)
   const appRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -286,7 +94,6 @@ export default function Home() {
     return () => clearInterval(interval)
   }, [])
 
-  // Auto-request location on load (native browser prompt, no custom UI)
   useEffect(() => {
     if (typeof window !== 'undefined' && navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(
@@ -304,12 +111,6 @@ export default function Home() {
   async function fetchCrowdReports() {
     const reports = await getCrowdLevels()
     setCrowdReports(reports)
-  }
-
-
-
-  function getLatestCrowdReport(pubId: number): CrowdReport | undefined {
-    return crowdReports[String(pubId)]
   }
 
   const suburbs = useMemo(() => {
@@ -330,7 +131,6 @@ export default function Home() {
         return matchesSearch && matchesSuburb && matchesPrice && matchesHappyHour
       })
       .sort((a, b) => {
-        // When HH filter is on, put currently-active happy hours first
         if (showHappyHourOnly) {
           const aActive = a.isHappyHourNow || isHappyHour(a.happyHour) ? 1 : 0
           const bActive = b.isHappyHourNow || isHappyHour(b.happyHour) ? 1 : 0
@@ -365,7 +165,7 @@ export default function Home() {
       priciestSuburb: priciest?.suburb || ''
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pubs, currentTime]) // currentTime triggers happyHourNow recount every minute
+  }, [pubs, currentTime])
 
   const liveCrowdCount = Object.keys(crowdReports).length
 
@@ -387,90 +187,29 @@ export default function Home() {
 
   return (
     <main className="min-h-screen bg-cream">
-
-      {/* ═══════════════════════════════════════════════════════════════ */}
-      {/* ═══  HERO SECTION — EatClub-style brand-first landing       ═══ */}
-      {/* ═══════════════════════════════════════════════════════════════ */}
+      {/* ═══ HERO SECTION ═══ */}
       {heroVisible && (
-        <section className="bg-cream relative overflow-hidden">
-          {/* Top nav bar — minimal like EatClub */}
-          <div className="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
-            <div className="flex items-center gap-2.5">
-              <img src="/logo.png" alt="PintDex" className="w-10 h-10 rounded-lg object-contain" />
-              <span className="text-xl font-extrabold tracking-tight font-heading text-charcoal">PintDex</span>
-            </div>
-            <button
-              onClick={() => setShowSubmitForm(true)}
-              className="px-5 py-2.5 bg-charcoal hover:bg-charcoal/90 text-white rounded-full font-bold transition-all text-sm"
-            >
-              Submit a Price
-            </button>
-          </div>
-
-          {/* Hero content — big, confident, breathing room */}
-          <div className="max-w-4xl mx-auto px-4 pt-12 sm:pt-20 pb-16 sm:pb-24 text-center">
-            <h1 className="text-4xl sm:text-6xl lg:text-7xl font-black text-charcoal font-heading leading-[1.05] mb-6">
-              Perth&apos;s pint prices,{' '}
-              <span className="text-amber">sorted.</span>
-            </h1>
-            <p className="text-lg sm:text-xl text-stone-500 max-w-2xl mx-auto mb-10 leading-relaxed">
-              Real-time prices across {stats.total}+ pubs and {suburbs.length} suburbs.
-              Find happy hours, compare prices, and save on your next round.
-            </p>
-
-            {/* Hero stat highlights — EatClub-style bold numbers */}
-            <div className="flex flex-wrap justify-center gap-4 sm:gap-8 mb-10">
-              <div className="bg-white rounded-2xl px-5 py-3 shadow-sm border border-stone-200/60">
-                <span className="block text-2xl sm:text-3xl font-black font-mono text-green-700">${stats.minPrice}</span>
-                <span className="text-xs text-stone-500">Cheapest pint</span>
-              </div>
-              <div className="bg-white rounded-2xl px-5 py-3 shadow-sm border border-stone-200/60">
-                <span className="block text-2xl sm:text-3xl font-black font-mono text-charcoal">${stats.avgPrice}</span>
-                <span className="text-xs text-stone-500">Perth average</span>
-              </div>
-              {stats.happyHourNow > 0 && (
-                <div className="bg-white rounded-2xl px-5 py-3 shadow-sm border border-amber/30 bg-amber/5">
-                  <span className="block text-2xl sm:text-3xl font-black font-mono text-amber">{stats.happyHourNow}</span>
-                  <span className="text-xs text-stone-500">Happy hours live</span>
-                </div>
-              )}
-            </div>
-
-            {/* CTA buttons */}
-            <div className="flex flex-col sm:flex-row gap-3 justify-center">
-              <button
-                onClick={scrollToApp}
-                className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-charcoal hover:bg-charcoal/90 text-white rounded-full font-bold text-lg transition-all shadow-lg shadow-charcoal/10"
-              >
-                Explore {stats.total} venues
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
-                </svg>
-              </button>
-              <button
-                onClick={() => { scrollToApp(); setActiveTab('explore'); }}
-                className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-white hover:bg-stone-50 text-charcoal rounded-full font-bold text-lg transition-all border border-stone-300"
-              >
-                Discover features
-              </button>
-            </div>
-          </div>
-        </section>
+        <HeroSection
+          avgPrice={stats.avgPrice}
+          cheapestPrice={stats.minPrice}
+          venueCount={stats.total}
+          suburbCount={suburbs.length}
+          happyHourCount={stats.happyHourNow}
+          onExploreClick={scrollToApp}
+          onDiscoverClick={() => { scrollToApp(); setActiveTab('explore'); }}
+          onSubmitClick={() => setShowSubmitForm(true)}
+        />
       )}
 
-
-      {/* ═══════════════════════════════════════════════════════════════ */}
-      {/* ═══  APP SECTION — the full PintDex experience              ═══ */}
-      {/* ═══════════════════════════════════════════════════════════════ */}
+      {/* ═══ APP SECTION ═══ */}
       <div ref={appRef}>
         <PriceTicker pubs={pubs} />
-        <header className="bg-white sticky top-0 z-[1000] shadow-[0_1px_4px_rgba(0,0,0,0.06)]">
-          {/* Compact brand bar */}
+        <header className="bg-cream sticky top-0 z-[1000] shadow-[0_1px_4px_rgba(0,0,0,0.06)]">
           <div className="max-w-7xl mx-auto px-4 pt-2.5 pb-0">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <img src="/logo.png" alt="PintDex" className="w-10 h-10 rounded-lg flex-shrink-0 object-contain" />
-                <h1 className="text-lg font-extrabold tracking-tight leading-none font-heading text-charcoal">PintDex</h1>
+                <h1 className="text-lg font-bold tracking-tight leading-none font-heading text-charcoal">PintDex</h1>
                 <div className="flex items-center gap-1 ml-1">
                   <div className="w-1.5 h-1.5 rounded-full bg-amber animate-pulse" />
                   <span className="text-[10px] text-amber/70 uppercase tracking-wider font-medium">Live</span>
@@ -485,32 +224,18 @@ export default function Home() {
               </button>
             </div>
 
-            {/* Stat pods — warm amber accent */}
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mt-2.5 pb-2.5">
-              <div className="bg-stone-50 rounded-lg px-2.5 py-1.5 border border-stone-200">
-                <span className="text-stone-500 text-[9px] uppercase tracking-wider block leading-none">Perth Avg</span>
-                <span className="text-charcoal font-mono font-black text-base sm:text-lg leading-tight">${stats.avgPrice}</span>
-                <span className="text-stone-400 text-[9px] block leading-none mt-0.5">{stats.total} venues</span>
-              </div>
-              <div className="bg-stone-50 rounded-lg px-2.5 py-1.5 border border-stone-200">
-                <span className="text-stone-500 text-[9px] uppercase tracking-wider block leading-none">Cheapest</span>
-                <span className="text-green-700 font-mono font-black text-base sm:text-lg leading-tight">${stats.minPrice}</span>
-                <span className="text-stone-400 text-[9px] block leading-none mt-0.5 truncate">{stats.cheapestSuburb}</span>
-              </div>
-              <div className="bg-stone-50 rounded-lg px-2.5 py-1.5 border border-stone-200">
-                <span className="text-stone-500 text-[9px] uppercase tracking-wider block leading-none">Priciest</span>
-                <span className="text-red-700 font-mono font-black text-base sm:text-lg leading-tight">${stats.maxPriceValue}</span>
-                <span className="text-stone-400 text-[9px] block leading-none mt-0.5 truncate">{stats.priciestSuburb}</span>
-              </div>
-              <div className="bg-stone-50 rounded-lg px-2.5 py-1.5 border border-stone-200">
-                <span className="text-stone-500 text-[9px] uppercase tracking-wider block leading-none">Happy Hour</span>
-                <span className="text-amber font-mono font-black text-base sm:text-lg leading-tight">{stats.happyHourNow}</span>
-                <span className="text-stone-400 text-[9px] block leading-none mt-0.5">{suburbs.length} suburbs</span>
-              </div>
-            </div>
+            <StatsBar
+              avgPrice={stats.avgPrice}
+              cheapestPrice={stats.minPrice}
+              cheapestSuburb={stats.cheapestSuburb}
+              priciestPrice={stats.maxPriceValue}
+              priciestSuburb={stats.priciestSuburb}
+              happyHourCount={stats.happyHourNow}
+              suburbCount={suburbs.length}
+              venueCount={stats.total}
+            />
           </div>
 
-          {/* Tab navigation */}
           <TabBar
             activeTab={activeTab}
             onTabChange={setActiveTab}
@@ -518,7 +243,6 @@ export default function Home() {
             crowdCount={liveCrowdCount}
           />
 
-          {/* Filters — only on Pubs tab */}
           {activeTab === 'pubs' && (
             <FilterSection
               viewMode={viewMode}
@@ -545,15 +269,24 @@ export default function Home() {
         </header>
 
         <div className="max-w-7xl mx-auto px-4 py-5">
-
           {/* ═══ PUBS TAB ═══ */}
           {activeTab === 'pubs' && (
             <>
               <PintIndexCompact pubs={pubs} filteredPubs={filteredPubs} onViewMore={() => setActiveTab('market')} />
 
-              <div className="mb-5 rounded-2xl overflow-hidden shadow-[0_2px_12px_rgba(0,0,0,0.06)] border border-stone-200/60 relative z-0 isolate">
-                <Map pubs={filteredPubs} isHappyHour={isHappyHour} userLocation={userLocation} totalPubCount={pubs.length} />
-              </div>
+              <button
+                onClick={() => setShowMap(!showMap)}
+                className="flex items-center gap-2 text-sm text-stone-500 hover:text-charcoal transition-colors mb-3"
+              >
+                <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
+                {showMap ? 'Hide map' : 'Show map'}
+              </button>
+
+              {showMap && (
+                <div className="mb-5 rounded-2xl overflow-hidden shadow-[0_2px_12px_rgba(0,0,0,0.06)] border border-stone-200/60 relative z-0 isolate">
+                  <Map pubs={filteredPubs} isHappyHour={isHappyHour} userLocation={userLocation} totalPubCount={pubs.length} />
+                </div>
+              )}
 
               <div className="flex items-center justify-between mb-4">
                 <p className="text-stone-600 text-sm">
@@ -594,151 +327,33 @@ export default function Home() {
           )}
 
           {activeTab === 'pubs' && viewMode === 'list' && (
-            <div className="bg-white rounded-2xl shadow-[0_2px_12px_rgba(0,0,0,0.06)] border border-stone-200/60 overflow-hidden">
-              <table className="w-full">
-                <thead>
-                  <tr className="bg-stone-50 border-b border-stone-200">
-                    <th className="text-left py-3 px-4 text-xs font-semibold text-stone-600 uppercase tracking-wide">Pub</th>
-                    <th className="text-left py-3 px-4 text-xs font-semibold text-stone-600 uppercase tracking-wide hidden sm:table-cell">Suburb</th>
-                    <th className="text-left py-3 px-4 text-xs font-semibold text-stone-600 uppercase tracking-wide hidden sm:table-cell">Beer</th>
-                    <th className="text-right py-3 px-4 text-xs font-semibold text-stone-600 uppercase tracking-wide">Price</th>
-                    <th className="text-left py-3 px-4 text-xs font-semibold text-stone-600 uppercase tracking-wide hidden md:table-cell">Happy Hour</th>
-                    <th className="text-center py-3 px-4 text-xs font-semibold text-stone-600 uppercase tracking-wide">Crowd</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {(showAllPubs ? filteredPubs : filteredPubs.slice(0, INITIAL_PUB_COUNT)).map((pub, index) => {
-                    const crowdReport = getLatestCrowdReport(pub.id)
-                    const happyHourStatus = getHappyHourStatus(pub.happyHour)
-                    return (
-                      <tr 
-                        key={pub.id} 
-                        className={`border-b border-stone-100 hover:bg-amber/5 transition-colors cursor-pointer ${
-                          index % 2 === 0 ? 'bg-white' : 'bg-stone-50/30'
-                        }`}
-                        onClick={() => router.push(`/pub/${pub.slug}`)}
-                      >
-                        <td className="py-3 px-2 sm:px-4">
-                          <div className="flex items-center gap-2">
-                            <span className="text-xs text-stone-300 w-5 text-right tabular-nums">{index + 1}</span>
-                            <div>
-                              <div className="flex items-center gap-1.5">
-                                <a
-                                  href={getDirectionsUrl(pub)}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  onClick={(e) => e.stopPropagation()}
-                                  className="flex-shrink-0 text-stone-300 hover:text-amber transition-colors"
-                                  title="Get directions"
-                                >
-                                  <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
-                                    <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
-                                  </svg>
-                                </a>
-                                <Link href={`/pub/${pub.slug}`} className="font-semibold text-stone-900 text-sm hover:text-amber transition-colors">{pub.name}</Link>
-                              </div>
-                              <p className="text-xs text-stone-500 sm:hidden">{pub.suburb}{userLocation && ` · ${formatDistance(getDistanceKm(userLocation.lat, userLocation.lng, pub.lat, pub.lng))}`}</p>
-                            </div>
-                          </div>
-                        </td>
-                        <td className="py-3 px-4 text-sm text-stone-600 hidden sm:table-cell">
-                          {pub.suburb}
-                          {userLocation && <span className="text-stone-400 text-xs ml-1">· {formatDistance(getDistanceKm(userLocation.lat, userLocation.lng, pub.lat, pub.lng))}</span>}
-                        </td>
-                        <td className="py-3 px-4 hidden sm:table-cell">
-                          <span className="text-xs text-stone-500 truncate max-w-[120px] block">
-                            {pub.beerType || '—'}
-                          </span>
-                        </td>
-                        <td className={`py-3 px-2 sm:px-4 text-right font-bold font-mono text-lg whitespace-nowrap ${getPriceTextColor(pub.price)}`}>
-                          {pub.isHappyHourNow && pub.regularPrice !== null && pub.regularPrice !== pub.price && (
-                            <span className="text-xs text-stone-400 line-through font-normal mr-1">${pub.regularPrice.toFixed(2)}</span>
-                          )}
-                          {pub.price !== null ? `$${pub.price.toFixed(2)}` : 'TBC'}
-                        </td>
-                        <td className="py-3 px-4 hidden md:table-cell">
-                          {pub.happyHour ? (
-                            <span className={`text-xs ${
-                              happyHourStatus.isActive ? 'text-amber font-bold' : 
-                              happyHourStatus.isToday ? 'text-amber-dark font-semibold' : 
-                              'text-stone-500'
-                            }`}>
-                              {happyHourStatus.statusEmoji} {happyHourStatus.statusText}
-                            </span>
-                          ) : (
-                            <span className="text-xs text-stone-400">—</span>
-                          )}
-                        </td>
-                        <td className="py-3 px-4 text-center">
-                          {crowdReport ? (
-                            <span className="text-sm" title={`${crowdReport.minutes_ago}m ago`}>
-                              {CROWD_LEVELS[crowdReport.crowd_level].emoji}
-                            </span>
-                          ) : (
-                            <button
-                              onClick={() => setCrowdReportPub(pub)}
-                              className="text-xs text-stone-400 hover:text-amber"
-                            >
-                              Report
-                            </button>
-                          )}
-                        </td>
-                      </tr>
-                    )
-                  })}
-                </tbody>
-              </table>
-              {!showAllPubs && filteredPubs.length > INITIAL_PUB_COUNT && (
-                <button
-                  onClick={() => setShowAllPubs(true)}
-                  className="w-full py-3 text-sm font-medium text-charcoal hover:text-amber hover:bg-amber/5 transition-colors flex items-center justify-center gap-1 border-t border-stone-200"
-                >
-                  Show All {filteredPubs.length} Venues
-                  <span className="inline-block">&#9660;</span>
-                </button>
-              )}
-            </div>
+            <PubListView
+              pubs={filteredPubs}
+              crowdReports={crowdReports}
+              userLocation={userLocation}
+              onCrowdReport={setCrowdReportPub}
+              showAll={showAllPubs}
+              initialCount={INITIAL_PUB_COUNT}
+              onShowAll={() => setShowAllPubs(true)}
+            />
           )}
 
           {activeTab === 'pubs' && viewMode === 'cards' && (
-            <>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 items-stretch">
-              {(showAllPubs ? filteredPubs : filteredPubs.slice(0, INITIAL_PUB_COUNT)).map((pub, index) => {
-                const crowdReport = getLatestCrowdReport(pub.id)
-                const happyHourStatus = getHappyHourStatus(pub.happyHour)
-                return (
-                  <PubCard
-                    key={pub.id}
-                    pub={pub}
-                    index={index}
-                    sortBy={sortBy}
-                    showMiniMaps={showMiniMaps}
-                    crowdReport={crowdReport}
-                    happyHourStatus={happyHourStatus}
-                    getDirectionsUrl={getDirectionsUrl}
-                    getPriceColor={getPriceColor}
-                    getPriceBgColor={getPriceBgColor}
-                    formatLastUpdated={formatLastUpdated}
-                    onCrowdReport={setCrowdReportPub}
-                    distance={userLocation ? formatDistance(getDistanceKm(userLocation.lat, userLocation.lng, pub.lat, pub.lng)) : undefined}
-                  />
-                )
-              })}
-            </div>
-            {!showAllPubs && filteredPubs.length > INITIAL_PUB_COUNT && (
-              <button
-                onClick={() => setShowAllPubs(true)}
-                className="w-full mt-4 py-3 text-sm font-medium text-charcoal hover:text-amber bg-white hover:bg-amber/5 rounded-2xl shadow-[0_2px_12px_rgba(0,0,0,0.06)] border border-stone-200/60 transition-colors flex items-center justify-center gap-1"
-              >
-                Show All {filteredPubs.length} Venues
-                <span className="inline-block">&#9660;</span>
-              </button>
-            )}
-            </>
+            <PubCardsView
+              pubs={filteredPubs}
+              crowdReports={crowdReports}
+              showMiniMaps={showMiniMaps}
+              userLocation={userLocation}
+              sortBy={sortBy}
+              onCrowdReport={setCrowdReportPub}
+              showAll={showAllPubs}
+              initialCount={INITIAL_PUB_COUNT}
+              onShowAll={() => setShowAllPubs(true)}
+            />
           )}
 
           {activeTab === 'pubs' && filteredPubs.length === 0 && (
-            <div className="text-center py-12 bg-white rounded-xl border border-stone-200">
+            <div className="text-center py-12 bg-white rounded-2xl border border-stone-200/60">
               <div className="text-5xl mb-3">{showHappyHourOnly ? '\u{1F37B}' : '\u{1F50D}'}</div>
               <h3 className="text-lg font-bold text-stone-700 mb-1">{showHappyHourOnly ? 'No pubs with happy hour info yet' : 'No pubs found'}</h3>
               <p className="text-stone-500 text-sm">{showHappyHourOnly ? 'We\u2019re building our happy hour database \u2014 submit yours!' : 'Try adjusting your filters'}</p>
@@ -746,61 +361,10 @@ export default function Home() {
           )}
         </div>
 
-        {/* ═══  HOW IT WORKS  ═══ */}
         <HowItWorks />
-
-        {/* ═══  SOCIAL PROOF  ═══ */}
-        <SocialProof stats={stats} />
-
-        {/* ═══  FAQ  ═══ */}
+        <SocialProof venueCount={stats.total} suburbCount={suburbs.length} avgPrice={stats.avgPrice} />
         <FAQ />
-
-        {/* ═══  FOOTER  ═══ */}
-        <footer className="bg-charcoal text-white py-12">
-          <div className="max-w-7xl mx-auto px-4">
-            <div className="flex flex-col sm:flex-row items-center justify-between gap-6 mb-8">
-              <div className="flex items-center gap-2.5">
-                <img src="/logo.png" alt="PintDex" className="w-10 h-10 rounded-lg object-contain" />
-                <span className="text-xl font-extrabold tracking-tight font-heading">PintDex</span>
-              </div>
-              <p className="text-stone-400 text-sm text-center">Perth&apos;s pint prices, sorted. Community-driven since 2024.</p>
-            </div>
-
-            <div className="flex flex-wrap justify-center gap-6 mb-8 pb-8 border-b border-stone-700">
-              <div className="flex items-center gap-2">
-                <span className="text-amber text-lg">⬡</span>
-                <div>
-                  <p className="font-semibold text-white">Schooner</p>
-                  <p className="text-xs text-stone-400">425ml</p>
-                </div>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-amber text-lg">⬡</span>
-                <div>
-                  <p className="font-semibold text-amber">Pint</p>
-                  <p className="text-xs text-stone-400">570ml</p>
-                </div>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-amber text-lg">⬡</span>
-                <div>
-                  <p className="font-semibold text-white">Long Neck</p>
-                  <p className="text-xs text-stone-400">750ml</p>
-                </div>
-              </div>
-            </div>
-
-            <div className="text-center">
-              <p className="text-stone-400 text-xs">Prices may vary. Pint prices shown. Always drink responsibly.</p>
-              <a
-                href="mailto:perthpintprices@gmail.com?subject=Price%20Correction&body=Hi%2C%20I%20noticed%20a%20wrong%20price%20on%20the%20site.%0A%0APub%20name%3A%20%0ACorrect%20price%3A%20%0ADetails%3A%20"
-                className="inline-block mt-3 text-amber hover:text-amber-light text-xs"
-              >
-                Report Wrong Price
-              </a>
-            </div>
-          </div>
-        </footer>
+        <Footer />
       </div>
 
       <SubmitPubForm isOpen={showSubmitForm} onClose={() => setShowSubmitForm(false)} />

--- a/src/app/pub/[slug]/PubDetailClient.tsx
+++ b/src/app/pub/[slug]/PubDetailClient.tsx
@@ -10,7 +10,7 @@ import E from '@/lib/emoji'
 
 const PubDetailMap = dynamic(() => import('@/components/PubDetailMap'), {
   ssr: false,
-  loading: () => <div className="h-64 bg-stone-100 animate-pulse rounded-xl" />,
+  loading: () => <div className="h-[350px] bg-stone-100 animate-pulse rounded-2xl" />,
 })
 
 function timeAgo(dateStr: string): string {
@@ -92,8 +92,8 @@ export default function PubDetailClient({ pub, nearbyPubs }: PubDetailClientProp
   return (
     <div className="min-h-screen bg-cream">
       {/* Navigation */}
-      <div className="bg-white border-b border-stone-200 sticky top-0 z-50">
-        <div className="max-w-2xl mx-auto px-4 py-3 flex items-center justify-between">
+      <div className="bg-cream border-b border-stone-200/60 sticky top-0 z-50">
+        <div className="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
           <Link href="/" className="flex items-center gap-2 text-amber hover:text-amber-700 transition-colors font-semibold text-sm">
             <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
               <path d="M19 12H5M12 19l-7-7 7-7"/>
@@ -109,199 +109,168 @@ export default function PubDetailClient({ pub, nearbyPubs }: PubDetailClientProp
         </div>
       </div>
 
-      <div className="max-w-2xl mx-auto px-4 py-6 space-y-5">
-        {/* Hero Section */}
-        <div className="space-y-3">
-          <div className="flex items-start justify-between gap-4">
-            <div className="flex-1 min-w-0">
-              <h1 className="text-2xl font-bold font-heading text-stone-900 leading-tight">{pub.name}</h1>
-              <p className="text-stone-500 mt-1">{pub.suburb}, Perth WA</p>
-              {distance && <p className="text-amber text-sm font-medium mt-0.5">{distance}</p>}
-            </div>
-            <div className="text-right flex-shrink-0">
-              {pub.isHappyHourNow && pub.regularPrice !== null && pub.regularPrice !== pub.price && (
-                <div className="text-sm text-stone-400 line-through font-mono">${pub.regularPrice.toFixed(2)}</div>
-              )}
-              <div className={`text-4xl font-bold font-mono bg-gradient-to-br ${getPriceColor(pub.price)} bg-clip-text text-transparent`}>
-                {pub.price !== null ? `$${pub.price.toFixed(2)}` : 'TBC'}
-              </div>
-              <p className="text-xs text-stone-400 mt-0.5">
-                {pub.price !== null ? getPriceLabel(pub.price, perthAvg) : 'Unverified'}
+      <div className="max-w-5xl mx-auto px-4 py-6 space-y-8">
+        {/* Breadcrumb */}
+        <nav className="flex items-center gap-2 text-sm text-stone-400">
+          <Link href="/" className="hover:text-amber transition-colors">Home</Link>
+          <span>/</span>
+          <span>{pub.suburb}</span>
+          <span>/</span>
+          <span className="text-charcoal font-medium">{pub.name}</span>
+        </nav>
+
+        {/* Two-column layout */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-12">
+          {/* Left column — info */}
+          <div className="space-y-6">
+            <div>
+              <h1 className="text-3xl sm:text-4xl font-heading font-semibold text-charcoal leading-tight">
+                {pub.name}
+              </h1>
+              <p className="text-stone-500 text-lg mt-1">
+                {pub.suburb}{distance && ` · ${distance}`}
               </p>
             </div>
-          </div>
 
-          {/* Badges Row */}
-          <div className="flex flex-wrap gap-2">
-            {pub.isHappyHourNow && (
-              <Badge className="bg-amber hover:bg-amber text-white animate-pulse">
-                {E.party} HAPPY HOUR LIVE
-                {pub.happyHourMinutesRemaining && ` · ${pub.happyHourMinutesRemaining}m left`}
-              </Badge>
-            )}
-            {pub.hasTab && (
-              <Badge className="text-white" style={{ backgroundColor: '#5B2D8E' }}>TAB Venue</Badge>
-            )}
-            {pub.kidFriendly && (
-              <Badge className="bg-emerald-600 hover:bg-emerald-600 text-white">Kid Friendly</Badge>
-            )}
-            {pub.sunsetSpot && (
-              <Badge className="bg-amber-500 hover:bg-amber-500 text-white">Sunset Spot</Badge>
-            )}
-            {pub.priceVerified && pub.price !== null && (
-              <Badge variant="outline" className="border-stone-300 text-stone-500">
-                <svg className="w-3 h-3 mr-1 text-emerald-500" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/>
-                </svg>
-                Verified Price
-              </Badge>
-            )}
-          </div>
-        </div>
+            {/* Price */}
+            <div className="flex items-end gap-3">
+              <div>
+                {pub.isHappyHourNow && pub.regularPrice !== null && pub.regularPrice !== pub.price && (
+                  <div className="text-sm text-stone-400 line-through font-mono">${pub.regularPrice.toFixed(2)}</div>
+                )}
+                <div className={`text-5xl font-bold font-mono bg-gradient-to-br ${getPriceColor(pub.price)} bg-clip-text text-transparent`}>
+                  {pub.price !== null ? `$${pub.price.toFixed(2)}` : 'TBC'}
+                </div>
+              </div>
+              <div className="pb-1">
+                <p className="text-sm text-stone-400">
+                  {pub.price !== null ? getPriceLabel(pub.price, perthAvg) : 'Unverified'}
+                </p>
+                {pub.price !== null && (
+                  <p className="text-xs text-stone-400 mt-0.5">
+                    {pub.price < perthAvg
+                      ? `$${(perthAvg - pub.price).toFixed(2)} below Perth avg`
+                      : pub.price > perthAvg
+                      ? `$${(pub.price - perthAvg).toFixed(2)} above Perth avg`
+                      : 'At Perth average'
+                    }
+                  </p>
+                )}
+              </div>
+            </div>
 
-        {/* Map */}
-        <Card className="overflow-hidden border-stone-200/60 shadow-sm rounded-xl">
-          <div className="h-64">
-            <PubDetailMap lat={pub.lat} lng={pub.lng} name={pub.name} price={pub.price} />
-          </div>
-        </Card>
+            {/* Badges */}
+            <div className="flex flex-wrap gap-2">
+              {pub.isHappyHourNow && (
+                <Badge className="bg-amber hover:bg-amber text-white animate-pulse">
+                  {E.party} HAPPY HOUR LIVE
+                  {pub.happyHourMinutesRemaining && ` · ${pub.happyHourMinutesRemaining}m left`}
+                </Badge>
+              )}
+              {pub.hasTab && (
+                <Badge className="text-white" style={{ backgroundColor: '#5B2D8E' }}>TAB Venue</Badge>
+              )}
+              {pub.kidFriendly && (
+                <Badge className="bg-emerald-600 hover:bg-emerald-600 text-white">Kid Friendly</Badge>
+              )}
+              {pub.sunsetSpot && (
+                <Badge className="bg-amber-500 hover:bg-amber-500 text-white">Sunset Spot</Badge>
+              )}
+              {pub.priceVerified && pub.price !== null && (
+                <Badge variant="outline" className="border-stone-300 text-stone-500">
+                  <svg className="w-3 h-3 mr-1 text-emerald-500" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/>
+                  </svg>
+                  Verified Price
+                </Badge>
+              )}
+            </div>
 
-        {/* Details Grid */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          {/* Address */}
-          <Card className="border-stone-200/60 shadow-sm rounded-xl">
-            <CardContent className="p-4">
-              <div className="text-xs text-stone-400 uppercase tracking-wider font-semibold mb-1">Address</div>
-              <p className="text-sm text-stone-700">{pub.address}</p>
+            {/* Beer on tap */}
+            <div>
+              <div className="text-xs text-stone-400 uppercase tracking-wider font-semibold mb-1">What&apos;s on Tap</div>
+              <p className="text-base text-stone-700 font-medium">🍺 {pub.beerType || 'House Pint'}</p>
+            </div>
+
+            {/* Happy Hour */}
+            {(pub.happyHour || pub.happyHourPrice) && (
+              <div className={`p-4 rounded-2xl border ${pub.isHappyHourNow ? 'border-amber/30 bg-amber/5' : 'border-stone-200/60 bg-white'}`}>
+                <div className="text-xs text-stone-400 uppercase tracking-wider font-semibold mb-1">Happy Hour</div>
+                {pub.happyHourPrice && (
+                  <p className={`text-xl font-bold font-mono ${pub.isHappyHourNow ? 'text-amber' : 'text-stone-700'}`}>
+                    ${pub.happyHourPrice.toFixed(2)}
+                  </p>
+                )}
+                {pub.happyHourDays && <p className="text-sm text-stone-600 mt-0.5">{pub.happyHourDays}</p>}
+                {pub.happyHourStart && pub.happyHourEnd && (
+                  <p className="text-sm text-stone-500">{formatHappyHourTime(pub.happyHourStart, pub.happyHourEnd)}</p>
+                )}
+                {!pub.happyHourPrice && pub.happyHour && <p className="text-sm text-stone-600">{pub.happyHour}</p>}
+              </div>
+            )}
+
+            {/* About */}
+            {pub.description && (
+              <div>
+                <div className="text-xs text-stone-400 uppercase tracking-wider font-semibold mb-2">About</div>
+                <p className="text-base text-stone-600 leading-relaxed">{pub.description}</p>
+              </div>
+            )}
+
+            {/* Data quality */}
+            <div className="text-sm text-stone-400 space-y-0.5">
+              {pub.lastVerified && <p>Verified {timeAgo(pub.lastVerified)}</p>}
+              {pub.lastUpdated && <p>Updated: {new Date(pub.lastUpdated).toLocaleDateString('en-AU')}</p>}
+            </div>
+
+            {/* Action buttons */}
+            <div className="flex gap-3">
+              {pub.website && (
+                <a
+                  href={pub.website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex-1 bg-amber text-white text-center py-3 rounded-2xl font-semibold text-sm hover:bg-amber-dark transition-colors"
+                >
+                  Visit Website →
+                </a>
+              )}
               <a
                 href={directionsUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 mt-2 text-amber text-xs font-semibold hover:text-amber-700 transition-colors"
+                className={`${pub.website ? '' : 'flex-1'} bg-charcoal text-white text-center py-3 px-6 rounded-2xl font-semibold text-sm hover:bg-charcoal/90 transition-colors`}
               >
-                <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
-                </svg>
-                Get Directions
+                Directions
               </a>
-            </CardContent>
-          </Card>
+            </div>
+          </div>
 
-          {/* Beer */}
-          <Card className="border-stone-200/60 shadow-sm rounded-xl">
-            <CardContent className="p-4">
-              <div className="text-xs text-stone-400 uppercase tracking-wider font-semibold mb-1">What&apos;s on Tap</div>
-              <p className="text-sm text-stone-700 font-medium">{pub.beerType || 'House Pint'}</p>
-              {pub.price !== null && (
-                <p className="text-xs text-stone-400 mt-1">
-                  {pub.price < perthAvg
-                    ? `$${(perthAvg - pub.price).toFixed(2)} below Perth avg`
-                    : pub.price > perthAvg
-                    ? `$${(pub.price - perthAvg).toFixed(2)} above Perth avg`
-                    : 'At Perth average'
-                  }
-                </p>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Happy Hour */}
-          {(pub.happyHour || pub.happyHourPrice) && (
-            <Card className={`border-stone-200/60 shadow-sm rounded-xl ${pub.isHappyHourNow ? 'ring-2 ring-amber/30 bg-amber/5' : ''}`}>
-              <CardContent className="p-4">
-                <div className="text-xs text-stone-400 uppercase tracking-wider font-semibold mb-1">Happy Hour</div>
-                {pub.happyHourPrice && (
-                  <p className={`text-lg font-bold font-mono ${pub.isHappyHourNow ? 'text-amber' : 'text-stone-700'}`}>
-                    ${pub.happyHourPrice.toFixed(2)}
-                  </p>
-                )}
-                {pub.happyHourDays && (
-                  <p className="text-sm text-stone-600 mt-0.5">{pub.happyHourDays}</p>
-                )}
-                {pub.happyHourStart && pub.happyHourEnd && (
-                  <p className="text-sm text-stone-500">
-                    {formatHappyHourTime(pub.happyHourStart, pub.happyHourEnd)}
-                  </p>
-                )}
-                {!pub.happyHourPrice && pub.happyHour && (
-                  <p className="text-sm text-stone-600">{pub.happyHour}</p>
-                )}
-              </CardContent>
-            </Card>
-          )}
-
-          {/* Verified */}
-          <Card className="border-stone-200/60 shadow-sm rounded-xl">
-            <CardContent className="p-4">
-              <div className="text-xs text-stone-400 uppercase tracking-wider font-semibold mb-1">Data Quality</div>
-              {pub.lastVerified && (
-                <p className="text-sm text-stone-700">
-                  Verified {timeAgo(pub.lastVerified)}
-                </p>
-              )}
-              {pub.lastUpdated && (
-                <p className="text-xs text-stone-400 mt-0.5">
-                  Last updated: {new Date(pub.lastUpdated).toLocaleDateString('en-AU')}
-                </p>
-              )}
-              {!pub.lastVerified && !pub.lastUpdated && (
-                <p className="text-sm text-stone-500">No verification data</p>
-              )}
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Description */}
-        {pub.description && (
-          <Card className="border-stone-200/60 shadow-sm rounded-xl">
-            <CardContent className="p-4">
-              <div className="text-xs text-stone-400 uppercase tracking-wider font-semibold mb-2">About</div>
-              <p className="text-sm text-stone-600 leading-relaxed">{pub.description}</p>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Website & Actions */}
-        <div className="flex gap-3">
-          {pub.website && (
-            <a
-              href={pub.website}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex-1 bg-amber text-white text-center py-3 rounded-xl font-semibold text-sm hover:bg-amber-700 transition-colors"
-            >
-              Visit Website →
-            </a>
-          )}
-          <a
-            href={directionsUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={`${pub.website ? '' : 'flex-1'} bg-stone-800 text-white text-center py-3 px-6 rounded-xl font-semibold text-sm hover:bg-stone-700 transition-colors`}
-          >
-            Directions
-          </a>
+          {/* Right column — map/visual */}
+          <div className="rounded-2xl overflow-hidden h-[350px] border border-stone-200/60 shadow-sm">
+            <PubDetailMap lat={pub.lat} lng={pub.lng} name={pub.name} price={pub.price} />
+          </div>
         </div>
 
         {/* Nearby Pubs */}
         {nearbyPubs.length > 0 && (
-          <div className="space-y-3">
-            <h2 className="text-lg font-bold font-heading text-stone-900">
+          <div className="space-y-4 mt-16">
+            <h2 className="text-xl font-heading font-semibold text-charcoal">
               More in {pub.suburb}
             </h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               {nearbyPubs.map(nearby => (
                 <Link key={nearby.id} href={`/pub/${nearby.slug}`}>
-                  <Card className="border-stone-200/60 shadow-sm rounded-xl hover:shadow-md transition-all cursor-pointer">
-                    <CardContent className="p-4 flex items-center justify-between">
+                  <Card className="border-stone-200/60 shadow-sm rounded-2xl hover:shadow-lg transition-all cursor-pointer">
+                    <CardContent className="p-5 flex items-center justify-between">
                       <div className="min-w-0 flex-1">
-                        <p className="font-semibold text-stone-900 text-sm truncate">{nearby.name}</p>
-                        <p className="text-xs text-stone-500 truncate">{nearby.beerType}</p>
+                        <p className="font-semibold text-charcoal text-base truncate">{nearby.name}</p>
+                        <p className="text-sm text-stone-500 truncate">{nearby.beerType}</p>
                         {nearby.isHappyHourNow && (
                           <p className="text-xs text-amber font-semibold mt-0.5">{E.party} Happy Hour Live</p>
                         )}
                       </div>
-                      <div className={`text-lg font-bold font-mono bg-gradient-to-br ${getPriceColor(nearby.price)} bg-clip-text text-transparent ml-3`}>
+                      <div className={`text-xl font-bold font-mono bg-gradient-to-br ${getPriceColor(nearby.price)} bg-clip-text text-transparent ml-3`}>
                         {nearby.price !== null ? `$${nearby.price.toFixed(2)}` : 'TBC'}
                       </div>
                     </CardContent>
@@ -313,11 +282,11 @@ export default function PubDetailClient({ pub, nearbyPubs }: PubDetailClientProp
         )}
 
         {/* Footer */}
-        <div className="text-center py-6 text-xs text-stone-400">
+        <div className="text-center py-8 text-xs text-stone-400">
           <p>Data sourced from verified pub menus and community reports.</p>
           <p className="mt-1">
             Wrong price?{' '}
-            <Link href="/" className="text-amber hover:text-amber-700 font-semibold">
+            <Link href="/" className="text-amber hover:text-amber-dark font-semibold">
               Report it on PintDex
             </Link>
           </p>

--- a/src/components/BeerWeather.tsx
+++ b/src/components/BeerWeather.tsx
@@ -124,7 +124,7 @@ interface BeerWeatherProps {
 
 export default function BeerWeather({ pubs, userLocation }: BeerWeatherProps) {
   const [weather, setWeather] = useState<WeatherData | null>(null)
-  const [isExpanded, setIsExpanded] = useState(false)
+  const [isExpanded, setIsExpanded] = useState(true)
   const [error, setError] = useState(false)
 
   useEffect(() => {

--- a/src/components/DadBar.tsx
+++ b/src/components/DadBar.tsx
@@ -36,7 +36,7 @@ const PLAYGROUND_NOTES: Record<number, string> = {
 }
 
 export default function DadBar({ pubs, userLocation }: { pubs: Pub[], userLocation?: { lat: number; lng: number } | null }) {
-  const [isExpanded, setIsExpanded] = useState(false)
+  const [isExpanded, setIsExpanded] = useState(true)
   const [showAll, setShowAll] = useState(false)
 
   const dadPubs = useMemo(() => {

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -1,0 +1,68 @@
+'use client'
+import { useState } from 'react'
+
+export default function FAQ() {
+  const [openIndex, setOpenIndex] = useState<number | null>(null)
+  const faqs = [
+    {
+      q: 'How are prices verified?',
+      a: 'Every price on PintDex is manually verified through pub menus, direct calls, and community submissions. We never estimate or guess — if we don\'t have a verified price, we show "Price TBC" until we confirm it.',
+    },
+    {
+      q: 'How often is the data updated?',
+      a: 'We run automated checks weekly and accept community submissions around the clock. Every price includes a "last verified" date so you know how fresh it is.',
+    },
+    {
+      q: 'What does the price represent?',
+      a: 'All prices shown are for a standard pint (570ml) of the cheapest tap beer available at each venue. Happy hour prices are shown when they\'re currently active.',
+    },
+    {
+      q: 'How can I submit a price?',
+      a: 'Tap the "Submit a Price" button at the top of the page. Tell us the pub name, suburb, and the pint price you paid. We\'ll verify and add it to the database.',
+    },
+    {
+      q: 'Why is a pub showing "Price TBC"?',
+      a: 'We only display prices we\'ve confirmed. "Price TBC" means we know the pub exists but haven\'t verified its current pint price yet. You can help by submitting it!',
+    },
+    {
+      q: 'Is PintDex free?',
+      a: 'Yep — completely free. No app download, no sign-up, no ads. Just Perth pint prices, sorted.',
+    },
+  ]
+
+  return (
+    <section className="py-20 sm:py-24 border-t border-stone-200/60">
+      <div className="max-w-3xl mx-auto px-4">
+        <h2 className="text-title text-charcoal font-heading text-center mb-4">
+          Questions?
+        </h2>
+        <p className="text-stone-500 text-center mb-10 text-lg">Everything you need to know about PintDex.</p>
+        <div className="space-y-0">
+          {faqs.map((faq, i) => (
+            <div key={i} className="border-b border-stone-200/60">
+              <button
+                onClick={() => setOpenIndex(openIndex === i ? null : i)}
+                className="w-full flex items-center justify-between py-5 text-left group"
+              >
+                <span className="text-lg font-semibold text-charcoal group-hover:text-amber transition-colors pr-4">
+                  {faq.q}
+                </span>
+                <svg
+                  className={`w-5 h-5 text-stone-400 flex-shrink-0 transition-transform duration-200 ${openIndex === i ? 'rotate-180' : ''}`}
+                  fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+              {openIndex === i && (
+                <div className="pb-5 text-stone-600 leading-relaxed -mt-1">
+                  {faq.a}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/FilterSection.tsx
+++ b/src/components/FilterSection.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Search, LayoutGrid, List, Clock, Map, SlidersHorizontal, ChevronDown, X, MapPin } from "lucide-react"
+import { Search, SlidersHorizontal, ChevronDown, X, MapPin, LayoutGrid, List, Clock, Map as MapIcon } from "lucide-react"
 import { useState, useRef, useEffect } from "react"
 import { cn } from "@/lib/utils"
 
@@ -47,9 +47,15 @@ export function FilterSection({
   stats,
   hasLocation,
 }: FilterSectionProps) {
-  const activeFilterCount = (selectedSuburb && selectedSuburb !== 'all' ? 1 : 0) + (maxPrice < 15 ? 1 : 0) + (sortBy !== 'price' && sortBy !== 'nearest' ? 1 : 0)
   const isNearestActive = sortBy === 'nearest' && hasLocation
   const dropdownRef = useRef<HTMLDivElement>(null)
+
+  const activeFilterCount =
+    (selectedSuburb && selectedSuburb !== 'all' ? 1 : 0) +
+    (maxPrice < 15 ? 1 : 0) +
+    (sortBy !== 'price' && sortBy !== 'nearest' ? 1 : 0) +
+    (showHappyHourOnly ? 1 : 0) +
+    (isNearestActive ? 1 : 0)
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {
@@ -69,12 +75,10 @@ export function FilterSection({
     setShowHappyHourOnly(false)
   }
 
-  const totalActive = activeFilterCount + (isNearestActive ? 1 : 0)
-
   return (
-    <div className="border-t border-stone-100/80 bg-white/95">
-      {/* Row 1: Search + Suburb */}
-      <div className="max-w-7xl mx-auto px-4 pt-2 pb-1.5 flex items-center gap-2">
+    <div className="border-t border-stone-100/80 bg-cream">
+      {/* One clean row: Search + Suburbs + Filters */}
+      <div className="max-w-7xl mx-auto px-4 py-2.5 flex items-center gap-2">
         <div className="relative flex-1">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-stone-400 pointer-events-none" />
           <input
@@ -82,7 +86,7 @@ export function FilterSection({
             placeholder="Search pubs or suburbs..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-8 pr-8 py-2 text-sm bg-stone-50 border border-stone-200 rounded-xl text-stone-700 placeholder-stone-400 focus:outline-none focus:ring-1 focus:ring-amber focus:border-amber transition-colors"
+            className="w-full pl-8 pr-8 py-2.5 text-sm bg-stone-50 border border-stone-200/60 rounded-xl text-stone-700 placeholder-stone-400 focus:outline-none focus:ring-1 focus:ring-amber focus:border-amber transition-colors"
           />
           {searchTerm && (
             <button onClick={() => setSearchTerm('')} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600">
@@ -93,180 +97,157 @@ export function FilterSection({
         <select
           value={selectedSuburb || 'all'}
           onChange={(e) => setSelectedSuburb(e.target.value)}
-          className="text-sm bg-stone-50 border border-stone-200 rounded-xl px-3 py-2 text-stone-600 focus:outline-none focus:ring-1 focus:ring-amber focus:border-amber transition-colors cursor-pointer flex-shrink-0 max-w-[130px] sm:max-w-[160px]"
+          className="text-sm bg-stone-50 border border-stone-200/60 rounded-xl px-3 py-2.5 text-stone-600 focus:outline-none focus:ring-1 focus:ring-amber focus:border-amber transition-colors cursor-pointer flex-shrink-0 max-w-[130px] sm:max-w-[160px]"
         >
           <option value="all">All Suburbs</option>
           {suburbs.map(suburb => (
             <option key={suburb} value={suburb}>{suburb}</option>
           ))}
         </select>
-      </div>
 
-      {/* Row 2: Pill controls + Filters button (separate containers to avoid overflow clipping) */}
-      <div className="max-w-7xl mx-auto px-4 pb-2">
-        <div className="flex items-center gap-2">
-          {/* Scrollable pills area */}
-          <div className="flex items-center gap-2 overflow-x-auto scrollbar-hide flex-1 min-w-0">
-            {/* Cards / List toggle */}
-            <div className="flex items-center bg-stone-100 rounded-lg p-0.5 gap-0.5 flex-shrink-0">
-              <button
-                onClick={() => setViewMode('cards')}
-                className={cn(
-                  "flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium transition-all whitespace-nowrap",
-                  viewMode === 'cards' ? "bg-white text-stone-800 shadow-sm" : "text-stone-500 hover:text-stone-700"
-                )}
-              >
-                <LayoutGrid className="h-3.5 w-3.5" />
-                Cards
-              </button>
-              <button
-                onClick={() => setViewMode('list')}
-                className={cn(
-                  "flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium transition-all whitespace-nowrap",
-                  viewMode === 'list' ? "bg-white text-stone-800 shadow-sm" : "text-stone-500 hover:text-stone-700"
-                )}
-              >
-                <List className="h-3.5 w-3.5" />
-                List
-              </button>
-            </div>
-
-            <div className="h-5 w-px bg-stone-200 flex-shrink-0" />
-
-            {/* Happy Hour pill */}
-            <button
-              onClick={() => setShowHappyHourOnly(!showHappyHourOnly)}
-              className={cn(
-                "flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-all border flex-shrink-0 whitespace-nowrap",
-                showHappyHourOnly
-                  ? "bg-amber text-white border-amber"
-                  : "bg-white text-stone-500 border-stone-200 hover:border-stone-300 hover:text-stone-700"
-              )}
-            >
-              <Clock className="h-3 w-3" />
-              Happy Hour
-              {stats.happyHourNow > 0 && (
-                <span className={cn(
-                  "text-xs rounded-full px-1.5 py-0 font-semibold",
-                  showHappyHourOnly ? "bg-white/20 text-white" : "bg-stone-200 text-stone-600"
-                )}>
-                  {stats.happyHourNow}
-                </span>
-              )}
-            </button>
-
-            {/* Nearest pill — visible when location is available */}
-            {hasLocation && (
-              <button
-                onClick={() => setSortBy(sortBy === 'nearest' ? 'price' : 'nearest')}
-                className={cn(
-                  "flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-all border flex-shrink-0 whitespace-nowrap",
-                  isNearestActive
-                    ? "bg-blue-500 text-white border-blue-500"
-                    : "bg-white text-stone-500 border-stone-200 hover:border-stone-300 hover:text-stone-700"
-                )}
-              >
-                <MapPin className="h-3 w-3" />
-                Nearest
-              </button>
+        {/* Filters button with expanded dropdown */}
+        <div className="relative flex-shrink-0" ref={dropdownRef}>
+          <button
+            onClick={() => setShowMoreFilters(!showMoreFilters)}
+            className={cn(
+              "flex items-center gap-1.5 px-3 py-2.5 rounded-xl text-sm font-medium transition-all border whitespace-nowrap",
+              showMoreFilters || activeFilterCount > 0
+                ? "bg-amber text-white border-amber"
+                : "bg-stone-50 text-stone-500 border-stone-200/60 hover:border-stone-300 hover:text-stone-700"
             )}
-
-            {/* Mini Maps pill — only in Cards view */}
-            {viewMode === 'cards' && (
-              <button
-                onClick={() => setShowMiniMaps(!showMiniMaps)}
-                className={cn(
-                  "flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-all border flex-shrink-0 whitespace-nowrap",
-                  showMiniMaps
-                    ? "bg-amber text-white border-amber"
-                    : "bg-white text-stone-500 border-stone-200 hover:border-stone-300 hover:text-stone-700"
-                )}
-              >
-                <Map className="h-3 w-3" />
-                Mini Maps
-              </button>
+          >
+            <SlidersHorizontal className="h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Filters</span>
+            {activeFilterCount > 0 && (
+              <span className="bg-white/20 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center font-bold">
+                {activeFilterCount}
+              </span>
             )}
-          </div>
+            <ChevronDown className={cn("h-3 w-3 transition-transform", showMoreFilters && "rotate-180")} />
+          </button>
 
-          {/* Filters button — OUTSIDE scroll container so dropdown isn't clipped */}
-          <div className="relative flex-shrink-0" ref={dropdownRef}>
-            <button
-              onClick={() => setShowMoreFilters(!showMoreFilters)}
-              className={cn(
-                "flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-all border whitespace-nowrap",
-                showMoreFilters || activeFilterCount > 0
-                  ? "bg-amber text-white border-stone-800"
-                  : "bg-white text-stone-500 border-stone-200 hover:border-stone-300 hover:text-stone-700"
-              )}
-            >
-              <SlidersHorizontal className="h-3 w-3" />
-              Filters
-              {activeFilterCount > 0 && (
-                <span className="bg-amber text-white text-xs rounded-full w-4 h-4 flex items-center justify-center font-bold">
-                  {activeFilterCount}
-                </span>
-              )}
-              <ChevronDown className={cn("h-3 w-3 transition-transform", showMoreFilters && "rotate-180")} />
-            </button>
-
-            {showMoreFilters && (
-              <div className="absolute right-0 top-full mt-1.5 w-72 bg-white rounded-xl shadow-xl border border-stone-200 p-4 z-50">
-                {/* Sort By */}
-                <div className="mb-4">
-                  <label className="block text-xs font-semibold text-stone-400 uppercase tracking-wide mb-2">Sort By</label>
-                  <div className="flex gap-1.5">
-                    {([...(['price', 'name', 'suburb'] as const), ...(hasLocation ? (['nearest'] as const) : [])] as const).map(option => (
-                      <button
-                        key={option}
-                        onClick={() => setSortBy(option)}
-                        className={cn(
-                          "flex-1 px-2 py-1.5 rounded-lg text-xs font-medium transition-all",
-                          sortBy === option ? "bg-amber text-white" : "bg-stone-100 text-stone-600 hover:bg-stone-200"
-                        )}
-                      >
-                        {option === 'price' ? 'Price' : option === 'name' ? 'Name' : option === 'suburb' ? 'Suburb' : 'Nearest'}
-                      </button>
-                    ))}
-                  </div>
+          {showMoreFilters && (
+            <div className="absolute right-0 top-full mt-1.5 w-80 bg-white rounded-2xl shadow-xl border border-stone-200/60 p-5 z-50">
+              {/* View Mode */}
+              <div className="mb-4">
+                <label className="block text-xs font-semibold text-stone-400 uppercase tracking-wide mb-2">View</label>
+                <div className="flex gap-1.5">
+                  <button
+                    onClick={() => setViewMode('cards')}
+                    className={cn(
+                      "flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-xl text-xs font-medium transition-all",
+                      viewMode === 'cards' ? "bg-amber text-white" : "bg-stone-100 text-stone-600 hover:bg-stone-200"
+                    )}
+                  >
+                    <LayoutGrid className="h-3.5 w-3.5" /> Cards
+                  </button>
+                  <button
+                    onClick={() => setViewMode('list')}
+                    className={cn(
+                      "flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-xl text-xs font-medium transition-all",
+                      viewMode === 'list' ? "bg-amber text-white" : "bg-stone-100 text-stone-600 hover:bg-stone-200"
+                    )}
+                  >
+                    <List className="h-3.5 w-3.5" /> List
+                  </button>
                 </div>
+              </div>
 
-                {/* Max Price slider */}
-                <div className="mb-4">
-                  <label className="block text-xs font-semibold text-stone-400 uppercase tracking-wide mb-2">
-                    Max Price: <span className="text-amber">${maxPrice}</span>
-                  </label>
-                  <input
-                    type="range"
-                    min={6}
-                    max={15}
-                    step={0.5}
-                    value={maxPrice}
-                    onChange={(e) => setMaxPrice(Number(e.target.value))}
-                    className="w-full accent-gold"
-                  />
-                  <div className="flex justify-between text-xs text-stone-400 mt-0.5">
-                    <span>$6</span>
-                    <span>$15</span>
-                  </div>
-                </div>
-
-                {/* Active filters summary */}
-                {totalActive > 0 && (
-                  <div className="pt-3 border-t border-stone-100">
-                    <div className="flex items-center justify-between">
-                      <span className="text-xs text-stone-400">{totalActive} active filter{totalActive > 1 ? 's' : ''}</span>
-                      <button
-                        onClick={handleClearAll}
-                        className="text-xs text-coral hover:text-red-600 font-medium"
-                      >
-                        Clear All
-                      </button>
-                    </div>
-                  </div>
+              {/* Toggles */}
+              <div className="mb-4 space-y-2">
+                <label className="block text-xs font-semibold text-stone-400 uppercase tracking-wide mb-2">Toggles</label>
+                <button
+                  onClick={() => setShowHappyHourOnly(!showHappyHourOnly)}
+                  className={cn(
+                    "w-full flex items-center justify-between px-3 py-2 rounded-xl text-sm transition-all border",
+                    showHappyHourOnly
+                      ? "bg-amber/10 text-amber border-amber/30 font-medium"
+                      : "bg-stone-50 text-stone-600 border-stone-200/60 hover:bg-stone-100"
+                  )}
+                >
+                  <span className="flex items-center gap-2"><Clock className="h-3.5 w-3.5" /> Happy Hour Only</span>
+                  {stats.happyHourNow > 0 && <span className="text-xs bg-amber/20 text-amber px-1.5 py-0.5 rounded-full font-semibold">{stats.happyHourNow}</span>}
+                </button>
+                {hasLocation && (
+                  <button
+                    onClick={() => setSortBy(sortBy === 'nearest' ? 'price' : 'nearest')}
+                    className={cn(
+                      "w-full flex items-center justify-between px-3 py-2 rounded-xl text-sm transition-all border",
+                      isNearestActive
+                        ? "bg-amber/10 text-amber border-amber/30 font-medium"
+                        : "bg-stone-50 text-stone-600 border-stone-200/60 hover:bg-stone-100"
+                    )}
+                  >
+                    <span className="flex items-center gap-2"><MapPin className="h-3.5 w-3.5" /> Sort by Nearest</span>
+                  </button>
+                )}
+                {viewMode === 'cards' && (
+                  <button
+                    onClick={() => setShowMiniMaps(!showMiniMaps)}
+                    className={cn(
+                      "w-full flex items-center justify-between px-3 py-2 rounded-xl text-sm transition-all border",
+                      showMiniMaps
+                        ? "bg-amber/10 text-amber border-amber/30 font-medium"
+                        : "bg-stone-50 text-stone-600 border-stone-200/60 hover:bg-stone-100"
+                    )}
+                  >
+                    <span className="flex items-center gap-2"><MapIcon className="h-3.5 w-3.5" /> Show Maps on Cards</span>
+                  </button>
                 )}
               </div>
-            )}
-          </div>
+
+              {/* Sort By */}
+              <div className="mb-4">
+                <label className="block text-xs font-semibold text-stone-400 uppercase tracking-wide mb-2">Sort By</label>
+                <div className="flex gap-1.5">
+                  {(['price', 'name', 'suburb'] as const).map(option => (
+                    <button
+                      key={option}
+                      onClick={() => setSortBy(option)}
+                      className={cn(
+                        "flex-1 px-2 py-2 rounded-xl text-xs font-medium transition-all",
+                        sortBy === option ? "bg-amber text-white" : "bg-stone-100 text-stone-600 hover:bg-stone-200"
+                      )}
+                    >
+                      {option === 'price' ? 'Price' : option === 'name' ? 'Name' : 'Suburb'}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Max Price slider */}
+              <div className="mb-4">
+                <label className="block text-xs font-semibold text-stone-400 uppercase tracking-wide mb-2">
+                  Max Price: <span className="text-amber">${maxPrice}</span>
+                </label>
+                <input
+                  type="range"
+                  min={6}
+                  max={15}
+                  step={0.5}
+                  value={maxPrice}
+                  onChange={(e) => setMaxPrice(Number(e.target.value))}
+                  className="w-full accent-amber"
+                />
+                <div className="flex justify-between text-xs text-stone-400 mt-0.5">
+                  <span>$6</span>
+                  <span>$15</span>
+                </div>
+              </div>
+
+              {/* Clear All */}
+              {activeFilterCount > 0 && (
+                <div className="pt-3 border-t border-stone-100">
+                  <button
+                    onClick={handleClearAll}
+                    className="w-full text-center text-sm text-red-500 hover:text-red-600 font-medium py-1"
+                  >
+                    Clear All Filters
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,49 @@
+export default function Footer() {
+  return (
+    <footer className="bg-charcoal text-white py-12">
+      <div className="max-w-7xl mx-auto px-4">
+        <div className="flex flex-col sm:flex-row items-center justify-between gap-6 mb-8">
+          <div className="flex items-center gap-2.5">
+            <img src="/logo.png" alt="PintDex" className="w-10 h-10 rounded-lg object-contain" />
+            <span className="text-xl font-bold tracking-tight font-heading">PintDex</span>
+          </div>
+          <p className="text-stone-400 text-sm text-center">Perth&apos;s pint prices, sorted. Community-driven since 2024.</p>
+        </div>
+
+        <div className="flex flex-wrap justify-center gap-6 mb-8 pb-8 border-b border-stone-700">
+          <div className="flex items-center gap-2">
+            <span className="text-amber text-lg">⬡</span>
+            <div>
+              <p className="font-semibold text-white">Schooner</p>
+              <p className="text-xs text-stone-400">425ml</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-amber text-lg">⬡</span>
+            <div>
+              <p className="font-semibold text-amber">Pint</p>
+              <p className="text-xs text-stone-400">570ml</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-amber text-lg">⬡</span>
+            <div>
+              <p className="font-semibold text-white">Long Neck</p>
+              <p className="text-xs text-stone-400">750ml</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="text-center">
+          <p className="text-stone-400 text-xs">Prices may vary. Pint prices shown. Always drink responsibly.</p>
+          <a
+            href="mailto:perthpintprices@gmail.com?subject=Price%20Correction&body=Hi%2C%20I%20noticed%20a%20wrong%20price%20on%20the%20site.%0A%0APub%20name%3A%20%0ACorrect%20price%3A%20%0ADetails%3A%20"
+            className="inline-block mt-3 text-amber hover:text-amber-light text-xs"
+          >
+            Report Wrong Price
+          </a>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+interface HeroSectionProps {
+  avgPrice: string
+  cheapestPrice: number
+  venueCount: number
+  suburbCount: number
+  happyHourCount: number
+  onExploreClick: () => void
+  onDiscoverClick: () => void
+  onSubmitClick: () => void
+}
+
+export default function HeroSection({
+  avgPrice,
+  cheapestPrice,
+  venueCount,
+  suburbCount,
+  happyHourCount,
+  onExploreClick,
+  onDiscoverClick,
+  onSubmitClick,
+}: HeroSectionProps) {
+  return (
+    <section className="bg-cream relative overflow-hidden">
+      {/* Top nav bar — minimal like EatClub */}
+      <div className="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
+        <div className="flex items-center gap-2.5">
+          <img src="/logo.png" alt="PintDex" className="w-10 h-10 rounded-lg object-contain" />
+          <span className="text-xl font-bold tracking-tight font-heading text-charcoal">PintDex</span>
+        </div>
+        <button
+          onClick={onSubmitClick}
+          className="px-5 py-2.5 bg-charcoal hover:bg-charcoal/90 text-white rounded-full font-bold transition-all text-sm"
+        >
+          Submit a Price
+        </button>
+      </div>
+
+      {/* Hero content — big, confident, breathing room */}
+      <div className="max-w-4xl mx-auto px-4 pt-16 sm:pt-24 pb-20 sm:pb-28 text-center">
+        <h1 className="text-4xl sm:text-6xl lg:text-7xl font-bold text-charcoal font-heading leading-[1.05] mb-6">
+          Perth&apos;s pint prices,{' '}
+          <span className="text-amber">sorted.</span>
+        </h1>
+        <p className="text-lg sm:text-xl text-stone-500 max-w-2xl mx-auto mb-10 leading-relaxed">
+          Real-time prices across {venueCount}+ pubs and {suburbCount} suburbs.
+          Find happy hours, compare prices, and save on your next round.
+        </p>
+
+        {/* Hero stat highlights — EatClub-style bold numbers */}
+        <div className="flex flex-wrap justify-center gap-4 sm:gap-8 mb-10">
+          <div className="bg-white rounded-2xl px-5 py-3 shadow-sm border border-stone-200/60">
+            <span className="block text-2xl sm:text-3xl font-bold font-mono text-green-700">${cheapestPrice}</span>
+            <span className="text-xs text-stone-500">Cheapest pint</span>
+          </div>
+          <div className="bg-white rounded-2xl px-5 py-3 shadow-sm border border-stone-200/60">
+            <span className="block text-2xl sm:text-3xl font-bold font-mono text-charcoal">${avgPrice}</span>
+            <span className="text-xs text-stone-500">Perth average</span>
+          </div>
+          {happyHourCount > 0 && (
+            <div className="bg-white rounded-2xl px-5 py-3 shadow-sm border border-amber/30 bg-amber/5">
+              <span className="block text-2xl sm:text-3xl font-bold font-mono text-amber">{happyHourCount}</span>
+              <span className="text-xs text-stone-500">Happy hours live</span>
+            </div>
+          )}
+        </div>
+
+        {/* CTA buttons */}
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <button
+            onClick={onExploreClick}
+            className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-charcoal hover:bg-charcoal/90 text-white rounded-full font-bold text-lg transition-all shadow-lg shadow-charcoal/10"
+          >
+            Explore {venueCount} venues
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
+            </svg>
+          </button>
+          <button
+            onClick={onDiscoverClick}
+            className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-white hover:bg-stone-50 text-charcoal rounded-full font-bold text-lg transition-all border border-stone-300"
+          >
+            Discover features
+          </button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -1,0 +1,57 @@
+export default function HowItWorks() {
+  const steps = [
+    {
+      num: '01',
+      title: 'Find pubs near you',
+      desc: 'Browse 200+ pubs across 90 Perth suburbs with real-time prices and happy hour info.',
+      icon: (
+        <svg className="w-8 h-8" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+        </svg>
+      ),
+    },
+    {
+      num: '02',
+      title: 'Compare prices',
+      desc: 'See how every pub stacks up against the Perth average. Track happy hours and price changes.',
+      icon: (
+        <svg className="w-8 h-8" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+        </svg>
+      ),
+    },
+    {
+      num: '03',
+      title: 'Go enjoy your pint',
+      desc: 'Get directions, check the vibe, and save money on your next round. Simple as.',
+      icon: (
+        <svg className="w-8 h-8" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15.182 15.182a4.5 4.5 0 01-6.364 0M21 12a9 9 0 11-18 0 9 9 0 0118 0zM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75zm-.375 0h.008v.015h-.008V9.75zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75zm-.375 0h.008v.015h-.008V9.75z" />
+        </svg>
+      ),
+    },
+  ]
+
+  return (
+    <section className="py-20 sm:py-24 border-t border-stone-200/60">
+      <div className="max-w-4xl mx-auto px-4">
+        <h2 className="text-title text-charcoal font-heading text-center mb-4">
+          How it works
+        </h2>
+        <p className="text-stone-500 text-center mb-12 text-lg">No app download. No sign-up. Just prices.</p>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-8 sm:gap-12">
+          {steps.map((step) => (
+            <div key={step.num} className="text-center">
+              <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-amber/10 text-amber mb-5">
+                {step.icon}
+              </div>
+              <div className="text-sm font-mono text-amber font-bold mb-2">{step.num}</div>
+              <h3 className="text-xl font-semibold text-charcoal mb-2 font-heading">{step.title}</h3>
+              <p className="text-stone-500 leading-relaxed">{step.desc}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/PriceTicker.tsx
+++ b/src/components/PriceTicker.tsx
@@ -46,7 +46,7 @@ export default function PriceTicker({ pubs }: PriceTickerProps) {
   const duration = Math.max(15, tickers.length * 1.2);
 
   return (
-    <div className="w-full bg-white border-b border-stone-200 overflow-hidden relative select-none" style={{ height: '36px', zIndex: 50 }}>
+    <div className="w-full bg-charcoal/5 border-b border-stone-200/60 overflow-hidden relative select-none" style={{ height: '36px', zIndex: 50 }}>
       <style>{`
         @keyframes ticker-scroll {
           0% { transform: translate3d(0, 0, 0); }
@@ -72,10 +72,10 @@ export default function PriceTicker({ pubs }: PriceTickerProps) {
 
             return (
               <span key={`${t.suburb}-${i}`} className="inline-flex items-center gap-1.5 px-4 text-xs tracking-wide" style={{ height: '36px' }}>
-                <span className="font-semibold text-stone-700 uppercase text-[11px]">
+                <span className="font-semibold text-stone-700 uppercase text-xs sm:text-sm">
                   {t.suburb}
                 </span>
-                <span className="font-mono text-stone-900 font-bold text-[12px]">
+                <span className="font-mono text-stone-900 font-bold text-sm">
                   ${t.avgPrice.toFixed(2)}
                 </span>
                 <span className={`font-mono ${color} text-[11px]`}>

--- a/src/components/PubCard.tsx
+++ b/src/components/PubCard.tsx
@@ -1,51 +1,17 @@
 'use client'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-
-import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import dynamic from 'next/dynamic'
-
-const MiniMap = dynamic(() => import('./MiniMap'), {
-  ssr: false,
-  loading: () => <div className="h-24 bg-stone-100 animate-pulse" />
-})
-import CrowdBadge from './CrowdBadge'
+import { Badge } from '@/components/ui/badge'
 import { Pub } from '@/types/pub'
 import { CrowdReport } from '@/lib/supabase'
 import { HappyHourStatus } from '@/lib/happyHour'
 import E from '@/lib/emoji'
 
-function timeAgo(dateStr: string): string {
-  const date = new Date(dateStr)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
-  if (diffDays < 1) return 'today'
-  if (diffDays < 7) return `${diffDays}d ago`
-  if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`
-  if (diffDays < 365) return `${Math.floor(diffDays / 30)}mo ago`
-  return `${Math.floor(diffDays / 365)}y ago`
-}
-
-async function sharePub(pub: Pub) {
-  const text = `🍺 $${pub.price?.toFixed(2) ?? 'TBC'} pints at ${pub.name}, ${pub.suburb} — found on PintDex → pintdex.com.au`
-  if (navigator.share) {
-    try {
-      await navigator.share({ text })
-    } catch {}
-  } else if (navigator.clipboard) {
-    await navigator.clipboard.writeText(text)
-  }
-}
-
-// Subtle directions pin icon
-const DirectionsIcon = () => (
-  <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
-    <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
-  </svg>
-)
+const MiniMap = dynamic(() => import('./MiniMap'), {
+  ssr: false,
+  loading: () => <div className="h-[280px] bg-stone-100 animate-pulse" />,
+})
 
 interface PubCardProps {
   pub: Pub
@@ -78,133 +44,60 @@ export default function PubCard({
 }: PubCardProps) {
   const router = useRouter()
   return (
-    <Card className="group relative overflow-hidden hover:shadow-lg transition-all duration-200 border-stone-200/60 shadow-[0_1px_8px_rgba(0,0,0,0.04)] rounded-2xl h-full flex flex-col cursor-pointer" onClick={() => router.push(`/pub/${pub.slug}`)}>
-      {/* Happy Hour active badge */}
-      {happyHourStatus.isActive && (
-        <Badge className="absolute top-2 left-2 z-10 bg-amber hover:bg-amber text-white animate-pulse">
-          {E.party} HAPPY HOUR!
-        </Badge>
-      )}
-
-      {/* TAB badge */}
-      {pub.hasTab && (
-        <Badge className={`absolute top-2 ${happyHourStatus.isActive ? 'left-32' : 'left-2'} z-10 text-white text-[9px] px-1.5 py-0.5`} style={{ backgroundColor: '#5B2D8E' }}>
-          TAB
-        </Badge>
-      )}
-
-      {/* Kid-friendly badge */}
-      {pub.kidFriendly && (
-        <Badge className={`absolute top-2 ${pub.hasTab ? (happyHourStatus.isActive ? 'left-48' : 'left-20') : (happyHourStatus.isActive ? 'left-32' : 'left-2')} z-10 text-white text-[9px] px-1.5 py-0.5 bg-emerald-600`}>
-          KIDS
-        </Badge>
-      )}
-
-      {/* Mini map */}
-      {showMiniMaps && (
-        <div className="h-24 relative overflow-hidden">
-          <MiniMap lat={pub.lat} lng={pub.lng} name={pub.name} />
-          <div className="absolute inset-0 bg-gradient-to-t from-white via-transparent to-transparent pointer-events-none"></div>
-        </div>
-      )}
-
-      <CardHeader className={`p-4 pb-2 ${!showMiniMaps ? 'pt-5' : ''}`}>
-        <div className="flex justify-between items-start gap-2">
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-1.5">
-              <a
-                href={getDirectionsUrl(pub)}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={(e) => e.stopPropagation()}
-                className="flex-shrink-0 text-stone-300 hover:text-amber transition-colors"
-                title="Get directions"
-              >
-                <DirectionsIcon />
-              </a>
-              <Link href={`/pub/${pub.slug}`} className="hover:text-amber transition-colors"><h3 className="font-bold text-stone-900 truncate">{pub.name}</h3></Link>
+    <Link href={`/pub/${pub.slug}`} className="block h-full">
+      <div className="group relative overflow-hidden hover:shadow-lg transition-shadow duration-300 border border-stone-200/60 shadow-sm rounded-2xl h-full flex flex-col bg-white cursor-pointer">
+        {/* Image area — 280px tall */}
+        <div className="relative h-[280px] bg-stone-100">
+          {pub.imageUrl ? (
+            <img src={pub.imageUrl} alt={pub.name} className="w-full h-full object-cover" />
+          ) : showMiniMaps ? (
+            <MiniMap lat={pub.lat} lng={pub.lng} name={pub.name} />
+          ) : (
+            <div className="w-full h-full bg-gradient-to-br from-cream to-cream-dark flex items-center justify-center">
+              <span className="text-6xl opacity-20">🍺</span>
             </div>
-            <p className="text-xs text-stone-500">{pub.suburb}{distance && <span className="text-stone-400 text-xs"> · {distance}</span>}</p>
-          </div>
-          <div className="text-right">
-              {pub.isHappyHourNow && pub.regularPrice !== null && pub.regularPrice !== pub.price && (
-                <div className="text-[10px] text-stone-400 line-through font-mono">${pub.regularPrice.toFixed(2)}</div>
-              )}
-              <div className={`text-xl font-bold font-mono bg-gradient-to-br ${getPriceColor(pub.price)} bg-clip-text text-transparent`}>
-                {pub.price !== null ? `$${pub.price.toFixed(2)}` : 'TBC'}
-              </div>
-            </div>
+          )}
+
+          {/* Price badge — bottom left, overlapping image */}
+          <span className="absolute bottom-3 left-3 font-mono font-bold text-lg bg-white/90 backdrop-blur-sm px-3 py-1 rounded-full shadow-sm">
+            {pub.price !== null ? `$${pub.price.toFixed(2)}` : 'TBC'}
+          </span>
+
+          {/* Happy Hour badge — top left */}
+          {happyHourStatus.isActive && (
+            <Badge className="absolute top-3 left-3 bg-amber hover:bg-amber text-white animate-pulse text-xs">
+              {E.party} HAPPY HOUR
+            </Badge>
+          )}
+
+          {/* TAB badge — top right */}
+          {pub.hasTab && (
+            <Badge className="absolute top-3 right-3 text-white text-[10px] px-2 py-0.5" style={{ backgroundColor: '#5B2D8E' }}>
+              TAB
+            </Badge>
+          )}
         </div>
-      </CardHeader>
 
-      <CardContent className="px-4 py-2 space-y-2 flex-1">
-        {crowdReport && <CrowdBadge report={crowdReport} />}
-
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs text-stone-500 bg-stone-100">
-          {E.beer} {pub.beerType}
-        </span>
-
-        <p className="text-xs text-stone-600 flex items-center gap-1">
-          <svg className="w-3 h-3 text-stone-400 flex-shrink-0" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
-          {pub.address}
-        </p>
-
-        {pub.happyHour && (
-          <div className={`text-xs flex items-center gap-1 ${
-            happyHourStatus.isActive ? 'text-amber font-bold' : 
-            happyHourStatus.isToday ? 'text-amber font-semibold' : 
-            'text-stone-500'
-          }`}>
-            <span>{happyHourStatus.statusEmoji}</span>
-            <span>{happyHourStatus.statusText}</span>
-            {happyHourStatus.countdown && happyHourStatus.isActive && (
-              <span className="text-amber font-normal">• {happyHourStatus.countdown}</span>
+        {/* Text area — minimal */}
+        <div className="p-5 flex-1 flex flex-col">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0 flex-1">
+              <h3 className="font-heading font-semibold text-lg text-charcoal truncate">{pub.name}</h3>
+              <p className="text-stone-500 text-base mt-0.5">
+                {pub.suburb}{distance ? ` · ${distance}` : ''}
+              </p>
+            </div>
+            {pub.isHappyHourNow && (
+              <Badge className="bg-amber/10 text-amber border-amber/20 text-sm flex-shrink-0">
+                🍻 HH
+              </Badge>
             )}
           </div>
-        )}
-
-        {pub.description && (
-          <p className="text-xs text-stone-500 line-clamp-2 italic">\"{pub.description}\"</p>
-        )}
-
-        {pub.lastUpdated && (
-          <p className="text-xs text-stone-400">✓ Verified price</p>
-        )}
-      </CardContent>
-
-      <CardFooter className="px-4 py-3 border-t border-stone-100 flex items-center justify-between">
-        {pub.website ? (
-          <a
-            href={pub.website}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-amber hover:text-amber-600 text-xs font-semibold"
-          >
-            Visit website →
-          </a>
-        ) : (
-          <div></div>
-        )}
-        <div className="flex items-center gap-1.5">
-          <button
-            onClick={() => sharePub(pub)}
-            className="text-stone-400 hover:text-amber transition-colors p-1"
-            title="Share"
-          >
-            <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
-            </svg>
-          </button>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => onCrowdReport(pub)}
-            className="text-xs h-7"
-          >
-            How busy?
-          </Button>
+          {pub.beerType && (
+            <p className="text-sm text-stone-400 mt-2 truncate">{pub.beerType}</p>
+          )}
         </div>
-      </CardFooter>
-    </Card>
+      </div>
+    </Link>
   )
 }

--- a/src/components/PubCardsView.tsx
+++ b/src/components/PubCardsView.tsx
@@ -1,0 +1,74 @@
+'use client'
+import { Pub } from '@/types/pub'
+import { CrowdReport } from '@/lib/supabase'
+import { getHappyHourStatus } from '@/lib/happyHour'
+import { getDistanceKm, formatDistance } from '@/lib/location'
+import { getPriceColor, getPriceBgColor, getDirectionsUrl, formatLastUpdated } from '@/lib/priceColors'
+import PubCard from './PubCard'
+
+interface PubCardsViewProps {
+  pubs: Pub[]
+  crowdReports: Record<string, CrowdReport>
+  showMiniMaps: boolean
+  userLocation: { lat: number; lng: number } | null
+  sortBy: string
+  onCrowdReport: (pub: Pub) => void
+  showAll: boolean
+  initialCount: number
+  onShowAll: () => void
+}
+
+export default function PubCardsView({
+  pubs,
+  crowdReports,
+  showMiniMaps,
+  userLocation,
+  sortBy,
+  onCrowdReport,
+  showAll,
+  initialCount,
+  onShowAll,
+}: PubCardsViewProps) {
+  const displayPubs = showAll ? pubs : pubs.slice(0, initialCount)
+
+  function getLatestCrowdReport(pubId: number): CrowdReport | undefined {
+    return crowdReports[String(pubId)]
+  }
+
+  return (
+    <>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-x-16">
+        {displayPubs.map((pub, index) => {
+          const crowdReport = getLatestCrowdReport(pub.id)
+          const happyHourStatus = getHappyHourStatus(pub.happyHour)
+          return (
+            <PubCard
+              key={pub.id}
+              pub={pub}
+              index={index}
+              sortBy={sortBy}
+              showMiniMaps={showMiniMaps}
+              crowdReport={crowdReport}
+              happyHourStatus={happyHourStatus}
+              getDirectionsUrl={getDirectionsUrl}
+              getPriceColor={getPriceColor}
+              getPriceBgColor={getPriceBgColor}
+              formatLastUpdated={formatLastUpdated}
+              onCrowdReport={onCrowdReport}
+              distance={userLocation ? formatDistance(getDistanceKm(userLocation.lat, userLocation.lng, pub.lat, pub.lng)) : undefined}
+            />
+          )
+        })}
+      </div>
+      {!showAll && pubs.length > initialCount && (
+        <button
+          onClick={onShowAll}
+          className="w-full mt-4 py-3 text-sm font-medium text-charcoal hover:text-amber bg-white hover:bg-amber/5 rounded-2xl shadow-[0_2px_12px_rgba(0,0,0,0.06)] border border-stone-200/60 transition-colors flex items-center justify-center gap-1"
+        >
+          Show All {pubs.length} Venues
+          <span className="inline-block">&#9660;</span>
+        </button>
+      )}
+    </>
+  )
+}

--- a/src/components/PubListView.tsx
+++ b/src/components/PubListView.tsx
@@ -1,0 +1,142 @@
+'use client'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { Pub } from '@/types/pub'
+import { CrowdReport, CROWD_LEVELS } from '@/lib/supabase'
+import { getHappyHourStatus } from '@/lib/happyHour'
+import { getDistanceKm, formatDistance } from '@/lib/location'
+import { getPriceTextColor, getDirectionsUrl } from '@/lib/priceColors'
+
+interface PubListViewProps {
+  pubs: Pub[]
+  crowdReports: Record<string, CrowdReport>
+  userLocation: { lat: number; lng: number } | null
+  onCrowdReport: (pub: Pub) => void
+  showAll: boolean
+  initialCount: number
+  onShowAll: () => void
+}
+
+export default function PubListView({
+  pubs,
+  crowdReports,
+  userLocation,
+  onCrowdReport,
+  showAll,
+  initialCount,
+  onShowAll,
+}: PubListViewProps) {
+  const router = useRouter()
+  const displayPubs = showAll ? pubs : pubs.slice(0, initialCount)
+
+  function getLatestCrowdReport(pubId: number): CrowdReport | undefined {
+    return crowdReports[String(pubId)]
+  }
+
+  return (
+    <div className="bg-white rounded-2xl shadow-[0_2px_12px_rgba(0,0,0,0.06)] border border-stone-200/60 overflow-hidden">
+      <table className="w-full">
+        <thead>
+          <tr className="bg-stone-50 border-b border-stone-200">
+            <th className="text-left py-3 px-4 text-xs font-semibold text-stone-600 uppercase tracking-wide">Pub</th>
+            <th className="text-left py-3 px-4 text-xs font-semibold text-stone-600 uppercase tracking-wide hidden sm:table-cell">Suburb</th>
+            <th className="text-left py-3 px-4 text-xs font-semibold text-stone-600 uppercase tracking-wide hidden sm:table-cell">Beer</th>
+            <th className="text-right py-3 px-4 text-xs font-semibold text-stone-600 uppercase tracking-wide">Price</th>
+            <th className="text-left py-3 px-4 text-xs font-semibold text-stone-600 uppercase tracking-wide hidden md:table-cell">Happy Hour</th>
+            <th className="text-center py-3 px-4 text-xs font-semibold text-stone-600 uppercase tracking-wide">Crowd</th>
+          </tr>
+        </thead>
+        <tbody>
+          {displayPubs.map((pub, index) => {
+            const crowdReport = getLatestCrowdReport(pub.id)
+            const happyHourStatus = getHappyHourStatus(pub.happyHour)
+            return (
+              <tr
+                key={pub.id}
+                className={`border-b border-stone-100 hover:bg-amber/5 transition-colors cursor-pointer ${
+                  index % 2 === 0 ? 'bg-white' : 'bg-stone-50/30'
+                }`}
+                onClick={() => router.push(`/pub/${pub.slug}`)}
+              >
+                <td className="py-3 px-2 sm:px-4">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-stone-300 w-5 text-right tabular-nums">{index + 1}</span>
+                    <div>
+                      <div className="flex items-center gap-1.5">
+                        <a
+                          href={getDirectionsUrl(pub)}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          className="flex-shrink-0 text-stone-300 hover:text-amber transition-colors"
+                          title="Get directions"
+                        >
+                          <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
+                          </svg>
+                        </a>
+                        <Link href={`/pub/${pub.slug}`} className="font-semibold text-stone-900 text-sm hover:text-amber transition-colors">{pub.name}</Link>
+                      </div>
+                      <p className="text-xs text-stone-500 sm:hidden">{pub.suburb}{userLocation && ` · ${formatDistance(getDistanceKm(userLocation.lat, userLocation.lng, pub.lat, pub.lng))}`}</p>
+                    </div>
+                  </div>
+                </td>
+                <td className="py-3 px-4 text-sm text-stone-600 hidden sm:table-cell">
+                  {pub.suburb}
+                  {userLocation && <span className="text-stone-400 text-xs ml-1">· {formatDistance(getDistanceKm(userLocation.lat, userLocation.lng, pub.lat, pub.lng))}</span>}
+                </td>
+                <td className="py-3 px-4 hidden sm:table-cell">
+                  <span className="text-xs text-stone-500 truncate max-w-[120px] block">
+                    {pub.beerType || '—'}
+                  </span>
+                </td>
+                <td className={`py-3 px-2 sm:px-4 text-right font-bold font-mono text-lg whitespace-nowrap ${getPriceTextColor(pub.price)}`}>
+                  {pub.isHappyHourNow && pub.regularPrice !== null && pub.regularPrice !== pub.price && (
+                    <span className="text-xs text-stone-400 line-through font-normal mr-1">${pub.regularPrice.toFixed(2)}</span>
+                  )}
+                  {pub.price !== null ? `$${pub.price.toFixed(2)}` : 'TBC'}
+                </td>
+                <td className="py-3 px-4 hidden md:table-cell">
+                  {pub.happyHour ? (
+                    <span className={`text-xs ${
+                      happyHourStatus.isActive ? 'text-amber font-bold' :
+                      happyHourStatus.isToday ? 'text-amber-dark font-semibold' :
+                      'text-stone-500'
+                    }`}>
+                      {happyHourStatus.statusEmoji} {happyHourStatus.statusText}
+                    </span>
+                  ) : (
+                    <span className="text-xs text-stone-400">—</span>
+                  )}
+                </td>
+                <td className="py-3 px-4 text-center">
+                  {crowdReport ? (
+                    <span className="text-sm" title={`${crowdReport.minutes_ago}m ago`}>
+                      {CROWD_LEVELS[crowdReport.crowd_level].emoji}
+                    </span>
+                  ) : (
+                    <button
+                      onClick={(e) => { e.stopPropagation(); onCrowdReport(pub); }}
+                      className="text-xs text-stone-400 hover:text-amber"
+                    >
+                      Report
+                    </button>
+                  )}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      {!showAll && pubs.length > initialCount && (
+        <button
+          onClick={onShowAll}
+          className="w-full py-3 text-sm font-medium text-charcoal hover:text-amber hover:bg-amber/5 transition-colors flex items-center justify-center gap-1 border-t border-stone-200"
+        >
+          Show All {pubs.length} Venues
+          <span className="inline-block">&#9660;</span>
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/components/PuntNPints.tsx
+++ b/src/components/PuntNPints.tsx
@@ -25,7 +25,7 @@ interface PuntNPintsProps {
 
 export default function PuntNPints({ pubs, userLocation }: PuntNPintsProps) {
   const [isSectionOpen, setIsSectionOpen] = useState(false)
-  const [isExpanded, setIsExpanded] = useState(false)
+  const [isExpanded, setIsExpanded] = useState(true)
   const [tabLocations, setTabLocations] = useState<TabLocation[]>([])
 
   useEffect(() => {

--- a/src/components/SocialProof.tsx
+++ b/src/components/SocialProof.tsx
@@ -1,0 +1,28 @@
+interface SocialProofProps {
+  venueCount: number
+  suburbCount: number
+  avgPrice: string
+}
+
+export default function SocialProof({ venueCount, suburbCount, avgPrice }: SocialProofProps) {
+  const proofs = [
+    { value: `${venueCount}+`, label: 'Venues tracked' },
+    { value: String(suburbCount), label: 'Perth suburbs' },
+    { value: `$${avgPrice}`, label: 'Perth average pint' },
+    { value: '100%', label: 'Verified prices' },
+  ]
+  return (
+    <section className="py-16 sm:py-20 border-t border-stone-200/60 bg-cream-dark">
+      <div className="max-w-5xl mx-auto px-4">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 text-center">
+          {proofs.map((p) => (
+            <div key={p.label}>
+              <div className="text-3xl sm:text-4xl font-bold text-charcoal font-heading">{p.value}</div>
+              <div className="text-stone-500 text-sm mt-1">{p.label}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/StatsBar.tsx
+++ b/src/components/StatsBar.tsx
@@ -1,0 +1,46 @@
+interface StatsBarProps {
+  avgPrice: string
+  cheapestPrice: number
+  cheapestSuburb: string
+  priciestPrice: number
+  priciestSuburb: string
+  happyHourCount: number
+  suburbCount: number
+  venueCount: number
+}
+
+export default function StatsBar({
+  avgPrice,
+  cheapestPrice,
+  cheapestSuburb,
+  priciestPrice,
+  priciestSuburb,
+  happyHourCount,
+  suburbCount,
+  venueCount,
+}: StatsBarProps) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mt-2.5 pb-2.5">
+      <div className="bg-stone-50 rounded-xl p-3 sm:p-4 border border-stone-200/60">
+        <span className="text-stone-500 text-[10px] uppercase tracking-wider block leading-none">Perth Avg</span>
+        <span className="text-charcoal font-mono font-bold text-base sm:text-lg leading-tight">${avgPrice}</span>
+        <span className="text-stone-400 text-[10px] block leading-none mt-0.5">{venueCount} venues</span>
+      </div>
+      <div className="bg-stone-50 rounded-xl p-3 sm:p-4 border border-stone-200/60">
+        <span className="text-stone-500 text-[10px] uppercase tracking-wider block leading-none">Cheapest</span>
+        <span className="text-green-700 font-mono font-bold text-base sm:text-lg leading-tight">${cheapestPrice}</span>
+        <span className="text-stone-400 text-[10px] block leading-none mt-0.5 truncate">{cheapestSuburb}</span>
+      </div>
+      <div className="bg-stone-50 rounded-xl p-3 sm:p-4 border border-stone-200/60">
+        <span className="text-stone-500 text-[10px] uppercase tracking-wider block leading-none">Priciest</span>
+        <span className="text-red-700 font-mono font-bold text-base sm:text-lg leading-tight">${priciestPrice}</span>
+        <span className="text-stone-400 text-[10px] block leading-none mt-0.5 truncate">{priciestSuburb}</span>
+      </div>
+      <div className="bg-stone-50 rounded-xl p-3 sm:p-4 border border-stone-200/60">
+        <span className="text-stone-500 text-[10px] uppercase tracking-wider block leading-none">Happy Hour</span>
+        <span className="text-amber font-mono font-bold text-base sm:text-lg leading-tight">{happyHourCount}</span>
+        <span className="text-stone-400 text-[10px] block leading-none mt-0.5">{suburbCount} suburbs</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/SubmitPubForm.tsx
+++ b/src/components/SubmitPubForm.tsx
@@ -78,8 +78,8 @@ Notes: ${formData.notes || 'None'}
     }
   }
 
-  const inputClass = "w-full px-3 py-2.5 bg-stone-50 border border-stone-200 rounded-xl text-stone-800 placeholder-stone-400 focus:outline-none focus:ring-2 focus:ring-amber focus:border-transparent transition-all text-sm";
-  const labelClass = "block text-xs font-semibold text-stone-500 uppercase tracking-wide mb-1";
+  const inputClass = "w-full px-3 py-3 h-11 bg-stone-50 border border-stone-200/60 rounded-xl text-stone-800 placeholder-stone-400 focus:outline-none focus:ring-2 focus:ring-amber focus:border-transparent transition-all text-sm";
+  const labelClass = "block text-sm font-semibold text-stone-500 uppercase tracking-wide mb-1.5";
 
   return (
     <div 
@@ -90,7 +90,7 @@ Notes: ${formData.notes || 'None'}
         {/* Header */}
         <div className="px-6 py-4 border-b border-stone-100 flex items-center justify-between">
           <div>
-            <h2 className="text-lg font-bold text-stone-800">Submit a Price</h2>
+            <h2 className="text-xl font-bold text-stone-800">Submit a Price</h2>
             <p className="text-xs text-stone-400 mt-0.5">Know a cheap pint spot? Let us know!</p>
           </div>
           <button
@@ -200,7 +200,7 @@ Notes: ${formData.notes || 'None'}
             <button
               type="submit"
               disabled={isSubmitting}
-              className="w-full py-3 px-4 bg-amber hover:bg-amber-700 text-white font-bold rounded-xl transition-all transform hover:scale-[1.01] active:scale-[0.99] disabled:opacity-50 disabled:cursor-not-allowed shadow-md mt-2"
+              className="w-full py-3 px-4 h-12 bg-amber hover:bg-amber-700 text-white font-bold rounded-xl transition-all transform hover:scale-[1.01] active:scale-[0.99] disabled:opacity-50 disabled:cursor-not-allowed shadow-md mt-2"
             >
               {isSubmitting ? 'Opening email...' : 'Submit via Email'}
             </button>

--- a/src/components/SunsetSippers.tsx
+++ b/src/components/SunsetSippers.tsx
@@ -113,7 +113,7 @@ function getSunShadowGradient(azimuth: number, isGolden: boolean): string {
 
 export default function SunsetSippers({ pubs, userLocation }: SunsetSippersProps) {
   const [now, setNow] = useState(new Date())
-  const [isExpanded, setIsExpanded] = useState(false)
+  const [isExpanded, setIsExpanded] = useState(true)
   const [showAllPubs, setShowAllPubs] = useState(false)
   const [apiSunriseHour, setApiSunriseHour] = useState<number | null>(null)
   const [apiSunsetHour, setApiSunsetHour] = useState<number | null>(null)

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -59,7 +59,7 @@ const tabs: { id: TabId; label: string; activeIcon: JSX.Element; inactiveIcon: J
 
 export default function TabBar({ activeTab, onTabChange, pubCount, crowdCount }: TabBarProps) {
   return (
-    <div className="bg-white border-b border-stone-200">
+    <div className="bg-cream border-b border-stone-200/60">
       <div className="max-w-7xl mx-auto">
         <nav className="flex" role="tablist">
           {tabs.map((tab) => {
@@ -83,7 +83,7 @@ export default function TabBar({ activeTab, onTabChange, pubCount, crowdCount }:
                   {isActive ? tab.activeIcon : tab.inactiveIcon}
                 </span>
 
-                <span className={`text-[11px] leading-none ${isActive ? 'font-semibold' : 'font-medium'}`}>
+                <span className={`text-xs leading-none ${isActive ? 'font-semibold' : 'font-medium'}`}>
                   {tab.label}
                 </span>
 

--- a/src/lib/priceColors.ts
+++ b/src/lib/priceColors.ts
@@ -1,0 +1,34 @@
+export function getPriceColor(price: number | null): string {
+  if (price === null) return 'from-stone-400 to-stone-500'
+  if (price <= 7) return 'from-green-600 to-green-700'
+  if (price <= 8) return 'from-yellow-600 to-yellow-700'
+  if (price <= 9) return 'from-orange-600 to-orange-700'
+  return 'from-red-600 to-red-700'
+}
+
+export function getPriceBgColor(price: number | null): string {
+  if (price === null) return 'bg-stone-400'
+  if (price <= 7) return 'bg-green-700'
+  if (price <= 8) return 'bg-yellow-700'
+  if (price <= 9) return 'bg-orange-700'
+  return 'bg-red-700'
+}
+
+export function getPriceTextColor(price: number | null): string {
+  if (price === null) return 'text-stone-400'
+  if (price <= 7) return 'text-green-700'
+  if (price <= 8) return 'text-yellow-700'
+  if (price <= 9) return 'text-orange-700'
+  return 'text-red-700'
+}
+
+export function getDirectionsUrl(pub: { name: string; address: string }): string {
+  const query = encodeURIComponent(`${pub.name}, ${pub.address}`)
+  return `https://www.google.com/maps/dir/?api=1&destination=${query}`
+}
+
+export function formatLastUpdated(dateStr: string | undefined): string {
+  if (!dateStr) return ''
+  const date = new Date(dateStr)
+  return date.toLocaleDateString('en-AU', { month: 'short', year: 'numeric' })
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -123,6 +123,7 @@ export async function getPubs(): Promise<Pub[]> {
       // KEY: price = effective price (switches to HH price when active)
       price: hhStatus.effectivePrice,
       regularPrice: regularPrice,
+      imageUrl: row.image_url ?? null,
       address: row.address || '',
       website: row.website || null,
       lat: row.lat || 0,
@@ -184,6 +185,7 @@ export async function getPubBySlug(slug: string): Promise<Pub | null> {
     suburb: row.suburb,
     price: hhStatus.effectivePrice,
     regularPrice: regularPrice,
+      imageUrl: row.image_url ?? null,
     address: row.address || '',
     website: row.website || null,
     lat: row.lat || 0,
@@ -249,6 +251,7 @@ export async function getNearbyPubs(suburb: string, excludeId: number, limit: nu
       suburb: row.suburb,
       price: hhStatus.effectivePrice,
       regularPrice: regularPrice,
+      imageUrl: row.image_url ?? null,
       address: row.address || '',
       website: row.website || null,
       lat: row.lat || 0,

--- a/src/types/pub.ts
+++ b/src/types/pub.ts
@@ -28,4 +28,5 @@ export interface Pub {
   isHappyHourNow: boolean
   happyHourLabel: string | null
   happyHourMinutesRemaining: number | null
+  imageUrl: string | null
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,21 @@ const config: Config = {
   ],
   theme: {
   	extend: {
+  spacing: {
+  			'18': '4.5rem',
+  			'22': '5.5rem',
+  			'26': '6.5rem',
+  			'30': '7.5rem',
+  		},
+  		fontSize: {
+  			'display': ['3rem', { lineHeight: '3.25rem', fontWeight: '700' }],
+  			'title': ['2.25rem', { lineHeight: '2.75rem', fontWeight: '600' }],
+  			'subtitle': ['1.25rem', { lineHeight: '1.75rem', fontWeight: '400' }],
+  			'body-lg': ['1.125rem', { lineHeight: '1.75rem', fontWeight: '400' }],
+  		},
+  		maxWidth: {
+  			'app': '1120px',
+  		},
   		fontFamily: {
   			heading: ['var(--font-space-grotesk)', 'sans-serif'],
   			mono: ['var(--font-jetbrains-mono)', 'monospace'],


### PR DESCRIPTION
## PintDex Rebrand — 3-Phase UI/UX Overhaul

### Phase 1 — CSS & Tailwind Quick Wins
- Extended spacing scale (72–160) for breathing room
- Added responsive font sizes and max-width tokens
- Enhanced transitions (shadow-lift, fade-in)
- Reduced default border-radius from 2xl to xl

### Phase 2 — Component Refactor
- Extracted 9 components from 821-line page.tsx → 374 lines
- New: HeroSection, HowItWorks, FAQ, SocialProof, StatsBar, Footer, PubListView, PubCardsView
- Shared utility: priceColors.ts

### Phase 3 — Feature & Layout Upgrades
- PubCard redesign: 280px image area, floating price badge, minimal text
- Filter bar consolidated to single row (search + suburb + filters dropdown)
- Map toggle (collapsible)
- Pub detail: two-column layout with breadcrumbs
- Discover features always expanded by default
- Ticker styling (larger text, subtle bg)
- Submit modal sizing improvements
- Added image_url support to Pub type and Supabase query