### PR TITLE
SupabaseGateway PR1: centralize the 11 anon API clients (no-op)

### DIFF
--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -1,11 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
+import { anonClient } from '@/lib/supabaseGateway'
 import { timingSafeEqual } from 'crypto'
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co',
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlmeGtvYmx2Z3R0ZWx6Ym9lbnBpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExODUwNjgsImV4cCI6MjA4Njc2MTA2OH0.qLy6B-VeVnMh0QSOxHK3uQEJ6iZr6xNHmfKov_7B-fY'
-)
+const supabase = anonClient()
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0

--- a/src/app/api/cron/price-check/route.ts
+++ b/src/app/api/cron/price-check/route.ts
@@ -1,9 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { anonClient } from '@/lib/supabaseGateway'
 import { NextRequest, NextResponse } from 'next/server'
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co'
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlmeGtvYmx2Z3R0ZWx6Ym9lbnBpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExODUwNjgsImV4cCI6MjA4Njc2MTA2OH0.qLy6B-VeVnMh0QSOxHK3uQEJ6iZr6xNHmfKov_7B-fY'
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+const supabase = anonClient()
 
 interface PriceChange {
   slug: string

--- a/src/app/api/cron/weekly-snapshot/route.ts
+++ b/src/app/api/cron/weekly-snapshot/route.ts
@@ -1,10 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { anonClient } from '@/lib/supabaseGateway'
 import { NextRequest, NextResponse } from 'next/server'
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co',
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlmeGtvYmx2Z3R0ZWx6Ym9lbnBpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExODUwNjgsImV4cCI6MjA4Njc2MTA2OH0.qLy6B-VeVnMh0QSOxHK3uQEJ6iZr6xNHmfKov_7B-fY'
-)
+const supabase = anonClient()
 
 /**
  * GET /api/cron/weekly-snapshot

--- a/src/app/api/menu-scan/route.ts
+++ b/src/app/api/menu-scan/route.ts
@@ -1,13 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
+import { anonClient } from '@/lib/supabaseGateway'
 import OpenAI from 'openai'
 
 export const maxDuration = 30
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co',
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlmeGtvYmx2Z3R0ZWx6Ym9lbnBpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExODUwNjgsImV4cCI6MjA4Njc2MTA2OH0.qLy6B-VeVnMh0QSOxHK3uQEJ6iZr6xNHmfKov_7B-fY'
-)
+const supabase = anonClient()
 
 // Lazy-init to avoid module-scope crash when env var is missing at build time
 let _openai: OpenAI | null = null

--- a/src/app/api/pint-of-the-day/route.ts
+++ b/src/app/api/pint-of-the-day/route.ts
@@ -1,12 +1,9 @@
 import { NextResponse } from 'next/server'
 
 export const dynamic = 'force-dynamic'
-import { createClient } from '@supabase/supabase-js'
+import { anonClient } from '@/lib/supabaseGateway'
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co',
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlmeGtvYmx2Z3R0ZWx6Ym9lbnBpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExODUwNjgsImV4cCI6MjA4Njc2MTA2OH0.qLy6B-VeVnMh0QSOxHK3uQEJ6iZr6xNHmfKov_7B-fY'
-)
+const supabase = anonClient()
 
 /**
  * Pint of the Day Algorithm:

--- a/src/app/api/price-report/route.ts
+++ b/src/app/api/price-report/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
+import { anonClient } from '@/lib/supabaseGateway'
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co',
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlmeGtvYmx2Z3R0ZWx6Ym9lbnBpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExODUwNjgsImV4cCI6MjA4Njc2MTA2OH0.qLy6B-VeVnMh0QSOxHK3uQEJ6iZr6xNHmfKov_7B-fY'
-)
+const supabase = anonClient()
 
 export async function POST(req: NextRequest) {
   try {

--- a/src/app/api/pub-submission/route.ts
+++ b/src/app/api/pub-submission/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import { anonClient } from '@/lib/supabaseGateway';
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co',
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlmeGtvYmx2Z3R0ZWx6Ym9lbnBpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExODUwNjgsImV4cCI6MjA4Njc2MTA2OH0.qLy6B-VeVnMh0QSOxHK3uQEJ6iZr6xNHmfKov_7B-fY'
-);
+const supabase = anonClient();
 
 export async function POST(req: NextRequest) {
   try {

--- a/src/app/api/pubs/route.ts
+++ b/src/app/api/pubs/route.ts
@@ -1,10 +1,7 @@
-import { createClient } from '@supabase/supabase-js';
+import { anonClient } from '@/lib/supabaseGateway';
 import { NextResponse } from 'next/server';
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co',
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlmeGtvYmx2Z3R0ZWx6Ym9lbnBpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExODUwNjgsImV4cCI6MjA4Njc2MTA2OH0.qLy6B-VeVnMh0QSOxHK3uQEJ6iZr6xNHmfKov_7B-fY'
-);
+const supabase = anonClient();
 
 export const revalidate = 300; // cache for 5 minutes
 

--- a/src/app/api/push/send/route.ts
+++ b/src/app/api/push/send/route.ts
@@ -1,11 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import webpush from 'web-push'
-import { createClient } from '@supabase/supabase-js'
+import { anonClient } from '@/lib/supabaseGateway'
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co',
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlmeGtvYmx2Z3R0ZWx6Ym9lbnBpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExODUwNjgsImV4cCI6MjA4Njc2MTA2OH0.qLy6B-VeVnMh0QSOxHK3uQEJ6iZr6xNHmfKov_7B-fY'
-)
+const supabase = anonClient()
 
 /**
  * POST /api/push/send

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -1,10 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { anonClient } from '@/lib/supabaseGateway'
 import { NextRequest, NextResponse } from 'next/server'
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co',
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlmeGtvYmx2Z3R0ZWx6Ym9lbnBpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExODUwNjgsImV4cCI6MjA4Njc2MTA2OH0.qLy6B-VeVnMh0QSOxHK3uQEJ6iZr6xNHmfKov_7B-fY'
-)
+const supabase = anonClient()
 
 /**
  * POST /api/push/subscribe

--- a/src/app/api/weekly-snapshot/route.ts
+++ b/src/app/api/weekly-snapshot/route.ts
@@ -1,10 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { anonClient } from '@/lib/supabaseGateway'
 import { NextRequest, NextResponse } from 'next/server'
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co',
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlmeGtvYmx2Z3R0ZWx6Ym9lbnBpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExODUwNjgsImV4cCI6MjA4Njc2MTA2OH0.qLy6B-VeVnMh0QSOxHK3uQEJ6iZr6xNHmfKov_7B-fY'
-)
+const supabase = anonClient()
 
 /**
  * GET /api/cron/weekly-snapshot

--- a/src/lib/supabaseGateway.ts
+++ b/src/lib/supabaseGateway.ts
@@ -1,0 +1,56 @@
+/**
+ * SupabaseGateway — the one place server-side API routes get a Supabase client.
+ *
+ * Replaces ~15 inline `createClient(...)` blocks across `src/app/api/**` so the
+ * project URL and key selection live in a single file, and the "should this route
+ * write past RLS?" question becomes an explicit, typed choice (anonClient vs
+ * serviceClient) instead of folklore buried in constructor arguments.
+ *
+ * This module is ADDITIVE for the API layer only. The `supabase` singleton in
+ * `src/lib/supabase.ts` (used by client components and the server data helpers)
+ * is intentionally left untouched.
+ */
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co'
+
+// The anon key is PUBLIC by design (it is the NEXT_PUBLIC_ key already shipped to
+// every browser). Keeping it as a single fallback here is harmless and preserves
+// the previous behaviour, while de-duplicating the literal that was copied into ~14 files.
+const SUPABASE_ANON_KEY =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlmeGtvYmx2Z3R0ZWx6Ym9lbnBpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExODUwNjgsImV4cCI6MjA4Njc2MTA2OH0.qLy6B-VeVnMh0QSOxHK3uQEJ6iZr6xNHmfKov_7B-fY'
+
+let anon: SupabaseClient | null = null
+
+/**
+ * RLS-bound client using the public anon key. Use for reads and for RLS-gated
+ * public writes (price reports, submissions, push subscriptions). Memoised.
+ */
+export function anonClient(): SupabaseClient {
+  if (!anon) {
+    anon = createClient(SUPABASE_URL, SUPABASE_ANON_KEY)
+  }
+  return anon
+}
+
+/**
+ * Privileged client using the service-role key — bypasses RLS. Use only in
+ * trusted, authenticated server routes that must write past RLS.
+ *
+ * IMPORTANT: call this PER-REQUEST (inside the route handler), never at module
+ * top level — CI builds without `SUPABASE_SERVICE_ROLE_KEY`, so constructing it
+ * at import time would crash `next build`.
+ *
+ * Throws loudly if the key is missing rather than silently degrading to the anon
+ * key (which would run a privileged route as an unprivileged client).
+ */
+export function serviceClient(): SupabaseClient {
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!key) {
+    throw new Error(
+      'SUPABASE_SERVICE_ROLE_KEY is not set — refusing to fall back to the anon key for a privileged route',
+    )
+  }
+  return createClient(SUPABASE_URL, key, { auth: { persistSession: false } })
+}


