### PR TITLE
Record the RLS lockdown as a SQL migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,6 @@ scripts/discover-venues-results.json
 # Research agent data
 perth_pubs_pricing/
 
-# Supabase local config
-supabase/
+# Supabase local config (but track migrations)
+supabase/*
+!supabase/migrations/

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,10 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### DB security lockdown + architecture keystones (2026-05-30)
+- **Refactor Phase 0 + SupabaseGateway** (PRs #45–#48): added `src/lib/perthClock.ts` (the time keystone) and `src/lib/supabaseGateway.ts` (`anonClient()` / `serviceClient()`), centralising 16 inline `createClient(...)` blocks and cutting the duplicated anon-JWT literal from ~14 files to 1. Fixed a real security bug — `admin/review` silently degraded service-role→anon (#47). Deleted 4 dead files. A CI **deploy gate** (#43) now runs `node:test` via `tsx` and blocks merges.
+- **RLS audit + lockdown:** a probe-driven scare ("anyone can write prices") was a **false alarm** — `pubs` / `price_history` / `price_snapshots` were always service-role-only. The audit did find 3 over-permissive tables: after migrating their writer routes to the service-role key (#48), dropped the public WRITE + read-leak policies on `pub_price_cache`, `push_subscriptions`, and `agent_activity`. Also fixed the **stale Pint Index** (the weekly-snapshot crons had been failing silently on anon writes). The DB change is recorded in [`supabase/migrations/20260530120000_rls_lockdown.sql`](../supabase/migrations/20260530120000_rls_lockdown.sql).
+
 ### Removed non-core features (2026-05-30)
 - Product call: killed everything that isn't the core pint-price experience. Deleted **pub-golf**, **pint-crawl**, **leaderboard**, and **weekly-report** (the "Pint Report" stats page) — all had **0 organic clicks/impressions over 90 days** and are rebuildable from git history.
 - Removed the 4 page routes + the orphaned `/api/weekly-report`, and cleaned every reference: sitemap entries, the `/discover` "Activities" carousel, and nav/footer links (MobileNav incl. now-unused icon imports, Footer, SubPageNav, HomeClient, homepage SSR crawl-links). Fixed the weekly push deep-link (was broken at `/weekly`) → `/insights/pint-index`. **18 files, −2,635 lines.** tsc + `next build` green; `/discover` visually verified (no empty section, footer nav trimmed).

--- a/supabase/migrations/20260530120000_rls_lockdown.sql
+++ b/supabase/migrations/20260530120000_rls_lockdown.sql
@@ -1,0 +1,49 @@
+-- Migration: RLS lockdown for server-only tables
+-- Applied: 2026-05-30 (run manually via the Supabase SQL editor; recorded here so the
+--          database policy change is tracked in the repo and reproducible).
+--
+-- Context
+-- -------
+-- A security audit found public-role (anon) WRITE and READ policies on three
+-- server-only tables. The application code that reads/writes these tables was moved
+-- to the service-role key in PR #48 (service-role BYPASSES RLS), so the public
+-- policies are no longer needed. Dropping them locks the tables to service-role
+-- access only. RLS stays ENABLED on every table.
+--
+-- Deliberately NOT touched: the public-submission INSERT policies on
+-- price_reports / pub_submissions / crowd_reports (the public report forms), and
+-- every SELECT policy the public website relies on (pubs, price_history,
+-- price_snapshots, etc.). The `pubs` and `agent_activity` ALL policies already
+-- restrict writes to `auth.role() = 'service_role'` and were left in place.
+--
+-- This script is idempotent (DROP POLICY IF EXISTS) and safe to re-run.
+
+begin;
+
+-- Keep RLS on (no-op if already enabled).
+alter table public.pub_price_cache    enable row level security;
+alter table public.push_subscriptions enable row level security;
+alter table public.agent_activity     enable row level security;
+
+-- pub_price_cache — internal price cache; written + read only by cron/price-check.
+drop policy if exists "Service insert/update" on public.pub_price_cache;  -- was: ALL to {public} USING (true) -- wide open
+drop policy if exists "Public read"           on public.pub_price_cache;  -- anon SELECT
+
+-- push_subscriptions — written + read only by the push API routes.
+drop policy if exists "Allow insert subscriptions" on public.push_subscriptions;
+drop policy if exists "Allow update subscriptions" on public.push_subscriptions;  -- was USING (true): anyone could edit any sub
+drop policy if exists "Allow delete subscriptions" on public.push_subscriptions;  -- was USING (true): anyone could delete any sub
+drop policy if exists "Allow select subscriptions" on public.push_subscriptions;  -- exposed every push endpoint
+
+-- agent_activity — internal activity log; written + read only by admin/stats.
+drop policy if exists "Allow anon to insert agent_activity" on public.agent_activity;
+drop policy if exists "Allow anon to read agent_activity"   on public.agent_activity;  -- exposed failed-login IPs
+-- Kept: "Service role full access" (ALL ... USING auth.role() = 'service_role').
+
+commit;
+
+-- End state (verified 2026-05-30):
+--   pub_price_cache     -> 0 policies  (service-role only)
+--   push_subscriptions  -> 0 policies  (service-role only)
+--   agent_activity      -> 1 policy    ("Service role full access")
+-- All three remain RLS-enabled; reachable only by service-role code.


### PR DESCRIPTION
Tracks the database security change in the repo (it was applied manually via the Supabase SQL editor). **Docs/SQL only — no application code.**

## Adds `supabase/migrations/20260530120000_rls_lockdown.sql`
Idempotent (`DROP POLICY IF EXISTS`) record of the lockdown:
- **Write holes closed:** dropped the public `ALL`/INSERT/UPDATE/DELETE policies on `pub_price_cache`, `push_subscriptions`, `agent_activity` (their writer routes moved to the service-role key in #48).
- **Read leaks closed:** dropped the anon SELECT policies on those three server-only tables (push endpoints, failed-login IPs).
- **Untouched:** public-submission INSERT policies (`price_reports`/`pub_submissions`/`crowd_reports`) and every SELECT policy the public site relies on (`pubs`, etc.). RLS remains enabled on all tables.

End state (verified live): `pub_price_cache` + `push_subscriptions` → 0 policies; `agent_activity` → 1 ("Service role full access"). All reachable only by service-role code.

Plus a consolidated PROJECT-STATUS entry covering the Phase 0 keystones, SupabaseGateway, and this security work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)