### PR TITLE
Move trusted-write routes to serviceClient (lockdown prep + fix stale Pint Index)

### DIFF
--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { anonClient } from '@/lib/supabaseGateway'
+import { serviceClient } from '@/lib/supabaseGateway'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { timingSafeEqual } from 'crypto'
-
-const supabase = anonClient()
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -113,7 +112,7 @@ function safeCompare(a: string, b: string): boolean {
 // ============================================================
 // LOG FAILED AUTH ATTEMPT TO DATABASE
 // ============================================================
-async function logFailedAttempt(ip: string): Promise<void> {
+async function logFailedAttempt(supabase: SupabaseClient, ip: string): Promise<void> {
   try {
     await supabase.from('agent_activity').insert({
       action: `Failed admin login attempt from ${ip}`,
@@ -127,6 +126,7 @@ async function logFailedAttempt(ip: string): Promise<void> {
 }
 
 export async function GET(request: NextRequest) {
+  const supabase = serviceClient()
   const ip = getClientIP(request)
 
   // Check rate limit FIRST
@@ -151,7 +151,7 @@ export async function GET(request: NextRequest) {
     recordFailedAttempt(ip)
 
     // Log failed attempt to database (await to ensure it completes before lambda terminates)
-    await logFailedAttempt(ip)
+    await logFailedAttempt(supabase, ip)
 
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }

--- a/src/app/api/cron/price-check/route.ts
+++ b/src/app/api/cron/price-check/route.ts
@@ -1,7 +1,5 @@
-import { anonClient } from '@/lib/supabaseGateway'
+import { serviceClient } from '@/lib/supabaseGateway'
 import { NextRequest, NextResponse } from 'next/server'
-
-const supabase = anonClient()
 
 interface PriceChange {
   slug: string
@@ -27,6 +25,8 @@ export async function GET(request: NextRequest) {
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+
+  const supabase = serviceClient()
 
   try {
     // 1. Fetch current verified prices

--- a/src/app/api/cron/weekly-snapshot/route.ts
+++ b/src/app/api/cron/weekly-snapshot/route.ts
@@ -1,7 +1,5 @@
-import { anonClient } from '@/lib/supabaseGateway'
+import { serviceClient } from '@/lib/supabaseGateway'
 import { NextRequest, NextResponse } from 'next/server'
-
-const supabase = anonClient()
 
 /**
  * GET /api/cron/weekly-snapshot
@@ -13,6 +11,8 @@ export async function GET(request: NextRequest) {
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+
+  const supabase = serviceClient()
 
   try {
     // Get verified pubs with prices

--- a/src/app/api/push/send/route.ts
+++ b/src/app/api/push/send/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import webpush from 'web-push'
-import { anonClient } from '@/lib/supabaseGateway'
-
-const supabase = anonClient()
+import { serviceClient } from '@/lib/supabaseGateway'
 
 /**
  * POST /api/push/send
@@ -25,6 +23,8 @@ export async function POST(request: NextRequest) {
     if (!process.env.PUSH_API_SECRET || authHeader !== `Bearer ${process.env.PUSH_API_SECRET}`) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const supabase = serviceClient()
 
     const { title, body, url, tag, targetSlugs, renotify } = await request.json()
 

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -1,7 +1,5 @@
-import { anonClient } from '@/lib/supabaseGateway'
+import { serviceClient } from '@/lib/supabaseGateway'
 import { NextRequest, NextResponse } from 'next/server'
-
-const supabase = anonClient()
 
 /**
  * POST /api/push/subscribe
@@ -9,6 +7,7 @@ const supabase = anonClient()
  */
 export async function POST(request: NextRequest) {
   try {
+    const supabase = serviceClient()
     const { subscription, watchedSlugs, userAgent } = await request.json()
 
     if (!subscription?.endpoint || !subscription?.keys?.p256dh || !subscription?.keys?.auth) {
@@ -47,6 +46,7 @@ export async function POST(request: NextRequest) {
  */
 export async function DELETE(request: NextRequest) {
   try {
+    const supabase = serviceClient()
     const { endpoint } = await request.json()
 
     if (!endpoint) {

--- a/src/app/api/weekly-snapshot/route.ts
+++ b/src/app/api/weekly-snapshot/route.ts
@@ -1,7 +1,5 @@
-import { anonClient } from '@/lib/supabaseGateway'
+import { serviceClient } from '@/lib/supabaseGateway'
 import { NextRequest, NextResponse } from 'next/server'
-
-const supabase = anonClient()
 
 /**
  * GET /api/cron/weekly-snapshot
@@ -13,6 +11,8 @@ export async function GET(request: NextRequest) {
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+
+  const supabase = serviceClient()
 
   try {
     // Get verified pubs with prices


### PR DESCRIPTION
Follow-up to the **RLS audit**: prepares the database lockdown by moving the trusted server jobs that write `price_snapshots` / `pub_price_cache` / `push_subscriptions` / `agent_activity` from the **anon key** to the **service-role key**. Once this deploys, those tables can be locked to service-role-only writes at the DB level (the open public-write policies get dropped).

## Routes migrated (anonClient → serviceClient, per-request)
| Route | Writes |
|---|---|
| `cron/price-check` | `pub_price_cache` |
| `cron/weekly-snapshot`, `weekly-snapshot` | `price_snapshots` |
| `push/subscribe`, `push/send` | `push_subscriptions` |
| `admin/stats` | `agent_activity` (failed-login log) |

## Also fixes a live bug
The audit found `price_snapshots` has **no anon write policy**, yet the weekly-snapshot crons wrote it with the anon key — so they've been **failing silently** and the **Pint Index has been going stale**. With the service-role key they can write again.

## Safety
- Every `serviceClient()` is constructed **inside** its handler (never module scope) — `serviceClient()` throws on a missing key, and CI builds without it. Verified: `SUPABASE_SERVICE_ROLE_KEY= npm run build` is **green**.
- `admin/stats` threads the client into its `logFailedAttempt` helper (the helper runs on the auth-failure path, so the client is built at the top of the handler).
- No business logic / queries / table names changed.

`tsc --noEmit` · `npm test` (10 pass) · `next build` (key unset) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)