### PR TITLE
fix: weekend happy-hour badge + Pint Index badge (from architecture review)

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -1,6 +1,6 @@
 # Perth Pint Prices Project Status
 
-Last updated: 2026-05-03
+Last updated: 2026-05-30
 
 ## What this is
 
@@ -9,6 +9,14 @@ Perth Pint Prices (perthpintprices.com) tracks pint prices across **857 Perth pu
 Stack, database, routes, components, and lib files are documented in `CLAUDE.md` (auto-loaded every session). This file covers history, recent work, and the backlog.
 
 ## What's done recently
+
+### Live-bug fixes from architecture review (2026-05-30)
+- A multi-agent architecture-review workflow surfaced three "live bugs"; two were real (fixed here), one was a false alarm.
+- **Happy-hour badge** (`5247efb`): the pub list/card components re-parsed the lossy `pub.happyHour` string through `happyHour.ts`'s regex, which can't match Weekends, single days, or am-pm spans (and the generated string drops `:30` minutes), so the "HH" badge silently showed off during weekend/half-hour/midday happy hours. `PubCardList`, `SunsetSippers`, and `PuntNPints` now read the structured `pub.isHappyHourNow` (computed by `happyHourLive` from raw fields). `TonightsMoves` + `DiscoverClient` deferred — their `isToday`/countdown use needs the `happyHourLive` extension (arch-review rank 1).
+- **Pint Index badge** (`f609b48`): `PintIndexBadge` fetched `price_snapshots` ascending + `limit(30)` = the 30 oldest snapshots, so the homepage badge price and "% this week" came from the start of history. Now fetches the newest 30 (descending) and reverses to chronological order.
+- **Not a bug:** record-price not writing `happy_hour_price` — Andrew's tool never sends a happy-hour price, so nothing is dropped. Latent gap (arch-review rank 5), not a live bug; left untouched.
+- Next body of work is the 7-candidate architecture deepening backlog from the same review (rank 1 = consolidate the happy-hour engine into one deep `happyHourLive` module and delete `happyHour.ts`).
+- Commits: `5247efb`, `f609b48`
 
 ### SEO redirect consolidation (2026-05-03)
 - Fixed the legacy redirect half of the highest-priority canonical redirect work:

--- a/src/components/PintIndexBadge.tsx
+++ b/src/components/PintIndexBadge.tsx
@@ -42,13 +42,15 @@ export default function PintIndexBadge({ className = 'hidden sm:flex' }: { class
       const { data } = await supabase
         .from('price_snapshots')
         .select('avg_price, snapshot_date')
-        .order('snapshot_date', { ascending: true })
+        .order('snapshot_date', { ascending: false })
         .limit(30)
       if (data) {
+        // Fetch newest-first so we get the latest 30, then reverse to
+        // chronological order for the sparkline + current/previous reads.
         setSnapshots(data.map((d: any) => ({
           avg_price: parseFloat(d.avg_price),
           snapshot_date: d.snapshot_date,
-        })))
+        })).reverse())
       }
     }
     fetchData()

--- a/src/components/PubCardList.tsx
+++ b/src/components/PubCardList.tsx
@@ -2,7 +2,6 @@
 
 import { Pub } from '@/types/pub'
 import { CrowdReport } from '@/lib/supabase'
-import { getHappyHourStatus } from '@/lib/happyHour'
 import { getDistanceKm, formatDistance } from '@/lib/location'
 import Link from 'next/link'
 import { Beer, Star } from 'lucide-react'
