### PR TITLE
V2 card redesign: replace table with cards + map peek

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -14,6 +14,8 @@ import HeroSection from '@/components/HeroSection'
 import { FilterSection } from '@/components/FilterSection'
 import PubListView from '@/components/PubListView'
 import PubCardsView from '@/components/PubCardsView'
+import PubCardList from '@/components/PubCardList'
+import MapPeek from '@/components/MapPeek'
 import PriceTicker from '@/components/PriceTicker'
 import HowItWorks from '@/components/HowItWorks'
 import SocialProof from '@/components/SocialProof'
@@ -24,17 +26,7 @@ import SubmitPubForm from '@/components/SubmitPubForm'
 import CrowdReporter from '@/components/CrowdReporter'
 import NotificationBell from '@/components/NotificationBell'
 
-const Map = dynamic(() => import('@/components/Map'), {
-  ssr: false,
-  loading: () => (
-    <div className="h-[250px] sm:h-[350px] md:h-[450px] bg-stone-100 rounded-xl flex items-center justify-center">
-      <div className="flex flex-col items-center gap-3">
-        <div className="w-12 h-12 border-4 border-stone-300 border-t-stone-600 rounded-full animate-spin"></div>
-        <span className="text-stone-600 font-medium">Loading map...</span>
-      </div>
-    </div>
-  )
-})
+// Map is now loaded via MapPeek component
 
 const INITIAL_PUB_COUNT = 10
 
