### PR TITLE
SupabaseGateway PR2: service routes + fix the admin/review downgrade

### DIFF
--- a/src/app/api/admin/review/route.ts
+++ b/src/app/api/admin/review/route.ts
@@ -1,11 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
+import { serviceClient } from '@/lib/supabaseGateway'
 import { timingSafeEqual } from 'crypto'
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co'
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlmeGtvYmx2Z3R0ZWx6Ym9lbnBpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExODUwNjgsImV4cCI6MjA4Njc2MTA2OH0.qLy6B-VeVnMh0QSOxHK3uQEJ6iZr6xNHmfKov_7B-fY'
-
-const supabase = createClient(supabaseUrl, supabaseKey)
 
 export const dynamic = 'force-dynamic'
 
@@ -29,6 +24,10 @@ export async function POST(request: NextRequest) {
   if (!process.env.ADMIN_PASSWORD || !safeCompare(password, process.env.ADMIN_PASSWORD)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+
+  // Privileged client (bypasses RLS). Throws if the service-role key is missing
+  // rather than silently downgrading to the anon key.
+  const supabase = serviceClient()
 
   const body = await request.json()
   const { type, id, action, target_slug } = body

--- a/src/app/api/agents/post-call/route.ts
+++ b/src/app/api/agents/post-call/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
+import { serviceClient } from '@/lib/supabaseGateway'
 import crypto from 'node:crypto'
 
 // ElevenLabs post-call webhook. Fired once per call with a full transcript,
@@ -83,10 +83,7 @@ export async function POST(req: NextRequest) {
   const d = body.data
   const pubSlug = d.conversation_initiation_client_data?.dynamic_variables?.pub_slug || null
 
-  const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co',
-    process.env.SUPABASE_SERVICE_ROLE_KEY || ''
-  )
+  const supabase = serviceClient()
 
   let pubId: number | null = null
   if (pubSlug) {

--- a/src/app/api/agents/record-price/[slug]/route.ts
+++ b/src/app/api/agents/record-price/[slug]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
+import { serviceClient } from '@/lib/supabaseGateway'
 
 // ElevenLabs "server tool" callback. The pub_slug arrives via URL path (filled
 // in by ElevenLabs from the conversation's {{pub_slug}} dynamic variable, NOT
@@ -62,10 +62,7 @@ export async function POST(req: NextRequest, { params }: { params: { slug: strin
     }
   }
 
-  const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co',
-    process.env.SUPABASE_SERVICE_ROLE_KEY || ''
-  )
+  const supabase = serviceClient()
 
   const { data: pub, error: fetchErr } = await supabase
     .from('pubs')

--- a/src/app/api/pintsweep/kickoff/route.ts
+++ b/src/app/api/pintsweep/kickoff/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
+import { serviceClient } from '@/lib/supabaseGateway'
 
 // Kicks off a batch outbound sweep via ElevenLabs Batch Calling. Pulls pubs
 // with a phone number and no verified price, builds per-recipient dynamic
@@ -40,10 +40,7 @@ export async function POST(req: NextRequest) {
     )
   }
 
-  const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co',
-    process.env.SUPABASE_SERVICE_ROLE_KEY || ''
-  )
+  const supabase = serviceClient()
 
   // Eligible pubs: have a phone, haven't been called in the last 24h, and
   // either missing a price or the price isn't human-verified (phone-agent


### PR DESCRIPTION
Part 2 of 2 — the **behaviour-changing** half, kept small and isolated per the consensus. Migrates the 4 service-role routes to `serviceClient()` and fixes the one real security bug.

## The fix that matters
`admin/review` selected `SUPABASE_SERVICE_ROLE_KEY || NEXT_PUBLIC_SUPABASE_ANON_KEY || '<jwt>'` **at module scope** — a silent service-role→anon downgrade letting an admin-only mutation (approve/reject price reports, write `pubs`/`price_reports`/`pub_submissions`) run RLS-bound as the public anon role if the service key were ever absent. Now it constructs `serviceClient()` **inside the POST handler after the auth check**, and `serviceClient()` **throws** on a missing key instead of degrading.

## The other 3 (behaviour-preserving)
`agents/record-price`, `agents/post-call`, `pintsweep/kickoff` already used `SUPABASE_SERVICE_ROLE_KEY || ''` (an empty key throws at request time). Swapping to `serviceClient()` is equivalent — it just throws a clear, named error instead of a cryptic auth failure. Andrew's live price webhook behaviour is unchanged (the key is present in prod — proven by the fact that it records prices today).

## Build-safety (the key constraint)
CI builds without the service-role key. Every `serviceClient()` call is **per-request** (lazy) — none at module scope — so `next build` never constructs it. **Verified empirically:** `next build` is green with `SUPABASE_SERVICE_ROLE_KEY` unset.

## Net result of PR1+PR2
`createClient` is gone from all of `src/app/api`; the anon JWT literal survives in exactly 2 places — the gateway and the untouched `src/lib/supabase.ts` singleton (down from ~14).

## Verification
`tsc --noEmit` · `npm test` · `next build` (key unset) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)