@@ -50,7 +49,6 @@ export default function PubCardList({
 
       {/* Pub rows */}
       {displayPubs.map((pub, index) => {
-        const hhStatus = getHappyHourStatus(pub.happyHour)
         const distanceKm = userLocation
           ? getDistanceKm(userLocation.lat, userLocation.lng, pub.lat, pub.lng)
           : null
@@ -79,7 +77,7 @@ export default function PubCardList({
             <div className="flex-1 min-w-0">
               <span className="font-body text-base font-bold text-ink">
                 {pub.name}
-                {hhStatus.isActive && (
+                {pub.isHappyHourNow && (
                   <span className="font-mono text-[0.58rem] font-bold uppercase tracking-[0.05em] px-1.5 py-0.5 rounded-pill ml-1.5 border-2 bg-red-pale text-red border-red inline-block align-middle">
                     HH
                   </span>
@@ -90,7 +88,7 @@ export default function PubCardList({
                 {distance && ` · ${distance}`}
                 {pub.beerType && ` · ${pub.beerType}`}
               </span>
-              {hhStatus.isActive && pub.happyHour && (
+              {pub.isHappyHourNow && pub.happyHour && (
                 <span className="font-mono text-[0.7rem] text-red font-semibold mt-0.5 flex items-center gap-1.5">
                   <span className="w-1.5 h-1.5 rounded-full bg-red flex-shrink-0" />
                   {pub.happyHour}

--- a/src/components/PuntNPints.tsx
+++ b/src/components/PuntNPints.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link'
 import { useState, useMemo, useEffect } from 'react'
 import { Pub } from '@/types/pub'
 import { getDistanceKm, formatDistance } from '@/lib/location'
-import { getHappyHourStatus } from '@/lib/happyHour'
 import { Trophy, Zap, Dog, ExternalLink } from 'lucide-react'
 
 function toSuburbSlug(suburb: string): string {
@@ -192,7 +191,6 @@ export default function PuntNPints({ pubs, userLocation }: PuntNPintsProps) {
           </div>
 
           {displayTabPubs.map((pub, i) => {
-            const hhStatus = getHappyHourStatus(pub.happyHour)
             const distance = userLocation
               ? formatDistance(getDistanceKm(userLocation.lat, userLocation.lng, pub.lat, pub.lng))
               : null
@@ -215,7 +213,7 @@ export default function PuntNPints({ pubs, userLocation }: PuntNPintsProps) {
                     <span className="font-mono text-[0.5rem] font-black px-1.5 py-0.5 rounded-pill border-2 border-ink bg-ink text-white flex-shrink-0">
                       TAB
                     </span>
-                    {hhStatus.isActive && (
+                    {pub.isHappyHourNow && (
                       <span className="font-mono text-[0.58rem] font-bold uppercase tracking-[0.05em] px-1.5 py-0.5 rounded-pill border-2 bg-red-pale text-red border-red flex-shrink-0">
                         HH
                       </span>
@@ -228,7 +226,7 @@ export default function PuntNPints({ pubs, userLocation }: PuntNPintsProps) {
                       {pub.beerType && ` · ${pub.beerType}`}
                     </span>
                   </div>
-                  {hhStatus.isActive && pub.happyHour && (
+                  {pub.isHappyHourNow && pub.happyHour && (
                     <span className="font-mono text-[0.7rem] text-red font-semibold mt-0.5 ml-6 flex items-center gap-1.5">
                       <span className="w-1.5 h-1.5 rounded-full bg-red flex-shrink-0" />
                       {pub.happyHour}
@@ -269,7 +267,6 @@ export default function PuntNPints({ pubs, userLocation }: PuntNPintsProps) {
             </div>
 
             {displayNearby.map(({ pub, nearestTab, distance: tabDist }, i) => {
-              const hhStatus = getHappyHourStatus(pub.happyHour)
               const userDist = userLocation
                 ? formatDistance(getDistanceKm(userLocation.lat, userLocation.lng, pub.lat, pub.lng))
                 : null
@@ -291,7 +288,7 @@ export default function PuntNPints({ pubs, userLocation }: PuntNPintsProps) {
                       <p className="font-body text-base font-bold text-ink group-hover:text-amber transition-colors truncate">
                         {pub.name}
                       </p>
-                      {hhStatus.isActive && (
+                      {pub.isHappyHourNow && (
                         <span className="font-mono text-[0.58rem] font-bold uppercase tracking-[0.05em] px-1.5 py-0.5 rounded-pill border-2 bg-red-pale text-red border-red flex-shrink-0">
                           HH
                         </span>

--- a/src/components/SunsetSippers.tsx
+++ b/src/components/SunsetSippers.tsx
@@ -5,7 +5,6 @@ import { useState, useEffect, useMemo } from 'react'
 import dynamic from 'next/dynamic'
 import { Pub } from '@/types/pub'
 import { getDistanceKm, formatDistance } from '@/lib/location'
-import { getHappyHourStatus } from '@/lib/happyHour'
 import { Sun, Sunset, Moon, Beer } from 'lucide-react'
 
 function toSuburbSlug(suburb: string): string {
@@ -320,7 +319,6 @@ export default function SunsetSippers({ pubs, userLocation }: SunsetSippersProps
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {displayPubs.map((pub) => {
-            const hhStatus = getHappyHourStatus(pub.happyHour)
             const distance = userLocation
               ? formatDistance(getDistanceKm(userLocation.lat, userLocation.lng, pub.lat, pub.lng))
               : null
@@ -366,13 +364,13 @@ export default function SunsetSippers({ pubs, userLocation }: SunsetSippersProps
                         {pub.beerType && ` · ${pub.beerType}`}
                       </p>
                     </div>
-                    {hhStatus.isActive && (
+                    {pub.isHappyHourNow && (
                       <span className="font-mono text-[0.58rem] font-bold uppercase tracking-[0.05em] px-1.5 py-0.5 rounded-pill border-2 bg-red-pale text-red border-red flex-shrink-0">
                         HH
                       </span>
                     )}
                   </div>
-                  {hhStatus.isActive && pub.happyHour && (
+                  {pub.isHappyHourNow && pub.happyHour && (
                     <span className="font-mono text-[0.65rem] text-red font-semibold mt-1 flex items-center gap-1.5">
                       <span className="w-1.5 h-1.5 rounded-full bg-red flex-shrink-0" />
                       {pub.happyHour}


### PR DESCRIPTION
Two correctness bugs surfaced by a multi-agent architecture-review workflow, fixed surgically. A third "live bug" the review flagged turned out to be a false alarm and was left untouched (see below).

## Fixes

### 1. Happy-hour "HH" badge silently showed *off* during weekend / half-hour / midday happy hours (`5247efb`)
The list/card components re-parsed the lossy `pub.happyHour` string through `happyHour.ts`'s regex, which **can't match** `Weekends`, single days, or `11am-2pm`-style spans — and the upstream `generateHappyHourText` already drops `:30` minutes and mis-applies am/pm. So the badge disagreed with the (correct) effective price on the same render.

The right value is already computed by the `happyHourLive` engine from **structured fields** and carried on every `Pub` as `isHappyHourNow`. `PubCardList`, `SunsetSippers`, and `PuntNPints` now read that and drop the broken parser.

> **Deferred:** `TonightsMoves` + `DiscoverClient` also use the parser's `isToday` / `countdown` ("Starting Soon", "2h left") — concepts `happyHourLive` doesn't expose yet. Fixing them correctly is the architecture review's **rank 1** (extend `happyHourLive`, then delete `happyHour.ts`), so they're intentionally left for that follow-up rather than half-fixed here.

### 2. Pint Index badge averaged the 30 *oldest* snapshots (`f609b48`)
`PintIndexBadge` fetched `price_snapshots` ordered `ascending` + `limit(30)`, so the homepage badge price and its "% this week" came from the **start of history**. Now fetches the newest 30 (`descending`) and reverses to chronological order, so `snapshots[length-1]` is the latest and the sparkline reads old→new.

## Not a bug (left untouched)
The review also flagged record-price not writing `happy_hour_price`. On inspection it's a **false alarm**: Andrew's tool body has no happy-hour-price field and `andrew.json` doesn't collect one, so no data is being dropped. It's a latent capability gap (review's rank 5), not a live bug — fixing it now would be speculative.

## Verification
- `npx tsc --noEmit` → exit 0
- Affected routes (`/`, `/discover`, `/guides/sunset-sippers`, `/guides/punt-and-pints`) → HTTP 200, clean compile, no error overlays
- Desktop (1280×800) + mobile (375×812) screenshots: homepage + PubCardList + Pint Index badge render correctly

## Diff
4 component files, net **−5 lines** (broken parser usage removed). No behavior change beyond the two fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)