### PR TITLE
Add haversineDistanceKm helper and dedupe in SubmitPubForm

### DIFF
--- a/src/components/SubmitPubForm.tsx
+++ b/src/components/SubmitPubForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { Beer, ScanLine, Trash2, Plus, Camera, ImagePlus } from 'lucide-react'
+import { haversineDistanceKm } from '@/lib/location';
 // heic2any is browser-only, dynamically imported in handleImageSelect
 
 interface Pub {
@@ -25,19 +26,6 @@ interface ExtractedItem {
   beer_type: string;
   price: number;
   price_type: 'regular' | 'happy_hour';
-}
-
-function getDistanceKmSimple(lat1: number, lng1: number, lat2: number, lng2: number): number {
-  const R = 6371;
-  const dLat = ((lat2 - lat1) * Math.PI) / 180;
-  const dLon = ((lng2 - lng1) * Math.PI) / 180;
-  const a =
-    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-    Math.cos((lat1 * Math.PI) / 180) *
-      Math.cos((lat2 * Math.PI) / 180) *
-      Math.sin(dLon / 2) *
-      Math.sin(dLon / 2);
-  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 }
 
 export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPub }: SubmitPubFormProps) {
@@ -152,8 +140,8 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
       list = [...list].sort((a, b) => {
         if (!a.lat || !a.lng) return 1;
         if (!b.lat || !b.lng) return -1;
-        const distA = getDistanceKmSimple(userLocation.lat, userLocation.lng, a.lat, a.lng);
-        const distB = getDistanceKmSimple(userLocation.lat, userLocation.lng, b.lat, b.lng);
+        const distA = haversineDistanceKm(userLocation.lat, userLocation.lng, a.lat, a.lng);
+        const distB = haversineDistanceKm(userLocation.lat, userLocation.lng, b.lat, b.lng);
         return distA - distB;
       });
     }

--- a/src/lib/location.test.ts
+++ b/src/lib/location.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { haversineDistanceKm } from './location'
+
+const expectWithinKm = (actual: number, expected: number, toleranceKm = 1) => {
+  assert.ok(
+    Math.abs(actual - expected) <= toleranceKm,
+    `expected ${actual}km to be within ${toleranceKm}km of ${expected}km`,
+  )
+}
+
+describe('haversineDistanceKm', () => {
+  it('returns 0 for identical coordinates', () => {
+    assert.equal(haversineDistanceKm(-31.9505, 115.8605, -31.9505, 115.8605), 0)
+  })
+
+  it('calculates the distance from Perth CBD to Fremantle', () => {
+    expectWithinKm(
+      haversineDistanceKm(-31.9505, 115.8605, -32.0569, 115.7439),
+      16,
+    )
+  })
+
+  it('calculates the distance from Sydney to Perth', () => {
+    expectWithinKm(
+      haversineDistanceKm(-33.8688, 151.2093, -31.9505, 115.8605),
+      3290,
+    )
+  })
+
+  it('calculates the distance between antipodal points', () => {
+    expectWithinKm(haversineDistanceKm(0, 0, 0, 180), 20015)
+  })
+})

--- a/src/lib/location.ts
+++ b/src/lib/location.ts
@@ -1,12 +1,24 @@
-// Haversine distance in km between two lat/lng points
+const EARTH_RADIUS_KM = 6371
+
+function degreesToRadians(degrees: number): number {
+  return degrees * Math.PI / 180
+}
+
+export function haversineDistanceKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const dLat = degreesToRadians(lat2 - lat1)
+  const dLng = degreesToRadians(lng2 - lng1)
+  const lat1Radians = degreesToRadians(lat1)
+  const lat2Radians = degreesToRadians(lat2)
+
+  const a = Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1Radians) * Math.cos(lat2Radians) *
+    Math.sin(dLng / 2) ** 2
+
+  return EARTH_RADIUS_KM * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}
+
 export function getDistanceKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
-  const R = 6371
-  const dLat = (lat2 - lat1) * Math.PI / 180
-  const dLng = (lng2 - lng1) * Math.PI / 180
-  const a = Math.sin(dLat/2) * Math.sin(dLat/2) +
-    Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
-    Math.sin(dLng/2) * Math.sin(dLng/2)
-  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a))
+  return haversineDistanceKm(lat1, lng1, lat2, lng2)
 }
 
 // Format distance for display


### PR DESCRIPTION
## What this changes

Adds a `haversineDistanceKm(lat1, lng1, lat2, lng2)` helper to `src/lib/location.ts` (with unit tests covering identity, Perth↔Fremantle, Sydney↔Perth, and antipodal points at ±1 km tolerance) and replaces the duplicate `getDistanceKmSimple` inside `SubmitPubForm.tsx` with an import of the new helper.

## Why

Refs the pre-existing duplication flagged during the previous PM-loop review — a one-off cleanup that consolidates the same haversine formula (R = 6371 km) into a single, tested location of truth in `@/lib/location`.

## Type

- [x] Refactor / chore

## Checklist

- [x] `npx tsc --noEmit` passes
- [ ] `npm run lint` passes
- [ ] `npm run build` succeeds locally
- [x] No emojis introduced
- [x] Design system tokens used — no UI changes
- [x] No user-facing copy added
- [x] No new page added
- [x] `agents/andrew.json` not touched
- [ ] `docs/PROJECT-STATUS.md` updated (after merge / push)