### PR DESCRIPTION
Part 1 of 2 of the `SupabaseGateway` keystone, scoped per a documented engineering consensus (me + an independent partner-engineer agent). **This PR changes no behaviour** — it's the mechanical half, isolated so PR2 (the one diff that *does* change behaviour) stays small and reviewable.

## What's here
- **`src/lib/supabaseGateway.ts`** — `anonClient()` (memoised, public anon key) and `serviceClient()` (lazy, **throws** on a missing service-role key instead of silently degrading to anon). `serviceClient()` is introduced but **not used until PR2**.
- **11 anon routes migrated** to `anonClient()`: `pubs`, `pint-of-the-day`, `admin/stats`, `price-report`, `pub-submission`, `menu-scan`, `push/send`, `push/subscribe`, and the 3 `cron`/snapshot writers.

## Why it's a no-op
Same project URL, same **public** `NEXT_PUBLIC_` anon key (the one already shipped to every browser) — just constructed in one place. The anon-JWT literal drops from ~14 copies to **one** (the gateway); it now survives only in the untouched `src/lib/supabase.ts` singleton and in `admin/review` (fixed in PR2).

## Deliberately NOT here (→ PR2)
The 4 service-role routes — `agents/record-price`, `agents/post-call`, `pintsweep/kickoff`, and the `admin/review` **silent service-role→anon downgrade** (the one real security bug). That's the isolated behaviour-changing diff.

## Verification
`tsc --noEmit` clean · `npm test` pass · `next build` green · confirmed `createClient` now remains only in the 4 service routes.

## Follow-up (separate, flagged)
The cron/snapshot writers write with the **public anon key**, implying `price_snapshots`/`pub_price_cache` may be world-writable. Pre-existing; needs a DB-policy (RLS) check + lockdown. Not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)