@@ -78,7 +70,7 @@ function HomeContent() {
   const [userLocation, setUserLocation] = useState<{lat: number, lng: number} | null>(null)
   const [locationState, setLocationState] = useState<'idle' | 'granted' | 'denied' | 'dismissed'>('idle')
   const [scrolledPastHero, setScrolledPastHero] = useState(false)
-  const [showMap, setShowMap] = useState(true)
+  // showMap state removed — now handled by MapPeek component
   const heroRef = useRef<HTMLDivElement>(null)
   const headerRef = useRef<HTMLElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
@@ -321,6 +313,14 @@ function HomeContent() {
       <div ref={contentRef} className="max-w-5xl mx-auto px-4 sm:px-6 pt-6 sm:pt-8 pb-6 sm:pb-8">
         <MyLocals pubs={pubs} userLocation={userLocation} />
 
+        {/* Map peek — hidden by default, toggle to show */}
+        <MapPeek
+          pubs={filteredPubs}
+          userLocation={userLocation}
+          totalPubCount={pubs.length}
+          happyHourCount={stats.happyHourNow}
+        />
+
         <div className="flex items-center justify-between mb-3">
           <p className="text-stone-500 text-sm">
             Displaying <span className="font-semibold text-charcoal">{showAllPubs ? filteredPubs.length : Math.min(INITIAL_PUB_COUNT, filteredPubs.length)}</span> of {filteredPubs.length} venues
@@ -336,8 +336,9 @@ function HomeContent() {
           )}
         </div>
 
+        {/* v2 Card-based listing with smart grouping */}
         {viewMode === 'list' && (
-          <PubListView
+          <PubCardList
             pubs={filteredPubs}
             crowdReports={crowdReports}
             userLocation={userLocation}
@@ -360,25 +361,9 @@ function HomeContent() {
 
         {filteredPubs.length === 0 && (
           <div className="text-center py-16 bg-white rounded-xl shadow-sm">
-            <div className="text-5xl mb-4">{showHappyHourOnly ? '\u{1F37B}' : '\u{1F50D}'}</div>
+            <div className="text-5xl mb-4">{showHappyHourOnly ? '🍻' : '🔍'}</div>
             <h3 className="font-serif text-xl text-charcoal mb-2">{showHappyHourOnly ? 'No pubs with happy hour info yet' : 'No pubs found'}</h3>
-            <p className="text-stone-500 text-sm">{showHappyHourOnly ? 'We\u2019re building our happy hour database \u2014 submit yours!' : 'Try adjusting your filters'}</p>
-          </div>
-        )}
-
-        {/* Map below pub list */}
-        <button
-          onClick={() => setShowMap(!showMap)}
-          className="flex items-center gap-2 text-sm text-stone-500 hover:text-charcoal transition-colors mb-3 mt-6 focus-visible:ring-2 focus-visible:ring-amber/50 focus-visible:ring-offset-1 rounded-lg"
-          aria-pressed={showMap}
-        >
-          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
-          {showMap ? 'Hide map' : 'Show map'}
-        </button>
-
-        {showMap && (
-          <div className="mb-6 rounded-xl overflow-hidden shadow-sm relative z-0 isolate" role="img" aria-label="Interactive map showing pub locations and pint prices across Perth">
-            <Map pubs={filteredPubs} userLocation={userLocation} totalPubCount={pubs.length} />
+            <p className="text-stone-500 text-sm">{showHappyHourOnly ? 'We’re building our happy hour database — submit yours!' : 'Try adjusting your filters'}</p>
           </div>
         )}
       </div>

--- a/src/components/MapPeek.tsx
+++ b/src/components/MapPeek.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useState } from 'react'
+import dynamic from 'next/dynamic'
+import { Pub } from '@/types/pub'
+
+const Map = dynamic(() => import('@/components/Map'), {
+  ssr: false,
+  loading: () => (
+    <div className="h-full bg-stone-100 flex items-center justify-center">
+      <div className="flex flex-col items-center gap-2">
+        <div className="w-8 h-8 border-3 border-stone-300 border-t-stone-500 rounded-full animate-spin" />
+        <span className="text-stone-500 text-xs font-medium">Loading map...</span>
+      </div>
+    </div>
+  )
+})
+
+interface MapPeekProps {
+  pubs: Pub[]
+  userLocation: { lat: number; lng: number } | null
+  totalPubCount: number
+  happyHourCount: number
+}
+
+export default function MapPeek({ pubs, userLocation, totalPubCount, happyHourCount }: MapPeekProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [visible, setVisible] = useState(false)
+
+  if (!visible) {
+    return (
+      <button
+        onClick={() => setVisible(true)}
+        className="flex items-center gap-2 text-sm text-stone-500 hover:text-charcoal transition-colors mb-3 focus-visible:ring-2 focus-visible:ring-amber/50 focus-visible:ring-offset-1 rounded-lg"
+      >
+        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
+        </svg>
+        Show map
+        {happyHourCount > 0 && (
+          <span className="inline-flex items-center gap-1 text-xs font-medium text-emerald-600">
+            <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
+            {happyHourCount} happy hour{happyHourCount !== 1 ? 's' : ''} live
+          </span>
+        )}
+      </button>
+    )
+  }
+
+  return (
+    <div className="mb-4">
+      <div className="flex items-center justify-between mb-2">
+        <button
+          onClick={() => setVisible(false)}
+          className="flex items-center gap-1.5 text-xs text-stone-400 hover:text-charcoal transition-colors"
+        >
+          <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
+          </svg>
+          Hide map
+        </button>
+        {happyHourCount > 0 && (
+          <span className="inline-flex items-center gap-1.5 text-xs font-medium text-emerald-600">
+            <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
+            {happyHourCount} happy hour{happyHourCount !== 1 ? 's' : ''} live
+          </span>
+        )}
+      </div>
+      <div
+        className={`rounded-xl overflow-hidden shadow-sm border border-stone-200/60 relative transition-all duration-400 ease-[cubic-bezier(0.4,0,0.2,1)] ${
+          expanded ? 'h-[320px] sm:h-[360px]' : 'h-[130px] sm:h-[160px]'
+        }`}
+        style={{ isolation: 'isolate' }}
+      >
+        <Map pubs={pubs} userLocation={userLocation} totalPubCount={totalPubCount} />
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="absolute bottom-2 left-1/2 -translate-x-1/2 z-[1000] bg-white border border-stone-200 rounded-full px-3.5 py-1 text-[11px] font-semibold text-stone-500 hover:bg-stone-50 transition-all shadow-md flex items-center gap-1.5"
+        >
+          <svg
+            className={`w-3 h-3 transition-transform duration-300 ${expanded ? 'rotate-180' : ''}`}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+          >
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+          {expanded ? 'Collapse map' : 'Expand map'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/PubCardList.tsx
+++ b/src/components/PubCardList.tsx
@@ -1,0 +1,264 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useRouter } from 'next/navigation'
+import { Pub } from '@/types/pub'
+import { CrowdReport, CROWD_LEVELS } from '@/lib/supabase'
+import { getHappyHourStatus } from '@/lib/happyHour'
+import { getDistanceKm, formatDistance } from '@/lib/location'
+import { getFreshness, formatVerifiedDate } from '@/lib/freshness'
+import WatchlistButton from '@/components/WatchlistButton'
+
+interface PubCardListProps {
+  pubs: Pub[]
+  crowdReports: Record<string, CrowdReport>
+  userLocation: { lat: number; lng: number } | null
+  onCrowdReport: (pub: Pub) => void
+  showAll: boolean
+  initialCount: number
+  onShowAll: () => void
+  onHoverPub?: (pubId: number | null) => void
+}
+
+/** Get price badge color classes based on price tier */
+function getPriceBadgeClasses(price: number | null): string {
+  if (price === null) return 'bg-stone-100 text-stone-400 text-xs'
+  if (price <= 7) return 'bg-emerald-50 text-emerald-700'
+  if (price <= 9) return 'bg-amber-50 text-amber-700'
+  if (price <= 11) return 'bg-orange-50 text-orange-700'
+  return 'bg-red-50 text-red-600'
+}
+
+interface PubGroup {
+  key: string
+  label: string
+  emoji: string
+  pubs: Pub[]
+}
+
+/** Group pubs by happy hour status for smart display */
+function groupPubs(pubs: Pub[]): PubGroup[] {
+  const activeHH: Pub[] = []
+  const soonHH: Pub[] = []
+  const rest: Pub[] = []
+
+  for (const pub of pubs) {
+    const hhStatus = getHappyHourStatus(pub.happyHour)
+    if (hhStatus.isActive) {
+      activeHH.push(pub)
+    } else if (hhStatus.isToday && hhStatus.countdown) {
+      soonHH.push(pub)
+    } else {
+      rest.push(pub)
+    }
+  }
+
+  const groups: PubGroup[] = []
+  if (activeHH.length > 0) {
+    groups.push({ key: 'active', label: 'Happy hour now', emoji: '🟢', pubs: activeHH })
+  }
+  if (soonHH.length > 0) {
+    groups.push({ key: 'soon', label: 'Starting soon', emoji: '⏰', pubs: soonHH })
+  }
+  if (rest.length > 0) {
+    groups.push({ key: 'nearby', label: 'Nearby', emoji: '📍', pubs: rest })
+  }
+  return groups
+}
+
+function PubCard({
+  pub,
+  crowdReport,
+  userLocation,
+  onCrowdReport,
+  onHoverPub,
+}: {
+  pub: Pub
+  crowdReport?: CrowdReport
+  userLocation: { lat: number; lng: number } | null
+  onCrowdReport: (pub: Pub) => void
+  onHoverPub?: (pubId: number | null) => void
+}) {
+  const router = useRouter()
+  const hhStatus = getHappyHourStatus(pub.happyHour)
+  const freshness = getFreshness(pub.lastVerified)
+  const distance = userLocation
+    ? formatDistance(getDistanceKm(userLocation.lat, userLocation.lng, pub.lat, pub.lng))
+    : null
+
+  const priceClasses = getPriceBadgeClasses(pub.price)
+  const isActiveHH = hhStatus.isActive
+
+  return (
+    <div
+      className={`bg-white rounded-[10px] px-3.5 py-3 cursor-pointer transition-all duration-150 border hover:shadow-md hover:border-stone-200 ${
+        isActiveHH ? 'border-l-[3px] border-l-emerald-500 border-t-transparent border-r-transparent border-b-transparent' : 'border-transparent'
+      }`}
+      onClick={() => router.push(`/pub/${pub.slug}`)}
+      onMouseEnter={() => onHoverPub?.(pub.id)}
+      onMouseLeave={() => onHoverPub?.(null)}
+    >
+      {/* Row 1: Name + Price */}
+      <div className="flex items-center justify-between gap-2.5">
+        <div className="flex items-center gap-2 min-w-0 flex-1">
+          <span className="font-semibold text-[15px] text-charcoal truncate leading-tight">
+            {pub.name}
+          </span>
+          <WatchlistButton slug={pub.slug} name={pub.name} suburb={pub.suburb} size="sm" />
+        </div>
+        <span className={`font-mono text-[15px] font-medium whitespace-nowrap px-2 py-0.5 rounded-md ${priceClasses}`}>
+          {pub.price !== null ? `$${pub.price.toFixed(2)}` : 'TBC'}
+        </span>
+      </div>
+
+      {/* Row 2: Meta — suburb · distance · beer */}
+      <div className="flex items-center gap-1.5 mt-1 text-xs text-stone-400 flex-wrap">
+        <span>{pub.suburb}</span>
+        {distance && (
+          <>
+            <span className="text-stone-300">·</span>
+            <span className="inline-flex items-center gap-0.5">
+              <svg className="w-[11px] h-[11px]" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
+              </svg>
+              {distance}
+            </span>
+          </>
+        )}
+        {pub.beerType && (
+          <>
+            <span className="text-stone-300">·</span>
+            <span className="truncate max-w-[180px]">{pub.beerType}</span>
+          </>
+        )}
+      </div>
+
+      {/* Row 3: Happy hour + tags */}
+      <div className="flex items-center justify-between gap-2 mt-1.5">
+        <div className="flex items-center gap-2">
+          {/* Happy hour badge */}
+          {hhStatus.isActive && (
+            <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-emerald-50 text-emerald-700 text-xs font-medium">
+              <span className="w-[6px] h-[6px] rounded-full bg-emerald-500 animate-pulse" />
+              Ends in {hhStatus.countdown?.replace(' left', '')}
+            </span>
+          )}
+          {!hhStatus.isActive && hhStatus.isToday && hhStatus.countdown && (
+            <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-amber-50 text-amber-700 text-xs font-medium">
+              <span className="w-[5px] h-[5px] rounded-full bg-amber" />
+              {hhStatus.countdown} — {pub.happyHour}
+            </span>
+          )}
+        </div>
+
+        {/* Tags: freshness, crowd, vibe */}
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <span className={`inline-flex items-center gap-1 text-[11px] font-medium ${freshness.color}`} title={formatVerifiedDate(pub.lastVerified)}>
+            <span className="text-[10px]">{freshness.icon}</span>
+            {freshness.label}
+          </span>
+          {pub.sunsetSpot && (
+            <span className="text-[11px] text-stone-400">🌅 Sunset</span>
+          )}
+          {pub.vibeTag && (
+            <span className="text-[11px] text-stone-400">{pub.vibeTag}</span>
+          )}
+          {crowdReport && (
+            <span className="text-[11px] text-stone-400" title={`${crowdReport.minutes_ago}m ago`}>
+              {CROWD_LEVELS[crowdReport.crowd_level].emoji} {CROWD_LEVELS[crowdReport.crowd_level].label}
+            </span>
+          )}
+          {!crowdReport && (
+            <button
+              onClick={(e) => { e.stopPropagation(); onCrowdReport(pub) }}
+              className="text-stone-300 hover:text-amber transition-colors"
+              title="Report crowd level"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.5">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128H5.228A2 2 0 013 17.208V4.792a2 2 0 012.228-1.92L15 4.792m0 14.336V4.792" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function PubCardList({
+  pubs,
+  crowdReports,
+  userLocation,
+  onCrowdReport,
+  showAll,
+  initialCount,
+  onShowAll,
+  onHoverPub,
+}: PubCardListProps) {
+  const displayPubs = showAll ? pubs : pubs.slice(0, initialCount)
+  const groups = useMemo(() => groupPubs(displayPubs), [displayPubs])
+
+  // If there are no HH groups (e.g. late night), just show flat list
+  const hasGroups = groups.length > 1 || (groups.length === 1 && groups[0].key !== 'nearby')
+
+  function getLatestCrowdReport(pubId: number): CrowdReport | undefined {
+    return crowdReports[String(pubId)]
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {hasGroups ? (
+        groups.map((group) => (
+          <div key={group.key}>
+            {/* Section divider */}
+            <div className="flex items-center gap-2 pt-3 pb-1">
+              <span className="text-[11px] font-semibold uppercase tracking-wider text-stone-400">
+                {group.emoji} {group.label}
+              </span>
+              <div className="flex-1 h-px bg-stone-200/60" />
+            </div>
+            {/* Pub cards */}
+            <div className="flex flex-col gap-1.5">
+              {group.pubs.map((pub) => (
+                <PubCard
+                  key={pub.id}
+                  pub={pub}
+                  crowdReport={getLatestCrowdReport(pub.id)}
+                  userLocation={userLocation}
+                  onCrowdReport={onCrowdReport}
+                  onHoverPub={onHoverPub}
+                />
+              ))}
+            </div>
+          </div>
+        ))
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {displayPubs.map((pub) => (
+            <PubCard
+              key={pub.id}
+              pub={pub}
+              crowdReport={getLatestCrowdReport(pub.id)}
+              userLocation={userLocation}
+              onCrowdReport={onCrowdReport}
+              onHoverPub={onHoverPub}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Show all button */}
+      {!showAll && pubs.length > initialCount && (
+        <button
+          onClick={onShowAll}
+          className="w-full py-3.5 text-sm font-semibold text-charcoal hover:text-amber hover:bg-cream/50 transition-all flex items-center justify-center gap-2 bg-white rounded-[10px] mt-1"
+        >
+          View all {pubs.length} venues
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+          </svg>
+        </button>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Replaces the table-based pub listing on the homepage with a card-based layout and adds a collapsible map peek component.

### New components
- **PubCardList** — compact card layout with smart happy hour grouping (Active Now / Starting Soon / Nearby), 4-tier price color coding, inline HH countdown badges, freshness indicators, and crowd reporting
- - **MapPeek** — collapsible map strip hidden by default with "Show map" toggle, expand/collapse between 130px and 320px, live happy hour count badge
### Changes to HomeClient
- Imports and wires up PubCardList and MapPeek
- - MapPeek placed above the listing (below filters)
- - PubCardList replaces PubListView as the default list view
- - Removed old showMap state (now handled by MapPeek internally)
### Design decisions
- Mobile-first: cards are ~65px tall so 5-6 fit on screen vs ~3 with old table rows
- - Map hidden by default to keep homepage fast and focused
- - Smart grouping only appears when there are active/upcoming happy hours
- - 4-tier price badges: green (<=7), amber (<=9), orange (<=11), red (>11)