### PR TITLE
Remove all em dashes (—) from codebase - AI signal cleanup

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -59,10 +59,10 @@ function HomeContent() {
   const [showAllPubs, setShowAllPubs] = useState(false)
   const [userLocation, setUserLocation] = useState<{lat: number, lng: number} | null>(null)
   const [locationState, setLocationState] = useState<'idle' | 'granted' | 'denied' | 'dismissed'>('idle')
-  const [nearbyRadius, setNearbyRadius] = useState<number>(5) // km — 1, 3, 5, or 0 = all
+  const [nearbyRadius, setNearbyRadius] = useState<number>(5) // km - 1, 3, 5, or 0 = all
   const [beerTypeFilter, setBeerTypeFilter] = useState<string>('')
   const [scrolledPastHero, setScrolledPastHero] = useState(false)
-  // showMap state removed — now handled by MapPeek component
+  // showMap state removed - now handled by MapPeek component
   const heroRef = useRef<HTMLDivElement>(null)
   const headerRef = useRef<HTMLElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
@@ -72,7 +72,7 @@ function HomeContent() {
   const [kidFriendlyOnly, setKidFriendlyOnly] = useState(searchParams.get('kids') === '1')
   const [hasTabOnly, setHasTabOnly] = useState(searchParams.get('tab') === '1')
 
-  // P2a: URL sync — update URL params on filter change
+  // P2a: URL sync - update URL params on filter change
   const updateUrlParams = useCallback(() => {
     const params = new URLSearchParams()
     if (searchTerm) params.set('q', searchTerm)
@@ -146,7 +146,7 @@ function HomeContent() {
     }
   }
 
-  // Unified nav: expand when scrolled past hero (LATCHES — never collapses back)
+  // Unified nav: expand when scrolled past hero (LATCHES - never collapses back)
   useEffect(() => {
     const handleScroll = () => {
       if (heroRef.current && !scrolledPastHero) {
@@ -267,7 +267,7 @@ function HomeContent() {
 
   return (
     <main className="min-h-screen bg-white">
-      {/* ═══ HEADER — minimal monospace with pill CTA ═══ */}
+      {/* ═══ HEADER - minimal monospace with pill CTA ═══ */}
       <header ref={headerRef} className="max-w-container mx-auto px-6 py-6 flex items-center justify-between">
         <Link href="/" className="flex items-center gap-2 no-underline">
           <div className="w-7 h-7 bg-amber border-2 border-ink rounded-md flex items-center justify-center text-sm shadow-[2px_2px_0_#171717]">
@@ -299,7 +299,7 @@ function HomeContent() {
         </button>
       </header>
 
-      {/* ═══ HERO — beer glass, dots, stat strip ═══ */}
+      {/* ═══ HERO - beer glass, dots, stat strip ═══ */}
       <div ref={heroRef}>
         <HeroSection pubs={pubs} />
       </div>
@@ -326,7 +326,7 @@ function HomeContent() {
         )
       })()}
 
-      {/* ═══ FILTER BAR — below header, above content ═══ */}
+      {/* ═══ FILTER BAR - below header, above content ═══ */}
       <FilterSection
         viewMode={viewMode}
         setViewMode={setViewMode}

--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -11,7 +11,7 @@ export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
 // ============================================================
-// RATE LIMITING — In-memory store (resets on cold start, fine for serverless)
+// RATE LIMITING - In-memory store (resets on cold start, fine for serverless)
 // Blocks an IP after 5 failed attempts for 15 minutes
 // ============================================================
 interface RateLimitEntry {

--- a/src/app/api/pint-of-the-day/route.ts
+++ b/src/app/api/pint-of-the-day/route.ts
@@ -15,7 +15,7 @@ const supabase = createClient(
  * 3. Score pubs based on: price (lower = better), happy hour active, variety (different suburb each day)
  * 4. Pick the top scorer as Pint of the Day
  * 
- * The algorithm is deterministic — same date always returns same pub.
+ * The algorithm is deterministic - same date always returns same pub.
  * This lets us cache aggressively and ensures consistency across users.
  */
 export async function GET() {

--- a/src/app/api/push/send/route.ts
+++ b/src/app/api/push/send/route.ts
@@ -10,7 +10,7 @@ const supabase = createClient(
 /**
  * POST /api/push/send
  * Send push notifications to subscribers.
- * Protected by PUSH_API_SECRET — only callable by the scraper trigger.
+ * Protected by PUSH_API_SECRET - only callable by the scraper trigger.
  *
  * Body: {
  *   title: string,

--- a/src/app/discover/DiscoverClient.tsx
+++ b/src/app/discover/DiscoverClient.tsx
@@ -466,7 +466,7 @@ export default function DiscoverClient() {
               <p className="text-sm text-[#888] mb-4">Starting soon near you</p>
               <div className="space-y-1">
                 {upcomingHappyHours.length === 0 && (
-                  <p className="text-sm text-[#888] py-4 text-center">No happy hours active or upcoming right now — check back later!</p>
+                  <p className="text-sm text-[#888] py-4 text-center">No happy hours active or upcoming right now. Check back later!</p>
                 )}
                 {upcomingHappyHours.map(({ pub, status }) => (
                   <Link key={pub.id} href={`/pub/${pub.slug}`} className="flex items-center justify-between p-2.5 rounded-lg hover:bg-[#FAFAFA] hover:border-l-2 hover:border-l-[#E8740C] transition-all group">
@@ -544,7 +544,7 @@ export default function DiscoverClient() {
                       <div className="flex items-baseline gap-2 mt-0.5">
                         <span className="text-2xl sm:text-3xl font-bold text-[#1A1A1A] tabular-nums">${pintIndex.current.avg_price.toFixed(2)}</span>
                         <span className={`text-sm font-semibold ${pintIndex.monthChange > 0 ? 'text-[#5C4A3A]' : 'text-ink'}`}>
-                          {pintIndex.monthChange > 0 ? '▲' : pintIndex.monthChange < 0 ? '▼' : '—'}{' '}
+                          {pintIndex.monthChange > 0 ? '▲' : pintIndex.monthChange < 0 ? '▼' : '-'}{' '}
                           {pintIndex.monthChange >= 0 ? '+' : ''}{pintIndex.monthChange.toFixed(2)} ({pintIndex.monthPct >= 0 ? '+' : ''}{pintIndex.monthPct.toFixed(1)}%)
                         </span>
                       </div>

--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -3,13 +3,13 @@ import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 import DiscoverClient from './DiscoverClient'
 
 export const metadata: Metadata = {
-  title: 'Discover — Perth Pint Guides, Stats & Pub Picks | Arvo',
+  title: 'Discover: Perth Pint Guides, Stats & Pub Picks | Arvo',
   description: 'Live pint data, suburb rankings, sunset spots, dad bars, and more. Everything beyond the price table.',
   alternates: {
     canonical: 'https://perthpintprices.com/discover',
   },
   openGraph: {
-    title: 'Discover — Perth Pint Guides, Stats & Pub Picks | Arvo',
+    title: 'Discover: Perth Pint Guides, Stats & Pub Picks | Arvo',
     description: 'Live pint data, suburb rankings, sunset spots, dad bars, and more.',
     url: 'https://perthpintprices.com/discover',
     siteName: 'Arvo',
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
         url: 'https://perthpintprices.com/og-image.png',
         width: 1200,
         height: 630,
-        alt: "Discover Perth's best pints — guides, stats & pub picks",
+        alt: "Discover Perth's best pints. Guides, stats & pub picks",
       },
     ],
   },

--- a/src/app/guides/beer-weather/page.tsx
+++ b/src/app/guides/beer-weather/page.tsx
@@ -3,11 +3,11 @@ import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 import BeerWeatherPage from './BeerWeatherPage'
 
 export const metadata: Metadata = {
-  title: "Beer Weather Perth — Weather-Matched Pub Picks | Arvo",
+  title: "Beer Weather Perth: Weather-Matched Pub Picks | Arvo",
   description: "What's the weather saying about your next pint? Get real-time Perth weather matched to the perfect pub. Scorcher? Hit a beer garden. Rainy? Find a cozy corner.",
   alternates: { canonical: 'https://perthpintprices.com/guides/beer-weather' },
   openGraph: {
-    title: "Beer Weather Perth — Weather-Matched Pub Picks | Arvo",
+    title: "Beer Weather Perth: Weather-Matched Pub Picks | Arvo",
     description: "Real-time Perth weather matched to the perfect pub pick.",
     url: 'https://perthpintprices.com/guides/beer-weather',
     type: 'website',

--- a/src/app/guides/cozy-corners/page.tsx
+++ b/src/app/guides/cozy-corners/page.tsx
@@ -3,11 +3,11 @@ import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 import CozyCornersPage from './CozyCornersPage'
 
 export const metadata: Metadata = {
-  title: "Cozy Corners Perth — Best Rainy Day Pubs | Arvo",
+  title: "Cozy Corners Perth: Best Rainy Day Pubs | Arvo",
   description: "When Perth's weather turns, these cozy pubs have you covered. Find warm, sheltered venues with fireplaces, covered areas, and comfort food.",
   alternates: { canonical: 'https://perthpintprices.com/guides/cozy-corners' },
   openGraph: {
-    title: "Cozy Corners Perth — Best Rainy Day Pubs | Arvo",
+    title: "Cozy Corners Perth: Best Rainy Day Pubs | Arvo",
     description: "Perth's cosiest pubs for rainy days. Warm, sheltered, and perfect for a pint.",
     url: 'https://perthpintprices.com/guides/cozy-corners',
     type: 'website',

--- a/src/app/guides/dad-bar/page.tsx
+++ b/src/app/guides/dad-bar/page.tsx
@@ -3,11 +3,11 @@ import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 import DadBarPage from './DadBarPage'
 
 export const metadata: Metadata = {
-  title: "The Dad Bar — Classic Perth Pubs for Dads | Arvo",
+  title: "The Dad Bar: Classic Perth Pubs for Dads | Arvo",
   description: "No craft cocktails, no pretentious menus. Just honest Perth pubs where dads can enjoy a cold pint in peace. Kid-friendly spots included.",
   alternates: { canonical: 'https://perthpintprices.com/guides/dad-bar' },
   openGraph: {
-    title: "The Dad Bar — Classic Perth Pubs for Dads | Arvo",
+    title: "The Dad Bar: Classic Perth Pubs for Dads | Arvo",
     description: "Honest Perth pubs where dads can enjoy a cold pint in peace.",
     url: 'https://perthpintprices.com/guides/dad-bar',
     type: 'website',

--- a/src/app/guides/layout.tsx
+++ b/src/app/guides/layout.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Guides — Curated Perth Pub Picks for Every Occasion | Arvo',
+  title: 'Guides: Curated Perth Pub Picks for Every Occasion | Arvo',
   description: "Perth's best pub guides: beer weather picks, sunset spots, dad-friendly pubs, TAB venues, rainy day refuges, and more. Curated for every occasion.",
   alternates: { canonical: 'https://perthpintprices.com/guides' },
   openGraph: {

--- a/src/app/guides/punt-and-pints/page.tsx
+++ b/src/app/guides/punt-and-pints/page.tsx
@@ -3,11 +3,11 @@ import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 import PuntAndPintsPage from './PuntAndPintsPage'
 
 export const metadata: Metadata = {
-  title: "Punt & Pints — Perth Pubs with TAB Facilities | Arvo",
+  title: "Punt & Pints: Perth Pubs with TAB Facilities | Arvo",
   description: "Find Perth pubs with TAB facilities. Watch the races, place a bet, and enjoy a cold pint. All the TAB-equipped venues in Perth with verified prices.",
   alternates: { canonical: 'https://perthpintprices.com/guides/punt-and-pints' },
   openGraph: {
-    title: "Punt & Pints — Perth Pubs with TAB | Arvo",
+    title: "Punt & Pints: Perth Pubs with TAB | Arvo",
     description: "Perth pubs with TAB facilities. Watch the races with a cold pint.",
     url: 'https://perthpintprices.com/guides/punt-and-pints',
     type: 'website',

--- a/src/app/guides/sunset-sippers/page.tsx
+++ b/src/app/guides/sunset-sippers/page.tsx
@@ -3,11 +3,11 @@ import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 import SunsetSippersPage from './SunsetSippersPage'
 
 export const metadata: Metadata = {
-  title: "Sunset Sippers Perth — Best Golden Hour Pubs | Arvo",
+  title: "Sunset Sippers Perth: Best Golden Hour Pubs | Arvo",
   description: "Find Perth's best sunset pubs. Watch the sun go down with a cold pint at venues with west-facing views, beer gardens, and rooftop bars.",
   alternates: { canonical: 'https://perthpintprices.com/guides/sunset-sippers' },
   openGraph: {
-    title: "Sunset Sippers Perth — Best Golden Hour Pubs | Arvo",
+    title: "Sunset Sippers Perth: Best Golden Hour Pubs | Arvo",
     description: "Perth's best sunset pubs with west-facing views and beer gardens.",
     url: 'https://perthpintprices.com/guides/sunset-sippers',
     type: 'website',

--- a/src/app/happy-hour/HappyHourClient.tsx
+++ b/src/app/happy-hour/HappyHourClient.tsx
@@ -154,7 +154,7 @@ export default function HappyHourClient() {
               No happy hours right now
             </h2>
             <p className="text-gray-mid text-sm mb-6 max-w-md mx-auto leading-relaxed">
-              Check back during the week — most kick off between 4-6pm.
+              Check back during the week. Most kick off between 4-6pm.
               We&apos;ll show live deals as soon as they start.
             </p>
             <Link

--- a/src/app/happy-hour/page.tsx
+++ b/src/app/happy-hour/page.tsx
@@ -3,7 +3,7 @@ import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 import HappyHourClient from './HappyHourClient'
 
 export const metadata: Metadata = {
-  title: 'Happy Hours Live Now in Perth — Cheapest Pints Right Now | Arvo',
+  title: 'Happy Hours Live Now in Perth: Cheapest Pints Right Now | Arvo',
   description:
     'See which Perth pubs have happy hour deals running right now. Live countdown timers, savings calculations, and the cheapest pints available today.',
   alternates: { canonical: 'https://perthpintprices.com/happy-hour' },

--- a/src/app/insights/layout.tsx
+++ b/src/app/insights/layout.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next'
 import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 
 export const metadata: Metadata = {
-  title: 'Insights — Perth Pint Price Data & Market Trends | Arvo',
+  title: 'Insights: Perth Pint Price Data & Market Trends | Arvo',
   description: 'Live Perth pint price index, suburb rankings, venue analysis, and beer market trends. Track how beer prices change across 300+ venues.',
   alternates: { canonical: 'https://perthpintprices.com/insights' },
   openGraph: {

--- a/src/app/insights/pint-index/page.tsx
+++ b/src/app/insights/pint-index/page.tsx
@@ -3,11 +3,11 @@ import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 import PintIndexPage from './PintIndexPage'
 
 export const metadata: Metadata = {
-  title: "Perth Pint Index™ — Live Beer Price Tracker | Arvo",
+  title: "Perth Pint Index™: Live Beer Price Tracker | Arvo",
   description: "Track Perth's average pint price over time. The Perth Pint Index™ monitors beer pricing trends across 300+ venues with weekly snapshots.",
   alternates: { canonical: 'https://perthpintprices.com/insights/pint-index' },
   openGraph: {
-    title: "Perth Pint Index™ — Live Beer Price Tracker | Arvo",
+    title: "Perth Pint Index™: Live Beer Price Tracker | Arvo",
     description: "Track Perth's average pint price over time across 300+ venues.",
     url: 'https://perthpintprices.com/insights/pint-index',
     type: 'website',

--- a/src/app/insights/pint-of-the-day/page.tsx
+++ b/src/app/insights/pint-of-the-day/page.tsx
@@ -3,7 +3,7 @@ import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 import PintOfTheDayPage from './PintOfTheDayPage'
 
 export const metadata: Metadata = {
-  title: "Perth Pint of the Day — Today's Best Value Beer | Arvo",
+  title: "Perth Pint of the Day: Today's Best Value Beer | Arvo",
   description: "Today's best value pint in Perth, algorithmically picked from 300+ venues. Updated daily with verified prices from real pub-goers.",
   alternates: { canonical: 'https://perthpintprices.com/insights/pint-of-the-day' },
   openGraph: {

--- a/src/app/insights/suburb-rankings/page.tsx
+++ b/src/app/insights/suburb-rankings/page.tsx
@@ -3,7 +3,7 @@ import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 import SuburbRankingsPage from './SuburbRankingsPage'
 
 export const metadata: Metadata = {
-  title: "Perth Suburb Pint Price Rankings — Cheapest Suburbs for Beer | Arvo",
+  title: "Perth Suburb Pint Price Rankings: Cheapest Suburbs for Beer | Arvo",
   description: "Compare pint prices across every Perth suburb. Find the cheapest suburbs for a beer, from Fremantle to Joondalup. Ranked by average pint price.",
   alternates: { canonical: 'https://perthpintprices.com/insights/suburb-rankings' },
   openGraph: {

--- a/src/app/insights/tonights-best-bets/page.tsx
+++ b/src/app/insights/tonights-best-bets/page.tsx
@@ -3,7 +3,7 @@ import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 import TonightsBestBetsPage from './TonightsBestBetsPage'
 
 export const metadata: Metadata = {
-  title: "Tonight's Best Pints in Perth — Where to Drink Now | Arvo",
+  title: "Tonight's Best Pints in Perth: Where to Drink Now | Arvo",
   description: "Find the cheapest pints in Perth right now. Live happy hour deals, tonight's best bets, and where to get the most value on your next round.",
   alternates: { canonical: 'https://perthpintprices.com/insights/tonights-best-bets' },
   openGraph: {

--- a/src/app/insights/venue-breakdown/page.tsx
+++ b/src/app/insights/venue-breakdown/page.tsx
@@ -3,7 +3,7 @@ import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 import VenueBreakdownPage from './VenueBreakdownPage'
 
 export const metadata: Metadata = {
-  title: "Perth Pub Price Analysis — Venue Breakdown by Price Bracket | Arvo",
+  title: "Perth Pub Price Analysis: Venue Breakdown by Price Bracket | Arvo",
   description: "Deep dive into Perth's pub pricing. See how venues stack up across price brackets, find undervalued gems, and spot overpriced outliers.",
   alternates: { canonical: 'https://perthpintprices.com/insights/venue-breakdown' },
   openGraph: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata(): Promise<Metadata> {
       icon: '/favicon.ico',
       apple: '/apple-touch-icon.png',
     },
-    title: "Arvo — Perth's pint prices, sorted.",
+    title: "Arvo | Perth's pint prices, sorted.",
     description: desc,
     keywords: 'Perth, pint prices, beer, pubs, happy hour, Western Australia, cheap drinks, Arvo',
     openGraph: {
@@ -37,10 +37,10 @@ export async function generateMetadata(): Promise<Metadata> {
           url: '/og-image.png',
           width: 1200,
           height: 630,
-          alt: "Arvo — Perth's pint prices, sorted",
+          alt: "Arvo | Perth's pint prices, sorted",
         },
       ],
-      title: "Arvo — Perth's pint prices, sorted.",
+      title: "Arvo | Perth's pint prices, sorted.",
       description: ogDesc,
       url: 'https://perthpintprices.com',
       siteName: 'Arvo',
@@ -49,8 +49,8 @@ export async function generateMetadata(): Promise<Metadata> {
     },
     twitter: {
       card: 'summary_large_image',
-      title: "Arvo — Perth's pint prices, sorted.",
-      description: `Perth's pint prices, sorted. ${stats.venueCount}+ venues — find cheap pints near you.`,
+      title: "Arvo | Perth's pint prices, sorted.",
+      description: `Perth's pint prices, sorted. ${stats.venueCount}+ venues. Find cheap pints near you.`,
     },
   }
 }

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -3,11 +3,11 @@ import LeaderboardClient from './LeaderboardClient'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: "Price Scout Leaderboard — Top Perth Pint Reporters | Arvo",
+  title: "Price Scout Leaderboard: Top Perth Pint Reporters | Arvo",
   description: "Perth's top price reporters helping keep Arvo accurate. Report pint prices to climb the leaderboard and earn bragging rights!",
   alternates: { canonical: 'https://perthpintprices.com/leaderboard' },
   openGraph: {
-    title: "Price Scout Leaderboard — Top Perth Pint Reporters | Arvo",
+    title: "Price Scout Leaderboard: Top Perth Pint Reporters | Arvo",
     description: "Perth's top price reporters helping keep Arvo accurate. Report pint prices to climb the leaderboard!",
     url: 'https://perthpintprices.com/leaderboard',
     type: 'website',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import { getSiteStats } from '@/lib/supabase'
 
 export async function generateMetadata(): Promise<Metadata> {
   const stats = await getSiteStats()
-  const title = "Arvo — Perth's pint prices, sorted."
+  const title = "Arvo | Perth's pint prices, sorted."
   const description = `Perth's pint prices, sorted. Real prices from real people across ${stats.venueCount}+ venues and ${stats.suburbCount} suburbs.`
 
   return {
@@ -25,14 +25,14 @@ export async function generateMetadata(): Promise<Metadata> {
           url: 'https://perthpintprices.com/og-image.png',
           width: 1200,
           height: 630,
-          alt: "Arvo — Perth's pint prices, sorted",
+          alt: "Arvo | Perth's pint prices, sorted",
         },
       ],
     },
     twitter: {
       card: 'summary_large_image',
       title,
-      description: `Perth's pint prices, sorted. ${stats.venueCount}+ venues — find cheap pints near you.`,
+      description: `Perth's pint prices, sorted. ${stats.venueCount}+ venues. Find cheap pints near you.`,
     },
   }
 }

--- a/src/app/pint-crawl/PintCrawlClient.tsx
+++ b/src/app/pint-crawl/PintCrawlClient.tsx
@@ -381,15 +381,15 @@ export default function PintCrawlClient({ pubs }: { pubs: Pub[] }) {
     if (typeof navigator !== 'undefined' && navigator.share) {
       try {
         await navigator.share({
-          title: `Arvo Pint Crawl — ${route.length} stops`,
-          text: `Check out this pub crawl: ${route.map(s => s.pub.name).join(' → ')} — $${totalCost.toFixed(2)} total`,
+          title: `Arvo Pint Crawl: ${route.length} stops`,
+          text: `Check out this pub crawl: ${route.map(s => s.pub.name).join(' → ')} - $${totalCost.toFixed(2)} total`,
           url,
         })
         setShared(true)
         setTimeout(() => setShared(false), 2000)
         return
       } catch {
-        // User cancelled or API failed — fall through to clipboard
+        // User cancelled or API failed - fall through to clipboard
       }
     }
     // Fallback: copy link to clipboard
@@ -937,7 +937,7 @@ export default function PintCrawlClient({ pubs }: { pubs: Pub[] }) {
                   className="w-full bg-ink text-white mono font-bold text-base rounded-2xl py-4 hover:bg-ink/90 transition-colors"
                 >
                   {currentStop < route.length - 1
-                    ? <><CircleCheck className="w-3.5 h-3.5 inline" /> Done — Next Stop</>
+                    ? <><CircleCheck className="w-3.5 h-3.5 inline" /> Done. Next Stop</>
                     : <><Flag className="w-3.5 h-3.5 inline" /> Finish Crawl!</>}
                 </button>
 

--- a/src/app/pint-crawl/page.tsx
+++ b/src/app/pint-crawl/page.tsx
@@ -5,11 +5,11 @@ import PintCrawlClient from './PintCrawlClient'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: "Pint Crawl Perth — Plan Your Perfect Pub Crawl | Arvo",
+  title: "Pint Crawl Perth: Plan Your Perfect Pub Crawl | Arvo",
   description: "Plan the perfect pub crawl in Perth. Set your budget, pick your stops, and get an optimized walking route with real pint prices from 300+ venues.",
   alternates: { canonical: 'https://perthpintprices.com/pint-crawl' },
   openGraph: {
-    title: "Pint Crawl Perth — Plan Your Route | Arvo",
+    title: "Pint Crawl Perth: Plan Your Route | Arvo",
     description: "Plan your perfect Perth pub crawl with budget-aware route planning.",
     url: 'https://perthpintprices.com/pint-crawl',
     type: 'website',

--- a/src/app/pub-golf/PubGolfClient.tsx
+++ b/src/app/pub-golf/PubGolfClient.tsx
@@ -290,7 +290,7 @@ export default function PubGolfClient({ pubs }: { pubs: Pub[] }) {
   const shareText = useMemo(() => {
     if (!winner) return ''
     const lines = [
-      `⛳ Arvo Pub Golf — ${courseName}`,
+      `⛳ Arvo Pub Golf: ${courseName}`,
       '',
       `🏆 ${winner.name} wins!`,
       '',

--- a/src/app/pub-golf/page.tsx
+++ b/src/app/pub-golf/page.tsx
@@ -4,11 +4,11 @@ import PubGolfClient from './PubGolfClient'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: "Pub Golf Perth — Score Your Pub Crawl | Arvo",
+  title: "Pub Golf Perth: Score Your Pub Crawl | Arvo",
   description: "Play pub golf across Perth's best pubs. Pick a course, track your scores, and see how much your round costs. Real prices from 300+ Perth venues.",
   alternates: { canonical: 'https://perthpintprices.com/pub-golf' },
   openGraph: {
-    title: "Pub Golf Perth — Score Your Crawl | Arvo",
+    title: "Pub Golf Perth: Score Your Crawl | Arvo",
     description: "Play pub golf across Perth's best pubs with real pint prices.",
     url: 'https://perthpintprices.com/pub-golf',
     type: 'website',

--- a/src/app/pub/[slug]/PubDetailClient.tsx
+++ b/src/app/pub/[slug]/PubDetailClient.tsx
@@ -234,7 +234,7 @@ export default function PubDetailClient({ pub, nearbyPubs, avgPrice }: PubDetail
             </div>
           </div>
 
-          {/* Right column — map */}
+          {/* Right column - map */}
           <div className="md:sticky md:top-20 rounded-card overflow-hidden h-[350px] border-3 border-ink shadow-hard">
             <PubDetailMap lat={pub.lat} lng={pub.lng} name={pub.name} price={pub.price} />
           </div>

--- a/src/app/pub/[slug]/page.tsx
+++ b/src/app/pub/[slug]/page.tsx
@@ -9,10 +9,10 @@ interface PageProps {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const pub = await getPubBySlug(params.slug)
-  if (!pub) return { title: 'Pub Not Found — Arvo' }
+  if (!pub) return { title: 'Pub Not Found | Arvo' }
   
   const priceText = pub.price !== null ? `$${pub.price.toFixed(2)} pints` : 'Price TBC'
-  const title = `${pub.name}, ${pub.suburb} — ${priceText} | Arvo`
+  const title = `${pub.name}, ${pub.suburb}: ${priceText} | Arvo`
   const description = `${priceText} at ${pub.name} in ${pub.suburb}, Perth WA.${pub.happyHour ? ` Happy Hour: ${pub.happyHour}.` : ''} ${pub.beerType ? `Serving ${pub.beerType}.` : ''} Find the best pint prices on Arvo.`
   
   return {
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     description,
     alternates: { canonical: `https://perthpintprices.com/pub/${params.slug}` },
     openGraph: {
-      title: `${pub.name} — ${priceText}`,
+      title: `${pub.name}: ${priceText}`,
       description,
       url: `https://perthpintprices.com/pub/${params.slug}`,
       siteName: 'Arvo',
@@ -29,7 +29,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary',
-      title: `${pub.name} — ${priceText}`,
+      title: `${pub.name}: ${priceText}`,
       description,
     },
   }

--- a/src/app/suburb/[slug]/SuburbClient.tsx
+++ b/src/app/suburb/[slug]/SuburbClient.tsx
@@ -98,7 +98,7 @@ export default function SuburbClient({ suburb, pubs, nearbySuburbs, perthAvgPric
       <section className="max-w-container mx-auto px-6 pb-6">
         <div className="border-3 border-ink rounded-card shadow-hard overflow-hidden">
           <div className="px-4 py-3 border-b border-gray-light">
-            <h2 className="font-mono font-extrabold text-[0.85rem] text-ink uppercase tracking-[0.05em]">All Venues — Cheapest First</h2>
+            <h2 className="font-mono font-extrabold text-[0.85rem] text-ink uppercase tracking-[0.05em]">All Venues - Cheapest First</h2>
           </div>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
@@ -145,7 +145,7 @@ export default function SuburbClient({ suburb, pubs, nearbySuburbs, perthAvgPric
                         {pub.happyHour ? (
                           <span className="text-[0.7rem] text-red font-bold">{pub.happyHour}</span>
                         ) : (
-                          <span className="text-[0.7rem] text-gray-mid">—</span>
+                          <span className="text-[0.7rem] text-gray-mid">-</span>
                         )}
                       </td>
                     </tr>

--- a/src/app/suburb/[slug]/page.tsx
+++ b/src/app/suburb/[slug]/page.tsx
@@ -14,12 +14,12 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const suburb = await getSuburbBySlug(params.slug)
-  if (!suburb) return { title: 'Suburb Not Found — Arvo' }
+  if (!suburb) return { title: 'Suburb Not Found | Arvo' }
 
   const priceText = suburb.cheapestPrice !== 'TBC'
     ? `${suburb.pubCount} Pubs from $${suburb.cheapestPrice}`
     : `${suburb.pubCount} Pubs`
-  const title = `Cheapest Pints in ${suburb.name} — ${priceText} | Arvo`
+  const title = `Cheapest Pints in ${suburb.name}: ${priceText} | Arvo`
 
   const descParts = [`Compare pint prices across ${suburb.pubCount} pubs in ${suburb.name}, Perth.`]
   if (suburb.cheapestPrice !== 'TBC') {

--- a/src/app/weekly-report/WeeklyReportClient.tsx
+++ b/src/app/weekly-report/WeeklyReportClient.tsx
@@ -93,7 +93,7 @@ export default function WeeklyClient() {
           <p className="text-stone-400 text-sm mt-1">Week of {weekLabel}</p>
         </div>
 
-        {/* Big Number — Average Price */}
+        {/* Big Number - Average Price */}
         <div className="border-3 border-ink rounded-card shadow-hard-sm p-5 bg-white">
           <p className="font-mono text-xs text-stone-400 uppercase mb-1">Average Pint Price</p>
           <div className="flex items-baseline gap-3">

--- a/src/app/weekly-report/page.tsx
+++ b/src/app/weekly-report/page.tsx
@@ -4,11 +4,11 @@ import WeeklyClient from './WeeklyReportClient'
 
 export const metadata: Metadata = {
   title: 'This Week in Perth Pints | Arvo',
-  description: 'Weekly roundup of Perth beer prices — price movements, cheapest pints, and trending venues.',
+  description: 'Weekly roundup of Perth beer prices. Price movements, cheapest pints, and trending venues.',
   alternates: { canonical: 'https://perthpintprices.com/weekly' },
   openGraph: {
     title: 'This Week in Perth Pints | Arvo',
-    description: 'Weekly roundup of Perth beer prices — drops, deals, and trends.',
+    description: 'Weekly roundup of Perth beer prices. Drops, deals, and trends.',
     url: 'https://perthpintprices.com/weekly',
     type: 'website',
     siteName: 'Arvo',

--- a/src/components/BeerWeather.tsx
+++ b/src/components/BeerWeather.tsx
@@ -64,7 +64,7 @@ function getWeatherCondition(weather: WeatherData, avgPrice: number): WeatherCon
       emoji: 'cloud-rain',
       label: 'Rainy day',
       message: "Rainy day? Cozy up inside with a cold one",
-      tagline: `${weather.temperature.toFixed(0)}° and wet — perfect happy hour weather`,
+      tagline: `${weather.temperature.toFixed(0)}° and wet. Perfect happy hour weather`,
       bgClass: 'bg-gradient-to-r from-slate-50 via-blue-50 to-slate-50',
       borderClass: 'border-blue-200',
       filter: (pubs) => pubs.filter(p => p.happyHour).filter(p => p.price !== null).sort((a, b) => a.price! - b.price!),
@@ -76,7 +76,7 @@ function getWeatherCondition(weather: WeatherData, avgPrice: number): WeatherCon
       emoji: 'flame',
       label: 'Scorcher',
       message: "Scorcher! Head to the beach pubs for a cold one",
-      tagline: `${weather.temperature.toFixed(0)}° scorcher — just point me to the coldest pint`,
+      tagline: `${weather.temperature.toFixed(0)}° scorcher. Just point me to the coldest pint`,
       bgClass: 'bg-gradient-to-r from-red-50 via-orange-50 to-orange-50',
       borderClass: 'border-red-200',
       filter: (pubs) => pubs.filter(p => p.sunsetSpot).filter(p => p.price !== null).sort((a, b) => a.price! - b.price!),
@@ -87,8 +87,8 @@ function getWeatherCondition(weather: WeatherData, avgPrice: number): WeatherCon
     return {
       emoji: 'sun',
       label: 'Perfect weather',
-      message: "Mint conditions — get outside and grab a pint!",
-      tagline: `${weather.temperature.toFixed(0)}° and sunny — get outside and grab a cold one`,
+      message: "Mint conditions. Get outside and grab a pint!",
+      tagline: `${weather.temperature.toFixed(0)}° and sunny. Get outside and grab a cold one`,
       bgClass: 'bg-gradient-to-r from-orange-50/70 via-yellow-50/50 to-orange-50/70',
       borderClass: 'border-orange-200',
       filter: (pubs) => pubs.filter(p => p.sunsetSpot || p.description?.toLowerCase().includes('garden')).filter(p => p.price !== null).sort((a, b) => a.price! - b.price!),
@@ -99,8 +99,8 @@ function getWeatherCondition(weather: WeatherData, avgPrice: number): WeatherCon
     return {
       emoji: 'cloud-sun',
       label: 'Great pub weather',
-      message: "Great pub weather — grab a mate and a pint",
-      tagline: `${weather.temperature.toFixed(0)}° with a breeze — grab a mate and a cold one`,
+      message: "Great pub weather. Grab a mate and a pint",
+      tagline: `${weather.temperature.toFixed(0)}° with a breeze. Grab a mate and a cold one`,
       bgClass: 'bg-gradient-to-r from-stone-50 via-orange-50/30 to-stone-50',
       borderClass: 'border-stone-200',
       filter: (pubs) => [...pubs].filter(p => p.price !== null).sort((a, b) => a.price! - b.price!),
@@ -112,7 +112,7 @@ function getWeatherCondition(weather: WeatherData, avgPrice: number): WeatherCon
     emoji: 'snowflake',
     label: 'Chilly',
     message: "Chilly! Warm up with a pint at a cozy pub",
-    tagline: `${weather.temperature.toFixed(0)}° and chilly — rug up and find a cozy corner`,
+    tagline: `${weather.temperature.toFixed(0)}° and chilly. Rug up and find a cozy corner`,
     bgClass: 'bg-gradient-to-r from-blue-50 via-indigo-50/30 to-blue-50',
     borderClass: 'border-blue-200',
     filter: (pubs) => [...pubs].filter(p => p.price !== null).sort((a, b) => a.price! - b.price!),
@@ -307,10 +307,10 @@ export default function BeerWeather({ pubs, userLocation }: BeerWeatherProps) {
 
             {/* Fun footer */}
             <div className="mt-3 text-center text-xs py-2 rounded-xl bg-white/40 text-stone-400">
-              {weather.temperature >= 35 && '🥵 Stay hydrated — water between pints!'}
+              {weather.temperature >= 35 && '🥵 Stay hydrated. Water between pints!'}
               {weather.temperature >= 30 && weather.temperature < 35 && <><Umbrella className="w-4 h-4 inline" /> Perfect day for a cold schooner by the water</>}
-              {weather.temperature >= 22 && weather.temperature < 30 && '🌿 Perth summer sesh weather — get amongst it'}
-              {weather.temperature >= 15 && weather.temperature < 22 && '🍂 Classic pub weather — enjoy!'}
+              {weather.temperature >= 22 && weather.temperature < 30 && '🌿 Perth summer sesh weather. Get amongst it'}
+              {weather.temperature >= 15 && weather.temperature < 22 && '🍂 Classic pub weather. Enjoy!'}
               {weather.temperature < 15 && '🧣 Bundle up and find a warm corner booth'}
               {isWindy && ' · Hold onto your hat out there!'}
             </div>

--- a/src/components/CrowdPulse.tsx
+++ b/src/components/CrowdPulse.tsx
@@ -99,7 +99,7 @@ export default function CrowdPulse({ pubs, crowdReports, userLocation }: CrowdPu
   if (liveCount === 0) {
     return (
       <div className="bg-white rounded-2xl border border-stone-200/40 p-6 text-center">
-        <p className="text-stone-400 text-sm">No crowd reports yet — be the first!</p>
+        <p className="text-stone-400 text-sm">No crowd reports yet. Be the first!</p>
       </div>
     )
   }

--- a/src/components/FilterSection.tsx
+++ b/src/components/FilterSection.tsx
@@ -89,7 +89,7 @@ export function FilterSection({
           </select>
         )}
 
-        {/* Sort toggle — NEAREST always visible */}
+        {/* Sort toggle - NEAREST always visible */}
         <div className="bg-white border-3 border-ink rounded-pill overflow-hidden flex">
           <button
             onClick={() => setSortBy('price')}
@@ -111,7 +111,7 @@ export function FilterSection({
         </div>
       </div>
 
-      {/* Radius pills — only when sorting by nearest */}
+      {/* Radius pills - only when sorting by nearest */}
       {sortBy === 'nearest' && hasLocation && setNearbyRadius && (
         <div className="flex items-center gap-2">
           <span className="font-mono text-[0.65rem] font-bold uppercase tracking-[0.06em] text-gray-mid">Within</span>

--- a/src/components/HappyHourPreview.tsx
+++ b/src/components/HappyHourPreview.tsx
@@ -57,7 +57,7 @@ export default function HappyHourPreview({ pubs }: HappyHourPreviewProps) {
         {/* Separator */}
         <span className="text-stone-300 text-sm">·</span>
 
-        {/* Pub names — flowing inline text */}
+        {/* Pub names - flowing inline text */}
         <div className="flex-1 min-w-0 overflow-hidden">
           <p className="text-sm text-stone-500 truncate">
             {activeCount > 0 && activePubs.map((h, i) => (

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -20,9 +20,9 @@ export default function InstallPrompt() {
     const dismissedAt = localStorage.getItem('install-prompt-dismissed')
     const SEVEN_DAYS = 7 * 24 * 60 * 60 * 1000
     
-    // Already installed — bail
+    // Already installed - bail
     if (isStandalone) return
-    // Dismissed recently (within 7 days) — bail
+    // Dismissed recently (within 7 days) - bail
     if (dismissedAt && Date.now() - parseInt(dismissedAt) < SEVEN_DAYS) return
 
     // Only show on mobile devices (skip desktop)
@@ -32,7 +32,7 @@ export default function InstallPrompt() {
     const isIOS = /iPhone|iPad|iPod/.test(navigator.userAgent) && !(window as any).MSStream
     
     if (isIOS) {
-      // iOS Safari — show manual instructions after delay
+      // iOS Safari - show manual instructions after delay
       const timer = setTimeout(() => {
         setPlatform('ios')
         setShow(true)
@@ -40,7 +40,7 @@ export default function InstallPrompt() {
       return () => clearTimeout(timer)
     }
 
-    // Android/Chrome — listen for native install prompt
+    // Android/Chrome - listen for native install prompt
     const handler = (e: Event) => {
       e.preventDefault()
       setDeferredPrompt(e as BeforeInstallPromptEvent)

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -8,7 +8,7 @@ import 'leaflet/dist/leaflet.css'
 import { getMapMode, MAP_TILES, MAP_FILTERS, MAP_ATTRIBUTION } from '@/lib/mapTheme'
 import React, { useEffect } from 'react'
 
-// Price-coded markers using DivIcon — sized by price (P1c)
+// Price-coded markers using DivIcon - sized by price (P1c)
 function getPriceIcon(price: number | null): L.DivIcon {
   // TBC = smallest (28px)
   if (price === null) {
@@ -150,14 +150,14 @@ function FitBounds({ pubs, userLocation, totalPubCount }: { pubs: Pub[], userLoc
       if (pubs.length === 0) {
         map.setView([-31.9505, 115.8605], 11)
       } else if (isFiltered) {
-        // User is searching/filtering — zoom to filtered results
+        // User is searching/filtering - zoom to filtered results
         const bounds = L.latLngBounds(pubs.map(pub => [pub.lat, pub.lng]))
         map.fitBounds(bounds, { padding: [30, 30], maxZoom: 15 })
       } else if (userLocation) {
-        // Filter cleared — return to user location
+        // Filter cleared - return to user location
         map.setView([userLocation.lat, userLocation.lng], 14, { animate: true })
       } else {
-        // Filter cleared, no user location — fit to all
+        // Filter cleared, no user location - fit to all
         const bounds = L.latLngBounds(pubs.map(pub => [pub.lat, pub.lng]))
         map.fitBounds(bounds, { padding: [30, 30], maxZoom: 14 })
       }

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -62,7 +62,7 @@ export default function NotificationBell() {
       <div className="relative">
         <button
           className="relative p-2 rounded-full text-gray-400 cursor-not-allowed"
-          title="Notifications blocked — enable in browser settings"
+          title="Notifications blocked. Enable in browser settings"
           disabled
           onMouseEnter={() => setShowTooltip(true)}
           onMouseLeave={() => setShowTooltip(false)}
@@ -71,7 +71,7 @@ export default function NotificationBell() {
         </button>
         {showTooltip && (
           <div className="absolute right-0 top-full mt-1 px-3 py-1.5 bg-ink text-white text-[11px] rounded-lg whitespace-nowrap z-50 shadow-lg">
-            Notifications blocked — enable in browser settings
+            Notifications blocked. Enable in browser settings
           </div>
         )}
       </div>
@@ -88,7 +88,7 @@ export default function NotificationBell() {
             ? 'text-amber bg-amber/10 hover:bg-amber/20'
             : 'text-gray-500 hover:text-amber hover:bg-amber/5'
         } ${isLoading ? 'animate-pulse' : ''}`}
-        title={isSubscribed ? 'Alerts on — tap to disable' : 'Enable price alerts'}
+        title={isSubscribed ? 'Alerts on. Tap to disable' : 'Enable price alerts'}
         onMouseEnter={() => setShowTooltip(true)}
         onMouseLeave={() => setShowTooltip(false)}
       >

--- a/src/components/PintIndex.tsx
+++ b/src/components/PintIndex.tsx
@@ -42,7 +42,7 @@ function Sparkline({ data, snapshots, width = 280, height = 60 }: {
 
   if (data.length < 2) return (
     <div className="bg-white rounded-2xl border border-stone-200/40 p-6 text-center">
-      <p className="text-stone-400 text-sm">No price history data yet — trends build over time.</p>
+      <p className="text-stone-400 text-sm">No price history data yet. Trends build over time.</p>
     </div>
   );
   
@@ -225,7 +225,7 @@ export default function PintIndex() {
   );
   if (snapshots.length === 0) return (
     <div className="bg-white rounded-2xl border border-stone-200/40 p-6 text-center">
-      <p className="text-stone-400 text-sm">No price history data yet — trends build over time.</p>
+      <p className="text-stone-400 text-sm">No price history data yet. Trends build over time.</p>
     </div>
   );
 

--- a/src/components/PintOfTheDay.tsx
+++ b/src/components/PintOfTheDay.tsx
@@ -60,7 +60,7 @@ export default function PintOfTheDay() {
 
   async function handleShare() {
     if (!data) return
-    const text = `🍺 Arvo Pint of the Day\n\n${data.pub.name} — ${data.pub.suburb}\n$${data.pub.effectivePrice.toFixed(2)} pint${data.pub.beerType ? ` (${data.pub.beerType})` : ''}\n${data.reason}\n\narvo.pub/pub/${data.pub.slug}`
+    const text = `🍺 Arvo Pint of the Day\n\n${data.pub.name}, ${data.pub.suburb}\n$${data.pub.effectivePrice.toFixed(2)} pint${data.pub.beerType ? ` (${data.pub.beerType})` : ''}\n${data.reason}\n\narvo.pub/pub/${data.pub.slug}`
     
     try {
       await navigator.clipboard.writeText(text)

--- a/src/components/PriceHistory.tsx
+++ b/src/components/PriceHistory.tsx
@@ -105,7 +105,7 @@ export default function PriceHistory({ pubId, currentPrice }: PriceHistoryProps)
             </span>
           )}
           {trendFlat && (
-            <span className="text-xs font-medium text-amber">— Stable</span>
+            <span className="text-xs font-medium text-amber">- Stable</span>
           )}
         </div>
       </div>
@@ -154,7 +154,7 @@ export default function PriceHistory({ pubId, currentPrice }: PriceHistoryProps)
 
       {pricePoints.length === 1 && (
         <p className="text-xs text-stone-400 mt-2 text-center">
-          Price tracking started — trend data builds over time
+          Price tracking started. Trend data builds over time
         </p>
       )}
     </div>

--- a/src/components/PubListView.tsx
+++ b/src/components/PubListView.tsx
@@ -147,7 +147,7 @@ export default function PubListView({
                 </td>
                 <td className="py-4 px-3 hidden sm:table-cell">
                   <span className="text-xs text-gray-mid truncate max-w-[160px] block" title={pub.beerType || ''}>
-                    {pub.beerType || '—'}
+                    {pub.beerType || '-'}
                   </span>
                 </td>
                 <td className={`py-4 px-3 sm:px-4 text-right font-bold font-mono text-lg whitespace-nowrap ${pub.price !== null && pub.price <= 8 ? 'text-bargain' : 'text-ink'}`}>
@@ -166,7 +166,7 @@ export default function PubListView({
                       {happyHourStatus.statusEmoji && <LucideIcon name={happyHourStatus.statusEmoji} className="w-3.5 h-3.5 inline" />} {happyHourStatus.statusText}
                     </span>
                   ) : (
-                    <span className="text-xs text-stone-400">—</span>
+                    <span className="text-xs text-stone-400">-</span>
                   )}
                 </td>
                 <td className="py-4 px-2 hidden lg:table-cell">

--- a/src/components/PuntNPints.tsx
+++ b/src/components/PuntNPints.tsx
@@ -39,7 +39,7 @@ export default function PuntNPints({ pubs, userLocation }: PuntNPintsProps) {
     fetchTabs()
   }, [])
 
-  // Pubs with TAB on-site — the holy grail: punt AND pint under one roof
+  // Pubs with TAB on-site - the holy grail: punt AND pint under one roof
   const tabPubs = useMemo(() => {
     return pubs
       .filter(p => p.hasTab && p.price !== null)
@@ -118,7 +118,7 @@ export default function PuntNPints({ pubs, userLocation }: PuntNPintsProps) {
         </div>
 
         {isSectionOpen && (<>
-        {/* TAB Pubs — Cheapest pints where you can bet on-site */}
+        {/* TAB Pubs - Cheapest pints where you can bet on-site */}
         <div className="mb-3">
           <p className="text-[10px] font-medium text-stone-500 mb-1.5">
             Bet &amp; Drink Under One Roof

--- a/src/components/RainyDay.tsx
+++ b/src/components/RainyDay.tsx
@@ -39,13 +39,13 @@ function getRainIntensity(code: number): string {
 const RAIN_QUIPS = [
   "Perfect excuse for a cheeky pint by the window",
   "Nothing beats rain on the roof and a cold one in hand",
-  "Chucking it down — time to hunker down with a brew",
-  "Wet outside, warm inside — that's the Perth way 🤙",
+  "Chucking it down. Time to hunker down with a brew",
+  "Wet outside, warm inside. That's the Perth way 🤙",
 ]
 
 const DRY_QUIPS = [
-  "No rain, no worries — still great spots to chill",
-  "Save these for the next downpour — or just go now",
+  "No rain, no worries. Still great spots to chill",
+  "Save these for the next downpour, or just go now",
   "Cozy vibes rain or shine ✌️",
 ]
 
@@ -153,7 +153,7 @@ export default function RainyDay({ pubs, userLocation }: RainyDayProps) {
               </div>
               <p className="text-xs text-stone-500">
                 {isRaining
-                  ? "It's chucking it down — here's where to hide"
+                  ? "It's chucking it down. Here's where to hide"
                   : "No rain today, but these are still top spots to hunker down"}
               </p>
             </div>
@@ -193,7 +193,7 @@ export default function RainyDay({ pubs, userLocation }: RainyDayProps) {
             {/* Tagline */}
             <p className="text-xs text-stone-500 italic mb-2 text-center">
               {isRaining
-                ? "Chucking it down out there — duck into one of these cozy spots"
+                ? "Chucking it down out there. Duck into one of these cozy spots"
                 : "No umbrella needed, but these cozy corners are always a good shout"}
             </p>
 

--- a/src/components/SubmitPubForm.tsx
+++ b/src/components/SubmitPubForm.tsx
@@ -370,7 +370,7 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation }: SubmitP
           <span className="flex-1 text-sm font-mono font-bold text-ink">
             {selectedPub.name}
             <span className="text-gray-mid font-normal ml-1.5">
-              — {selectedPub.suburb}
+              - {selectedPub.suburb}
             </span>
           </span>
           <button
@@ -453,7 +453,7 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation }: SubmitP
                   >
                     <span className="font-medium">{pub.name}</span>
                     <span className="text-gray-mid ml-1.5">
-                      — {pub.suburb}
+                      - {pub.suburb}
                     </span>
                   </button>
                 ))

--- a/src/components/SuburbLeague.tsx
+++ b/src/components/SuburbLeague.tsx
@@ -88,11 +88,11 @@ export default function SuburbLeague({ pubs }: { pubs: Pub[] }) {
       const pos = i + 1
 
       if (pos === 5 && total > 5) {
-        items.push({ type: 'divider', label: '— Promotion Zone ↑ —', colorClass: 'bg-orange/10 text-orange border-orange/30' })
+        items.push({ type: 'divider', label: '- Promotion Zone ↑ -', colorClass: 'bg-orange/10 text-orange border-orange/30' })
       }
 
       if (pos === total - 2 && total > 6) {
-        items.push({ type: 'divider', label: '— Relegation Zone ↓ —', colorClass: 'bg-coral/10 text-coral border-coral/30' })
+        items.push({ type: 'divider', label: '- Relegation Zone ↓ -', colorClass: 'bg-coral/10 text-coral border-coral/30' })
       }
 
       const isRelegation = pos > total - 3 && total > 6
@@ -127,10 +127,10 @@ export default function SuburbLeague({ pubs }: { pubs: Pub[] }) {
             </h3>
             <p className="text-xs text-stone-500 mt-0.5">
               {isExpanded
-                ? `${total} suburbs ${sortLabel} — tap columns to re-sort`
+                ? `${total} suburbs ${sortLabel}. Tap columns to re-sort`
                 : leader
-                  ? `${leader.suburb} leads at $${leader.avgPrice.toFixed(2)} avg — tap to explore`
-                  : 'Ranked by average pint price — footy ladder style'}
+                  ? `${leader.suburb} leads at $${leader.avgPrice.toFixed(2)} avg. Tap to explore`
+                  : 'Ranked by average pint price, footy ladder style'}
             </p>
           </div>
           <svg width="16" height="16" viewBox="0 0 16 16" className={`text-stone-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}>

--- a/src/components/SunsetSippers.tsx
+++ b/src/components/SunsetSippers.tsx
@@ -169,11 +169,11 @@ export default function SunsetSippers({ pubs, userLocation }: SunsetSippersProps
   const sunShadow = getSunShadowGradient(sunAzimuth, isGoldenHour || isSunset)
   const cheapestSunset = sunsetPubs[0]
 
-  // Sun arc SVG dimensions — taller arc with room for labels below
+  // Sun arc SVG dimensions - taller arc with room for labels below
   const arcWidth = 200
   const arcHeight = 72
   const arcCenterX = arcWidth / 2   // 100
-  const arcCenterY = 46             // horizon line — lower gives taller visible arc
+  const arcCenterY = 46             // horizon line - lower gives taller visible arc
   const arcRx = 86                  // wide horizontal radius
   const arcRy = 42                  // taller vertical radius → more prominent arc
 
@@ -225,7 +225,7 @@ export default function SunsetSippers({ pubs, userLocation }: SunsetSippersProps
             <StatusIcon />
             <div>
               <div className="flex items-center gap-2">
-                <h3 className="text-base sm:text-lg font-bold font-heading text-stone-800 flex items-center">Sunset Sippers<InfoTooltip text="Uses Perth's real-time sunset & golden hour times (calculated astronomically). Highlights west-facing pubs with verified prices — best spots to watch the sun go down with a pint." /></h3>
+                <h3 className="text-base sm:text-lg font-bold font-heading text-stone-800 flex items-center">Sunset Sippers<InfoTooltip text="Uses Perth's real-time sunset & golden hour times (calculated astronomically). Highlights west-facing pubs with verified prices. Best spots to watch the sun go down with a pint." /></h3>
                 {isGoldenHour && (
                   <span className="inline-flex items-center rounded-full bg-amber-500 text-white text-[10px] font-semibold px-2 py-0.5 animate-pulse shadow-sm">
                     GOLDEN HOUR
@@ -247,7 +247,7 @@ export default function SunsetSippers({ pubs, userLocation }: SunsetSippersProps
               <svg width={160} height={58} viewBox={`0 0 ${arcWidth} ${arcHeight}`} className="opacity-80" overflow="hidden" style={{display:'block'}}>
                 {/* Horizon line */}
                 <line x1="8" y1={arcCenterY} x2={arcWidth - 8} y2={arcCenterY} stroke="#d4a574" strokeWidth="1" strokeDasharray="3,3" opacity="0.6" />
-                {/* Full arc (dashed guide) — flat ellipse */}
+                {/* Full arc (dashed guide) - flat ellipse */}
                 <path
                   d={`M 12 ${arcCenterY} A ${arcRx} ${arcRy} 0 0 1 ${arcWidth - 12} ${arcCenterY}`}
                   fill="none"
@@ -256,7 +256,7 @@ export default function SunsetSippers({ pubs, userLocation }: SunsetSippersProps
                   strokeDasharray="3,3"
                   opacity="0.3"
                 />
-                {/* Traveled path — flat ellipse */}
+                {/* Traveled path - flat ellipse */}
                 {sunPosition > 0 && sunPosition < 100 && (
                   <path
                     d={`M 12 ${arcCenterY} A ${arcRx} ${arcRy} 0 0 1 ${sunX} ${sunY}`}
@@ -274,7 +274,7 @@ export default function SunsetSippers({ pubs, userLocation }: SunsetSippersProps
                     <circle cx={sunX} cy={sunY} r="3" fill="#D97706" />
                   </>
                 )}
-                {/* Labels — below horizon line, larger font, symmetric */}
+                {/* Labels - below horizon line, larger font, symmetric */}
                 <text x="6" y={arcCenterY + 18} fontSize="11" fill="#92734a" fontFamily="monospace" fontWeight="500">{E.arrow_up_plain}{formatTime(sunTimes.sunrise).replace(' ', '')}</text>
                 <text x={arcWidth - 70} y={arcCenterY + 18} fontSize="11" fill="#c2410c" fontFamily="monospace" fontWeight="500">{E.arrow_down_plain}{formatTime(sunTimes.sunset).replace(' ', '')}</text>
               </svg>

--- a/src/components/TonightsMoves.tsx
+++ b/src/components/TonightsMoves.tsx
@@ -152,7 +152,7 @@ export default function TonightsMoves({ pubs, userLocation }: TonightsMovesProps
               <div className="p-3 rounded-xl bg-gradient-to-r from-orange-50 to-yellow-50 border border-orange-200">
                 <h4 className="text-xs font-semibold text-orange mb-1 flex items-center gap-1">
                   {E.star} Market Tip
-                  <InfoTooltip text="Our algorithm picks the best value pub right now — weighing price, active happy hour bonus, beer quality, and suburb. Rescores as happy hours start and end." />
+                  <InfoTooltip text="Our algorithm picks the best value pub right now, weighing price, active happy hour bonus, beer quality, and suburb. Rescores as happy hours start and end." />
                 </h4>
                 <div className="flex items-center justify-between">
                   <div>

--- a/src/hooks/useWatchlist.ts
+++ b/src/hooks/useWatchlist.ts
@@ -112,7 +112,7 @@ export function useWatchlist(): WatchlistContextType {
 /**
  * Sync watchlist slugs to the push subscription on the server.
  * Only runs if the user has an active push subscription.
- * Silent fail — this is non-critical.
+ * Silent fail - this is non-critical.
  */
 async function syncWatchlistToPush(slugs: string[]): Promise<void> {
   try {
@@ -133,6 +133,6 @@ async function syncWatchlistToPush(slugs: string[]): Promise<void> {
       }),
     })
   } catch {
-    // Silent fail — push sync is non-critical
+    // Silent fail - push sync is non-critical
   }
 }

--- a/src/lib/freshness.ts
+++ b/src/lib/freshness.ts
@@ -19,7 +19,7 @@ export function getFreshness(lastVerified: string | null): FreshnessInfo {
       color: 'text-stone-400',
       bgColor: 'bg-stone-50',
       borderColor: 'border-stone-200',
-      icon: '—',
+      icon: '-',
     }
   }
 

--- a/src/lib/happyHourLive.ts
+++ b/src/lib/happyHourLive.ts
@@ -125,7 +125,7 @@ export function getHappyHourStatus(pub: {
   const hhStart = pub.happyHourStart ?? null
   const hhEnd = pub.happyHourEnd ?? null
   
-  // No happy hour timing data — can't determine if active
+  // No happy hour timing data - can't determine if active
   if (!hhDays || !hhStart || !hhEnd) {
     return {
       isActive: false,

--- a/src/lib/mapTile.ts
+++ b/src/lib/mapTile.ts
@@ -10,6 +10,6 @@ export function getMapTileUrl(lat: number, lng: number, zoom: number = 15): stri
   const y = Math.floor(
     ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * n
   )
-  // CartoDB Voyager No Labels — street grid without text for clean card backgrounds
+  // CartoDB Voyager No Labels - street grid without text for clean card backgrounds
   return `https://basemaps.cartocdn.com/rastertiles/voyager_nolabels/${zoom}/${x}/${y}@2x.png`
 }

--- a/src/lib/pushNotifications.ts
+++ b/src/lib/pushNotifications.ts
@@ -1,6 +1,6 @@
 'use client'
 
-// VAPID public key — safe to expose (env var set on Vercel)
+// VAPID public key - safe to expose (env var set on Vercel)
 const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY || ''
 
 /**
@@ -122,6 +122,6 @@ export async function syncWatchlist(watchedSlugs: string[]): Promise<void> {
       }),
     })
   } catch {
-    // Silent fail — push sync is non-critical
+    // Silent fail - push sync is non-critical
   }
 }


### PR DESCRIPTION
## Summary

Replaces all 127 em dash characters (—, U+2014) across 55 files with contextually appropriate alternatives. Em dashes are the #1 AI-generated content signal.

### Replacement rules applied:

| Context | Replacement | Count |
|---------|------------|-------|
| Page titles (`Feature — Subtitle \| Arvo`) | `:` or `\|` | ~30 |
| Meta descriptions | `.` (sentence break) | ~8 |
| UI copy / taglines | `.` or `,` | ~25 |
| Casual Perth copy (weather, rainy day) | `.` or `,` | ~16 |
| Code comments (`// thing — explanation`) | `-` (hyphen) | ~30 |
| Data display (`'—'` as empty indicator) | `'-'` (hyphen) | ~6 |
| Decorative dividers (`— Zone —`) | `- Zone -` | 2 |
| Share text | `:` | ~5 |
| Chart labels | `-` | ~2 |

### Verification
- ✅ `grep` confirms **zero** em dashes remaining in `src/`
- ✅ TypeScript type check passes (`tsc --noEmit` = 0 errors)
- No logic or functionality changes - text-only edits
- Perth voice preserved throughout

### Files changed
55 files, 127 insertions, 127 deletions