### PR TITLE
Phase 1 (PubUrls): one suburb-slug source of truth + SEO snapshot guard

### DIFF
--- a/src/app/[suburb]/[pub]/PubDetailClient.tsx
+++ b/src/app/[suburb]/[pub]/PubDetailClient.tsx
@@ -10,19 +10,12 @@ import SubmitPubForm from '@/components/SubmitPubForm'
 import { PenLine } from 'lucide-react'
 import { formatHappyHourDays } from '@/lib/happyHourLive'
 import Footer from '@/components/Footer'
+import { pubUrl, suburbUrl } from '@/lib/urls'
 
 const PubDetailMap = dynamic(() => import('@/components/PubDetailMap'), {
   ssr: false,
   loading: () => <div className="h-[350px] bg-off-white animate-pulse rounded-card border-3 border-ink" />,
 })
-
-function toSuburbSlug(suburb: string): string {
-  return suburb
-    .toLowerCase()
-    .replace(/['']/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-}
 
 function timeAgo(dateStr: string): string {
   const date = new Date(dateStr)
@@ -114,7 +107,7 @@ export default function PubDetailClient({ pub, nearbyPubs, avgPrice }: PubDetail
         <nav className="flex items-center gap-2 font-mono text-[0.7rem] text-gray-mid">
           <Link href="/" className="hover:text-amber transition-colors no-underline">Home</Link>
           <span>/</span>
-          <Link href={`/${toSuburbSlug(pub.suburb)}`} className="hover:text-amber transition-colors no-underline">{pub.suburb}</Link>
+          <Link href={suburbUrl(pub.suburb)} className="hover:text-amber transition-colors no-underline">{pub.suburb}</Link>
           <span>/</span>
           <span className="text-ink font-bold">{pub.name}</span>
         </nav>
@@ -264,7 +257,7 @@ export default function PubDetailClient({ pub, nearbyPubs, avgPrice }: PubDetail
                 More in {pub.suburb}
               </h2>
               <Link
-                href={`/${toSuburbSlug(pub.suburb)}`}
+                href={suburbUrl(pub.suburb)}
                 className="font-mono text-[0.7rem] font-bold text-amber hover:underline no-underline"
               >
                 View all →
@@ -273,7 +266,7 @@ export default function PubDetailClient({ pub, nearbyPubs, avgPrice }: PubDetail
             {nearbyPubs.map((nearby, i) => (
               <Link
                 key={nearby.id}
-                href={`/${toSuburbSlug(pub.suburb)}/${nearby.slug}`}
+                href={pubUrl({ suburb: pub.suburb, slug: nearby.slug })}
                 className={`flex items-center justify-between px-4 py-3 no-underline group hover:bg-off-white transition-colors ${
                   i < nearbyPubs.length - 1 ? 'border-b border-gray-light' : ''
                 }`}

--- a/src/app/[suburb]/[pub]/page.tsx
+++ b/src/app/[suburb]/[pub]/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next'
 import { notFound, permanentRedirect } from 'next/navigation'
-import { getPubBySlug, getAllPubSlugPairs, getNearbyPubs, getSiteStats, toSuburbSlug } from '@/lib/supabase'
-import { absolutePubUrl, absoluteSuburbUrl } from '@/lib/urls'
+import { getPubBySlug, getAllPubSlugPairs, getNearbyPubs, getSiteStats } from '@/lib/supabase'
+import { absolutePubUrl, absoluteSuburbUrl, toSuburbSlug } from '@/lib/urls'
 import PubDetailClient from './PubDetailClient'
 
 interface PageProps {

--- a/src/app/[suburb]/page.tsx
+++ b/src/app/[suburb]/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
-import { getAllSuburbs, getSuburbBySlug, getSuburbPubs, getNearbySuburbs, getSiteStats, toSuburbSlug } from '@/lib/supabase'
-import { pubUrl, suburbUrl, absoluteSuburbUrl } from '@/lib/urls'
+import { getAllSuburbs, getSuburbBySlug, getSuburbPubs, getNearbySuburbs, getSiteStats } from '@/lib/supabase'
+import { absoluteSuburbUrl } from '@/lib/urls'
 import SuburbClient from './SuburbClient'
 
 interface PageProps {

--- a/src/app/discover/DiscoverClient.tsx
+++ b/src/app/discover/DiscoverClient.tsx
@@ -10,10 +10,7 @@ import SubPageNav from '@/components/SubPageNav'
 import Footer from '@/components/Footer'
 import { Beer, Clock, Tag, Star } from 'lucide-react'
 import LucideIcon from '@/components/LucideIcon'
-
-function toSuburbSlug(suburb: string): string {
-  return suburb.toLowerCase().replace(/['']/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-}
+import { pubUrl } from '@/lib/urls'
 
 /* ─── Helpers ─── */
 function getPerthTime(): Date {
@@ -132,7 +129,7 @@ export default function DiscoverClient() {
               </p>
               <div className="flex items-center justify-center gap-2 mb-3 flex-wrap">
                 <Beer className="w-5 h-5 text-amber" />
-                <Link href={`/${toSuburbSlug(pintOfTheDay.pub.suburb)}/${pintOfTheDay.pub.slug}`} className="font-mono text-lg sm:text-xl font-extrabold text-ink hover:text-amber transition-colors no-underline">
+                <Link href={pubUrl(pintOfTheDay.pub)} className="font-mono text-lg sm:text-xl font-extrabold text-ink hover:text-amber transition-colors no-underline">
                   {pintOfTheDay.pub.name}
                 </Link>
                 <span className="text-gray-mid text-sm">{pintOfTheDay.pub.suburb}</span>
@@ -162,7 +159,7 @@ export default function DiscoverClient() {
               <p className="text-sm text-gray-mid mb-4">Lowest prices right now</p>
               <div className="space-y-1">
                 {bestBuys.slice(0, 5).map((pub, i) => (
-                  <Link key={pub.id} href={`/${toSuburbSlug(pub.suburb)}/${pub.slug}`} className="flex items-center justify-between p-2.5 rounded-card border-l-2 border-l-transparent hover:border-l-amber hover:bg-off-white transition-all group no-underline">
+                  <Link key={pub.id} href={pubUrl(pub)} className="flex items-center justify-between p-2.5 rounded-card border-l-2 border-l-transparent hover:border-l-amber hover:bg-off-white transition-all group no-underline">
                     <div className="flex items-center gap-3 min-w-0">
                       <span className="font-mono text-sm font-bold text-gray-mid w-5">{i + 1}</span>
                       <div className="min-w-0">
@@ -192,7 +189,7 @@ export default function DiscoverClient() {
                   <p className="text-sm text-gray-mid py-4 text-center">No happy hours active or upcoming right now. Check back later!</p>
                 )}
                 {upcomingHappyHours.map(({ pub, status }) => (
-                  <Link key={pub.id} href={`/${toSuburbSlug(pub.suburb)}/${pub.slug}`} className="flex items-center justify-between p-2.5 rounded-card border-l-2 border-l-transparent hover:border-l-amber hover:bg-off-white transition-all group no-underline">
+                  <Link key={pub.id} href={pubUrl(pub)} className="flex items-center justify-between p-2.5 rounded-card border-l-2 border-l-transparent hover:border-l-amber hover:bg-off-white transition-all group no-underline">
                     <div className="min-w-0">
                       <span className="font-mono text-sm font-bold text-ink truncate block group-hover:text-amber transition-colors">{pub.name}</span>
                       <p className="text-xs text-gray-mid">{pub.suburb}</p>
@@ -252,7 +249,6 @@ export default function DiscoverClient() {
             <div className="absolute right-0 top-0 bottom-4 w-12 pointer-events-none bg-gradient-to-l from-[#FDF8F0] to-transparent" />
           </div>
         </section>
-
 
         {/* ════════════════════════════════════════════
             5. CONTRIBUTE CTA BANNER

--- a/src/app/happy-hour/HappyHourClient.tsx
+++ b/src/app/happy-hour/HappyHourClient.tsx
@@ -7,10 +7,7 @@ import Footer from '@/components/Footer'
 import { getPubs } from '@/lib/supabase'
 import { Pub } from '@/types/pub'
 import { getDistanceKm, formatDistance } from '@/lib/location'
-
-function toSuburbSlug(suburb: string): string {
-  return suburb.toLowerCase().replace(/['']/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-}
+import { pubUrl } from '@/lib/urls'
 
 type SortMode = 'price' | 'nearest'
 
@@ -185,7 +182,7 @@ export default function HappyHourClient({ initialPubs }: HappyHourClientProps) {
               return (
                 <Link
                   key={pub.id}
-                  href={`/${toSuburbSlug(pub.suburb)}/${pub.slug}`}
+                  href={pubUrl(pub)}
                   className={`flex items-center gap-4 py-4 no-underline group ${
                     i < pubs.length - 1 ? 'border-b border-gray-light' : ''
                   }`}

--- a/src/app/happy-hour/page.tsx
+++ b/src/app/happy-hour/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from 'next'
 import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 import HappyHourClient from './HappyHourClient'
-import { getPubs, toSuburbSlug } from '@/lib/supabase'
+import { getPubs } from '@/lib/supabase'
+import { pubUrl } from '@/lib/urls'
 
 export const revalidate = 60 // Revalidate every 60 seconds for fresh happy hour data
 
@@ -39,7 +40,7 @@ export default async function HappyHourPage() {
       <div className="sr-only" aria-hidden="true">
         <h2>Happy Hour Deals in Perth</h2>
         {happyHourPubs.map(pub => (
-          <a key={pub.slug} href={`/${toSuburbSlug(pub.suburb)}/${pub.slug}`}>
+          <a key={pub.slug} href={pubUrl(pub)}>
             {pub.name} - {pub.suburb} - Happy Hour
           </a>
         ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next'
 import HomeClient from './HomeClient'
-import { getSiteStats, getPubs, toSuburbSlug } from '@/lib/supabase'
+import { getSiteStats, getPubs } from '@/lib/supabase'
+import { pubUrl, suburbUrl } from '@/lib/urls'
 
 export async function generateMetadata(): Promise<Metadata> {
   const stats = await getSiteStats()
@@ -138,14 +139,13 @@ export default async function HomePage() {
         </nav>
 
         <h2>Perth Suburbs</h2>
-        {suburbs.map(suburb => {
-          const slug = toSuburbSlug(suburb)
-          return <a key={slug} href={`/${slug}`}>{suburb}</a>
-        })}
+        {suburbs.map(suburb => (
+          <a key={suburb} href={suburbUrl(suburb)}>{suburb}</a>
+        ))}
 
         <h2>Perth Pubs - Cheapest Pints</h2>
         {pubs.slice(0, 50).map(pub => (
-          <a key={pub.slug} href={`/${toSuburbSlug(pub.suburb)}/${pub.slug}`}>
+          <a key={pub.slug} href={pubUrl(pub)}>
             {pub.name} - {pub.suburb}
             {pub.price ? ` - $${pub.price.toFixed(2)}` : ''}
           </a>

--- a/src/app/pub/[slug]/route.ts
+++ b/src/app/pub/[slug]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
-import { getPubBySlug, toSuburbSlug } from '@/lib/supabase'
+import { getPubBySlug } from '@/lib/supabase'
+import { pubUrl } from '@/lib/urls'
 
 interface RouteContext {
   params: { slug: string }
@@ -15,6 +16,6 @@ export async function GET(request: Request, { params }: RouteContext) {
     return new Response('Not found', { status: 404 })
   }
 
-  const destination = new URL(`/${toSuburbSlug(pub.suburb)}/${pub.slug}`, request.url)
+  const destination = new URL(pubUrl(pub), request.url)
   return NextResponse.redirect(destination, 301)
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,13 +1,11 @@
 import { MetadataRoute } from 'next'
 import { getAllPubSlugPairs, getAllSuburbs } from '@/lib/supabase'
-import { absolutePubUrl, absoluteSuburbUrl } from '@/lib/urls'
+import { BASE_URL, absolutePubUrl, absoluteSuburbUrl } from '@/lib/urls'
 
 // Regenerate hourly so new pubs added to Supabase appear in the sitemap
 // within 60 min. Without this, Next defaults to build-time generation and
 // the sitemap would only refresh on redeploy.
 export const revalidate = 3600
-
-const BASE_URL = 'https://perthpintprices.com'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const [slugPairs, suburbs] = await Promise.all([

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import { MetadataRoute } from 'next'
-import { getAllPubSlugPairs, getAllSuburbs, toSuburbSlug } from '@/lib/supabase'
+import { getAllPubSlugPairs, getAllSuburbs } from '@/lib/supabase'
+import { absolutePubUrl, absoluteSuburbUrl } from '@/lib/urls'
 
 // Regenerate hourly so new pubs added to Supabase appear in the sitemap
 // within 60 min. Without this, Next defaults to build-time generation and
@@ -34,14 +35,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   ]
 
   const suburbRoutes: MetadataRoute.Sitemap = suburbs.map(s => ({
-    url: `${BASE_URL}/${s.slug}`,
+    url: absoluteSuburbUrl(s.slug),
     lastModified: now,
     changeFrequency: 'weekly' as const,
     priority: 0.8,
   }))
 
   const pubRoutes: MetadataRoute.Sitemap = slugPairs.map(pair => ({
-    url: `${BASE_URL}/${toSuburbSlug(pair.suburb)}/${pair.slug}`,
+    url: absolutePubUrl(pair),
     lastModified: now,
     changeFrequency: 'weekly' as const,
     priority: 0.6,

--- a/src/components/BeerWeather.tsx
+++ b/src/components/BeerWeather.tsx
@@ -7,10 +7,7 @@ import { Pub } from '@/types/pub'
 import { getDistanceKm, formatDistance } from '@/lib/location'
 import { Umbrella, Thermometer, Sun, Leaf, Wind } from 'lucide-react'
 import LucideIcon from '@/components/LucideIcon'
-
-function toSuburbSlug(suburb: string): string {
-  return suburb.toLowerCase().replace(/['']/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-}
+import { pubUrl } from '@/lib/urls'
 
 interface WeatherData {
   temperature: number
@@ -269,7 +266,7 @@ export default function BeerWeather({ pubs, userLocation }: BeerWeatherProps) {
             <div className="space-y-0">
               {recommendedPubs.map((pub, index) => (
                 <Link
-                  key={pub.id} href={`/${toSuburbSlug(pub.suburb)}/${pub.slug}`}
+                  key={pub.id} href={pubUrl(pub)}
                   className={`flex items-center gap-3 px-3 py-3 no-underline group ${
                     index > 0 ? 'border-t border-gray-light' : ''
                   } ${index === 0 ? 'bg-amber/5' : ''}`}

--- a/src/components/DadBar.tsx
+++ b/src/components/DadBar.tsx
@@ -6,10 +6,7 @@ import { useState, useMemo } from 'react'
 import { Pub } from '@/types/pub'
 import { getDistanceKm, formatDistance } from '@/lib/location'
 import { Users, MapPin } from 'lucide-react'
-
-function toSuburbSlug(suburb: string): string {
-  return suburb.toLowerCase().replace(/['']/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-}
+import { pubUrl } from '@/lib/urls'
 
 const DAD_JOKES = [
   "I told my kids I'd buy them a drink at the pub. They got lemonade. I got a pint. Everyone won.",
@@ -120,7 +117,7 @@ export default function DadBar({ pubs, userLocation }: { pubs: Pub[], userLocati
             {/* Pub list */}
             <div className="space-y-0">
               {displayPubs.map((pub, i) => (
-                <Link key={pub.id} href={`/${toSuburbSlug(pub.suburb)}/${pub.slug}`} className={`flex items-center gap-2 px-3 py-2.5 no-underline group ${i > 0 ? 'border-t border-gray-light' : ''} ${i === 0 ? 'bg-amber/5' : ''}`}>
+                <Link key={pub.id} href={pubUrl(pub)} className={`flex items-center gap-2 px-3 py-2.5 no-underline group ${i > 0 ? 'border-t border-gray-light' : ''} ${i === 0 ? 'bg-amber/5' : ''}`}>
                   <span className={`font-mono text-[0.65rem] font-bold w-4 ${i === 0 ? 'text-amber' : 'text-gray-mid'}`}>{i === 0 ? '\u2605' : `${i + 1}`}</span>
                   <div className="flex-1 min-w-0">
                     <span className="font-body text-sm font-bold text-ink group-hover:text-amber transition-colors truncate block">{pub.name}</span>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,8 +1,5 @@
 import Link from 'next/link'
-
-function toSuburbSlug(suburb: string): string {
-  return suburb.toLowerCase().replace(/['']/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-}
+import { pubUrl } from '@/lib/urls'
 
 interface HeroSectionProps {
   pubs: { price: number | null; suburb: string; slug: string }[]
@@ -58,7 +55,7 @@ export default function HeroSection({ pubs }: HeroSectionProps) {
           <span className="font-mono text-[0.6rem] font-bold uppercase tracking-[0.08em] text-gray-mid block mt-0.5">Suburbs</span>
         </Link>
         {cheapestPub ? (
-          <Link href={`/${toSuburbSlug(cheapestPub.suburb)}/${cheapestPub.slug}`} className="border-3 border-ink rounded-card px-5 py-3.5 text-center min-w-[100px] bg-amber shadow-hard-sm animate-fade-up stagger-7 hover:translate-y-[-2px] transition-transform">
+          <Link href={pubUrl(cheapestPub)} className="border-3 border-ink rounded-card px-5 py-3.5 text-center min-w-[100px] bg-amber shadow-hard-sm animate-fade-up stagger-7 hover:translate-y-[-2px] transition-transform">
             <span className="font-mono text-[1.6rem] font-extrabold tracking-[-0.02em] block leading-[1.1] text-white">${cheapest}</span>
             <span className="font-mono text-[0.6rem] font-bold uppercase tracking-[0.08em] text-white/80 block mt-0.5">Cheapest</span>
           </Link>

--- a/src/components/PintOfTheDay.tsx
+++ b/src/components/PintOfTheDay.tsx
@@ -2,10 +2,7 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { Beer, CircleCheck, Copy, Lightbulb, Medal } from 'lucide-react'
-
-function toSuburbSlug(suburb: string): string {
-  return suburb.toLowerCase().replace(/['']/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-}
+import { absolutePubUrl, pubUrl } from '@/lib/urls'
 
 interface PintOfTheDayData {
   date: string
@@ -64,7 +61,7 @@ export default function PintOfTheDay() {
 
   async function handleShare() {
     if (!data) return
-    const text = `Perth Pint Prices Pint of the Day\n\n${data.pub.name}, ${data.pub.suburb}\n$${data.pub.effectivePrice.toFixed(2)} pint${data.pub.beerType ? ` (${data.pub.beerType})` : ''}\n${data.reason}\n\nhttps://perthpintprices.com/${toSuburbSlug(data.pub.suburb)}/${data.pub.slug}`
+    const text = `Perth Pint Prices Pint of the Day\n\n${data.pub.name}, ${data.pub.suburb}\n$${data.pub.effectivePrice.toFixed(2)} pint${data.pub.beerType ? ` (${data.pub.beerType})` : ''}\n${data.reason}\n\n${absolutePubUrl(data.pub)}`
     
     try {
       await navigator.clipboard.writeText(text)
@@ -111,7 +108,7 @@ export default function PintOfTheDay() {
       </div>
 
       {/* Main card */}
-      <Link href={`/${toSuburbSlug(data.pub.suburb)}/${data.pub.slug}`} className="block px-4 sm:px-5 pb-4 sm:pb-5 group">
+      <Link href={pubUrl(data.pub)} className="block px-4 sm:px-5 pb-4 sm:pb-5 group">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
             <h4 className="text-lg font-bold font-heading text-ink group-hover:text-amber transition-colors truncate">{data.pub.name}</h4>

--- a/src/components/PubCardList.tsx
+++ b/src/components/PubCardList.tsx
@@ -5,10 +5,7 @@ import { CrowdReport } from '@/lib/supabase'
 import { getDistanceKm, formatDistance } from '@/lib/location'
 import Link from 'next/link'
 import { Beer, Star } from 'lucide-react'
-
-function toSuburbSlug(suburb: string): string {
-  return suburb.toLowerCase().replace(/['']/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-}
+import { pubUrl } from '@/lib/urls'
 
 interface PubCardListProps {
   pubs: Pub[]
@@ -61,7 +58,7 @@ export default function PubCardList({
         return (
           <Link
             key={pub.id}
-            href={`/${toSuburbSlug(pub.suburb)}/${pub.slug}`}
+            href={pubUrl(pub)}
             className={`flex items-baseline justify-between py-3.5 px-2.5 -mx-2.5 border-b border-gray-light rounded-lg cursor-pointer no-underline text-ink hover:bg-off-white transition-colors ${
               isFirst ? 'border-l-[4px] border-l-amber bg-amber-pale/30 ml-0 pl-3' : ''
             }`}

--- a/src/components/PuntNPints.tsx
+++ b/src/components/PuntNPints.tsx
@@ -5,10 +5,7 @@ import { useState, useMemo, useEffect } from 'react'
 import { Pub } from '@/types/pub'
 import { getDistanceKm, formatDistance } from '@/lib/location'
 import { Trophy, Zap, Dog, ExternalLink } from 'lucide-react'
-
-function toSuburbSlug(suburb: string): string {
-  return suburb.toLowerCase().replace(/['']/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-}
+import { pubUrl } from '@/lib/urls'
 
 interface TabLocation {
   id: number
@@ -197,7 +194,7 @@ export default function PuntNPints({ pubs, userLocation }: PuntNPintsProps) {
             return (
               <Link
                 key={pub.id}
-                href={`/${toSuburbSlug(pub.suburb)}/${pub.slug}`}
+                href={pubUrl(pub)}
                 className={`flex items-center justify-between px-4 py-3.5 no-underline group ${
                   i > 0 ? 'border-t border-gray-light' : ''
                 } ${i === 0 ? 'bg-amber/5' : ''}`}
@@ -277,7 +274,7 @@ export default function PuntNPints({ pubs, userLocation }: PuntNPintsProps) {
               return (
                 <Link
                   key={pub.id}
-                  href={`/${toSuburbSlug(pub.suburb)}/${pub.slug}`}
+                  href={pubUrl(pub)}
                   className={`flex items-center justify-between px-4 py-3.5 no-underline group ${
                     i > 0 ? 'border-t border-gray-light' : ''
                   }`}

--- a/src/components/RainyDay.tsx
+++ b/src/components/RainyDay.tsx
@@ -5,10 +5,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { Pub } from '@/types/pub'
 import { getDistanceKm, formatDistance } from '@/lib/location'
 import { CloudRain, Coffee, Droplets } from 'lucide-react'
-
-function toSuburbSlug(suburb: string): string {
-  return suburb.toLowerCase().replace(/['']/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-}
+import { pubUrl } from '@/lib/urls'
 
 interface RainyDayProps {
   pubs: Pub[]
@@ -207,7 +204,7 @@ export default function RainyDay({ pubs, userLocation }: RainyDayProps) {
               {cozyPubs.map((pub, index) => (
                 <Link
                   key={pub.id}
-                  href={`/${toSuburbSlug(pub.suburb)}/${pub.slug}`}
+                  href={pubUrl(pub)}
                   className={`flex items-center gap-3 px-3 py-3 no-underline group ${
                     index > 0 ? 'border-t border-gray-light' : ''
                   } ${index === 0 ? 'bg-amber/5' : ''}`}

--- a/src/components/SuburbLeague.tsx
+++ b/src/components/SuburbLeague.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react'
 import Link from 'next/link'
 import { Pub } from '@/types/pub'
 import { BarChart3 } from 'lucide-react'
+import { suburbUrl } from '@/lib/urls'
 
 interface SuburbStats {
   suburb: string
@@ -18,10 +19,6 @@ interface SuburbStats {
 type RowItem =
   | { type: 'divider'; label: string; colorClass: string }
   | { type: 'suburb'; pos: number; stats: SuburbStats; rowBg: string }
-
-function toSlug(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-}
 
 export default function SuburbLeague({ pubs }: { pubs: Pub[] }) {
   const [isExpanded, setIsExpanded] = useState(true)
@@ -196,7 +193,7 @@ export default function SuburbLeague({ pubs }: { pubs: Pub[] }) {
                     <tr key={s.suburb} className={rowBg}>
                       <td className="px-2 py-2 text-center font-mono font-bold text-gray-mid text-[0.7rem]">{pos}</td>
                       <td className="px-2 py-2 text-left">
-                        <Link href={`/${toSlug(s.suburb)}`} className="font-body text-sm font-bold text-ink hover:text-amber transition-colors no-underline">{s.suburb}</Link>
+                        <Link href={suburbUrl(s.suburb)} className="font-body text-sm font-bold text-ink hover:text-amber transition-colors no-underline">{s.suburb}</Link>
                         <span className="font-mono text-[0.6rem] text-gray-mid ml-1">({s.pubCount})</span>
                       </td>
                       <td className="px-2 py-2 text-center font-mono font-bold text-ink text-sm">${s.avgPrice.toFixed(2)}</td>

--- a/src/components/SunsetSippers.tsx
+++ b/src/components/SunsetSippers.tsx
@@ -6,10 +6,7 @@ import dynamic from 'next/dynamic'
 import { Pub } from '@/types/pub'
 import { getDistanceKm, formatDistance } from '@/lib/location'
 import { Sun, Sunset, Moon, Beer } from 'lucide-react'
-
-function toSuburbSlug(suburb: string): string {
-  return suburb.toLowerCase().replace(/['']/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-}
+import { pubUrl } from '@/lib/urls'
 
 const MiniMap = dynamic(() => import('./MiniMap'), {
   ssr: false,
@@ -326,7 +323,7 @@ export default function SunsetSippers({ pubs, userLocation }: SunsetSippersProps
             return (
               <Link
                 key={pub.id}
-                href={`/${toSuburbSlug(pub.suburb)}/${pub.slug}`}
+                href={pubUrl(pub)}
                 className="border-3 border-ink rounded-card shadow-hard-sm bg-white overflow-hidden no-underline group"
                 onClick={(e) => e.stopPropagation()}
               >

--- a/src/components/TonightsMoves.tsx
+++ b/src/components/TonightsMoves.tsx
@@ -7,10 +7,7 @@ import { Pub } from '@/types/pub'
 import { getHappyHourStatus } from '@/lib/happyHour'
 import { getDistanceKm, formatDistance } from '@/lib/location'
 import { Clock, Star, TrendingDown, PartyPopper, Flame, Moon } from 'lucide-react'
-
-function toSuburbSlug(suburb: string): string {
-  return suburb.toLowerCase().replace(/['']/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-}
+import { pubUrl } from '@/lib/urls'
 
 interface TonightsMovesProps {
   pubs: Pub[]
@@ -159,7 +156,7 @@ export default function TonightsMoves({ pubs, userLocation }: TonightsMovesProps
                 </h4>
                 <div className="flex items-center justify-between">
                   <div>
-                    <Link href={`/${toSuburbSlug(marketTip.suburb)}/${marketTip.slug}`} className="font-body text-sm font-bold text-ink hover:text-amber transition-colors no-underline">{marketTip.name}</Link>
+                    <Link href={pubUrl(marketTip)} className="font-body text-sm font-bold text-ink hover:text-amber transition-colors no-underline">{marketTip.name}</Link>
                     <p className="font-body text-[0.7rem] text-gray-mid">{marketTip.suburb}{userLocation && ` · ${formatDistance(getDistanceKm(userLocation.lat, userLocation.lng, marketTip.lat, marketTip.lng))}`} · {marketTip.beerType}</p>
                   </div>
                   <div className="text-right">
@@ -179,7 +176,7 @@ export default function TonightsMoves({ pubs, userLocation }: TonightsMovesProps
               </h4>
               <div className="space-y-0">
                 {bestBuys.map((pub, i) => (
-                  <Link key={pub.id} href={`/${toSuburbSlug(pub.suburb)}/${pub.slug}`} className={`flex items-center justify-between px-3 py-2.5 no-underline group ${i > 0 ? 'border-t border-gray-light' : ''} ${i === 0 ? 'bg-amber/5' : ''}`}>
+                  <Link key={pub.id} href={pubUrl(pub)} className={`flex items-center justify-between px-3 py-2.5 no-underline group ${i > 0 ? 'border-t border-gray-light' : ''} ${i === 0 ? 'bg-amber/5' : ''}`}>
                     <div className="flex items-center gap-2 min-w-0">
                       <span className={`font-mono text-[0.65rem] font-bold w-4 ${i === 0 ? 'text-amber' : 'text-gray-mid'}`}>{i === 0 ? '\u2605' : `${i + 1}`}</span>
                       <div className="min-w-0">
@@ -203,7 +200,7 @@ export default function TonightsMoves({ pubs, userLocation }: TonightsMovesProps
                   {activeDeals.slice(0, 10).map((pub, i) => {
                     const status = getHappyHourStatus(pub.happyHour)
                     return (
-                      <Link key={pub.id} href={`/${toSuburbSlug(pub.suburb)}/${pub.slug}`} className={`flex items-center justify-between px-3 py-2.5 no-underline group ${i > 0 ? 'border-t border-gray-light' : ''}`}>
+                      <Link key={pub.id} href={pubUrl(pub)} className={`flex items-center justify-between px-3 py-2.5 no-underline group ${i > 0 ? 'border-t border-gray-light' : ''}`}>
                         <div className="min-w-0">
                           <span className="font-body text-sm font-bold text-ink group-hover:text-amber transition-colors truncate block">{pub.name}</span>
                           <p className="font-body text-[0.7rem] text-gray-mid">{pub.suburb}{userLocation && ` · ${formatDistance(getDistanceKm(userLocation.lat, userLocation.lng, pub.lat, pub.lng))}`}</p>
@@ -231,7 +228,7 @@ export default function TonightsMoves({ pubs, userLocation }: TonightsMovesProps
                   {upcomingDeals.map((pub, i) => {
                     const status = getHappyHourStatus(pub.happyHour)
                     return (
-                      <Link key={pub.id} href={`/${toSuburbSlug(pub.suburb)}/${pub.slug}`} className={`flex items-center justify-between px-3 py-2.5 no-underline group ${i > 0 ? 'border-t border-gray-light' : ''}`}>
+                      <Link key={pub.id} href={pubUrl(pub)} className={`flex items-center justify-between px-3 py-2.5 no-underline group ${i > 0 ? 'border-t border-gray-light' : ''}`}>
                         <div className="min-w-0">
                           <span className="font-body text-sm font-bold text-ink group-hover:text-amber transition-colors truncate block">{pub.name}</span>
                           <p className="font-body text-[0.7rem] text-gray-mid">{pub.suburb}{userLocation && ` · ${formatDistance(getDistanceKm(userLocation.lat, userLocation.lng, pub.lat, pub.lng))}`}</p>

--- a/src/components/VenueIntel.tsx
+++ b/src/components/VenueIntel.tsx
@@ -6,10 +6,7 @@ import { useState, useMemo } from 'react'
 import { Pub } from '@/types/pub'
 import { getDistanceKm, formatDistance } from '@/lib/location'
 import { BarChart3, TrendingDown, TrendingUp } from 'lucide-react'
-
-function toSuburbSlug(suburb: string): string {
-  return suburb.toLowerCase().replace(/['']/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-}
+import { pubUrl } from '@/lib/urls'
 
 interface VenueIntelProps {
   pubs: Pub[]
@@ -180,7 +177,7 @@ export default function VenueIntel({ pubs, userLocation }: VenueIntelProps) {
                 </h4>
                 <div className="space-y-0">
                   {undervalued.map(({ pub, diff }, i) => (
-                    <Link key={pub.id} href={`/${toSuburbSlug(pub.suburb)}/${pub.slug}`} className={`flex items-center justify-between px-3 py-2.5 no-underline group ${i > 0 ? 'border-t border-gray-light' : ''}`}>
+                    <Link key={pub.id} href={pubUrl(pub)} className={`flex items-center justify-between px-3 py-2.5 no-underline group ${i > 0 ? 'border-t border-gray-light' : ''}`}>
                       <div className="min-w-0">
                         <span className="font-body text-[0.8rem] font-bold text-ink group-hover:text-amber transition-colors truncate block">{pub.name}</span>
                         <p className="font-body text-[0.7rem] text-gray-mid">{pub.suburb}{userLocation && ` · ${formatDistance(getDistanceKm(userLocation.lat, userLocation.lng, pub.lat, pub.lng))}`}</p>
@@ -200,7 +197,7 @@ export default function VenueIntel({ pubs, userLocation }: VenueIntelProps) {
                 </h4>
                 <div className="space-y-0">
                   {overvalued.map(({ pub, diff }, i) => (
-                    <Link key={pub.id} href={`/${toSuburbSlug(pub.suburb)}/${pub.slug}`} className={`flex items-center justify-between px-3 py-2.5 no-underline group ${i > 0 ? 'border-t border-gray-light' : ''}`}>
+                    <Link key={pub.id} href={pubUrl(pub)} className={`flex items-center justify-between px-3 py-2.5 no-underline group ${i > 0 ? 'border-t border-gray-light' : ''}`}>
                       <div className="min-w-0">
                         <span className="font-body text-[0.8rem] font-bold text-ink group-hover:text-amber transition-colors truncate block">{pub.name}</span>
                         <p className="font-body text-[0.7rem] text-gray-mid">{pub.suburb}{userLocation && ` · ${formatDistance(getDistanceKm(userLocation.lat, userLocation.lng, pub.lat, pub.lng))}`}</p>

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 import { Pub } from '@/types/pub'
 import { getHappyHourStatus } from '@/lib/happyHourLive'
+import { toSuburbSlug } from './urls'
 
 function titleCase(str: string): string {
   if (!str) return str
@@ -523,13 +524,10 @@ export interface SuburbInfo {
   happyHourCount: number
 }
 
-export function toSuburbSlug(suburb: string): string {
-  return suburb
-    .toLowerCase()
-    .replace(/['']/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-}
+// toSuburbSlug is the canonical URL-slug kernel; it now lives in ./urls (the
+// pure URL seam). Re-exported here so existing `@/lib/supabase` importers and
+// the internal getAllSuburbs() usage below keep working unchanged.
+export { toSuburbSlug }
 
 export async function getAllSuburbs(): Promise<SuburbInfo[]> {
   const pubs = await getPubs()

--- a/src/lib/urls.test.ts
+++ b/src/lib/urls.test.ts
@@ -1,0 +1,203 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { pubUrl, suburbUrl, absolutePubUrl, toSuburbSlug } from './urls'
+
+// SEO TRIPWIRE — frozen snapshot of every live suburb's URL slug, captured
+// 2026-05-30 from the production `pubs` table (150 distinct suburbs). Pub and
+// suburb pages are statically generated at these exact paths and are indexed by
+// Google. If a change to the slug logic alters even one of these, it silently
+// 404s a live, indexed URL. This test must fail FIRST when that happens. Do not
+// edit the snapshot to make it pass unless you intend to change live URLs and
+// have a redirect plan. (Adding new suburbs over time is fine — they just are
+// not covered here until added.)
+const LIVE_SUBURB_SLUGS: Record<string, string> = {
+  "Alkimos": "alkimos",
+  "Applecross": "applecross",
+  "Ardross": "ardross",
+  "Armadale": "armadale",
+  "Ashby": "ashby",
+  "Attadale": "attadale",
+  "Balcatta": "balcatta",
+  "Baldivis": "baldivis",
+  "Ballajura": "ballajura",
+  "Baskerville": "baskerville",
+  "Bassendean": "bassendean",
+  "Bayswater": "bayswater",
+  "Bedfordale": "bedfordale",
+  "Beechboro": "beechboro",
+  "Belmont": "belmont",
+  "Bentley": "bentley",
+  "Bibra Lake": "bibra-lake",
+  "Bicton": "bicton",
+  "Bull Creek": "bull-creek",
+  "Burswood": "burswood",
+  "Calista": "calista",
+  "Canning Vale": "canning-vale",
+  "Cannington": "cannington",
+  "Carlisle": "carlisle",
+  "Carmel": "carmel",
+  "Carramar": "carramar",
+  "Casuarina": "casuarina",
+  "Caversham": "caversham",
+  "Chidlow": "chidlow",
+  "City Beach": "city-beach",
+  "Claremont": "claremont",
+  "Clarkson": "clarkson",
+  "Cloverdale": "cloverdale",
+  "Cockburn Central": "cockburn-central",
+  "Como": "como",
+  "Connolly": "connolly",
+  "Cooloongup": "cooloongup",
+  "Cottesloe": "cottesloe",
+  "Craigie": "craigie",
+  "Crawley": "crawley",
+  "Currambine": "currambine",
+  "Darch": "darch",
+  "Dawesville": "dawesville",
+  "Dianella": "dianella",
+  "Doubleview": "doubleview",
+  "Duncraig": "duncraig",
+  "East Fremantle": "east-fremantle",
+  "East Perth": "east-perth",
+  "East Victoria Park": "east-victoria-park",
+  "Ellenbrook": "ellenbrook",
+  "Floreat": "floreat",
+  "Forrestdale": "forrestdale",
+  "Forrestfield": "forrestfield",
+  "Fremantle": "fremantle",
+  "Gidgegannup": "gidgegannup",
+  "Girrawheen": "girrawheen",
+  "Gnangara": "gnangara",
+  "Gosnells": "gosnells",
+  "Greenwood": "greenwood",
+  "Guildford": "guildford",
+  "Hamilton Hill": "hamilton-hill",
+  "Hammond Park": "hammond-park",
+  "Henley Brook": "henley-brook",
+  "High Wycombe": "high-wycombe",
+  "Highgate": "highgate",
+  "Hillarys": "hillarys",
+  "Iluka": "iluka",
+  "Inglewood": "inglewood",
+  "Innaloo": "innaloo",
+  "Joondalup": "joondalup",
+  "Kalamunda": "kalamunda",
+  "Karrinyup": "karrinyup",
+  "Lathlain": "lathlain",
+  "Leederville": "leederville",
+  "Leeming": "leeming",
+  "Maddington": "maddington",
+  "Maida Vale": "maida-vale",
+  "Malaga": "malaga",
+  "Mandurah": "mandurah",
+  "Marangaroo": "marangaroo",
+  "Maylands": "maylands",
+  "Meadow Springs": "meadow-springs",
+  "Middle Swan": "middle-swan",
+  "Midland": "midland",
+  "Midvale": "midvale",
+  "Mindarie": "mindarie",
+  "Morley": "morley",
+  "Mosman Park": "mosman-park",
+  "Mount Hawthorn": "mount-hawthorn",
+  "Mount Helena": "mount-helena",
+  "Mount Lawley": "mount-lawley",
+  "Mullaloo": "mullaloo",
+  "Mundaring": "mundaring",
+  "Murdoch": "murdoch",
+  "Myaree": "myaree",
+  "Nedlands": "nedlands",
+  "Neerabup": "neerabup",
+  "North Beach": "north-beach",
+  "North Fremantle": "north-fremantle",
+  "North Perth": "north-perth",
+  "Northbridge": "northbridge",
+  "O'Connor": "oconnor",
+  "Ocean Reef": "ocean-reef",
+  "Osborne Park": "osborne-park",
+  "Parkerville": "parkerville",
+  "Parkwood": "parkwood",
+  "Peppermint Grove": "peppermint-grove",
+  "Perth": "perth",
+  "Perth Airport": "perth-airport",
+  "Perth CBD": "perth-cbd",
+  "Piara Waters": "piara-waters",
+  "Pickering Brook": "pickering-brook",
+  "Port Kennedy": "port-kennedy",
+  "Rivervale": "rivervale",
+  "Rockingham": "rockingham",
+  "Roleystone": "roleystone",
+  "Scarborough": "scarborough",
+  "Secret Harbour": "secret-harbour",
+  "Serpentine": "serpentine",
+  "Shoalwater": "shoalwater",
+  "South Fremantle": "south-fremantle",
+  "South Lake": "south-lake",
+  "South Perth": "south-perth",
+  "Southern River": "southern-river",
+  "Spearwood": "spearwood",
+  "Subiaco": "subiaco",
+  "Success": "success",
+  "Swan Valley": "swan-valley",
+  "Swan View": "swan-view",
+  "Swanbourne": "swanbourne",
+  "The Vines": "the-vines",
+  "Thornlie": "thornlie",
+  "Trigg": "trigg",
+  "Victoria Park": "victoria-park",
+  "Wangara": "wangara",
+  "Wanneroo": "wanneroo",
+  "Warnbro": "warnbro",
+  "Watermans Bay": "watermans-bay",
+  "Wattle Grove": "wattle-grove",
+  "Wellard": "wellard",
+  "Wembley": "wembley",
+  "Wembley Downs": "wembley-downs",
+  "West Leederville": "west-leederville",
+  "West Perth": "west-perth",
+  "Woodlands": "woodlands",
+  "Woodvale": "woodvale",
+  "Wooroloo": "wooroloo",
+  "Yanchep": "yanchep",
+  "Yangebup": "yangebup",
+  "Yokine": "yokine",
+}
+
+describe('live suburb slug snapshot (URL regression guard)', () => {
+  for (const [name, slug] of Object.entries(LIVE_SUBURB_SLUGS)) {
+    it(`${name} -> /${slug}`, () => {
+      assert.equal(toSuburbSlug(name), slug)
+      assert.equal(suburbUrl(name), `/${slug}`)
+    })
+  }
+})
+
+describe('toSuburbSlug edge cases', () => {
+  it("strips a straight apostrophe rather than hyphenating it (O'Connor -> oconnor)", () => {
+    // The single live case that distinguishes the canonical slug from the old
+    // SuburbLeague variant, which produced the now-404 \"o-connor\".
+    assert.equal(toSuburbSlug("O'Connor"), 'oconnor')
+  })
+  it('collapses internal whitespace and punctuation runs to one hyphen', () => {
+    assert.equal(toSuburbSlug('Mount   Lawley'), 'mount-lawley')
+  })
+  it('lowercases and trims leading/trailing separators', () => {
+    assert.equal(toSuburbSlug(' South Perth '), 'south-perth')
+  })
+})
+
+describe('url builders', () => {
+  it('pubUrl builds /{suburb-slug}/{pub-slug}', () => {
+    assert.equal(pubUrl({ suburb: "O'Connor", slug: 'the-local' }), '/oconnor/the-local')
+  })
+  it('suburbUrl passes through an already-slugged value when isSlug=true', () => {
+    assert.equal(suburbUrl('south-perth', true), '/south-perth')
+  })
+  it('absolutePubUrl prefixes the production origin', () => {
+    assert.equal(
+      absolutePubUrl({ suburb: 'Fremantle', slug: 'the-norfolk-hotel' }),
+      'https://perthpintprices.com/fremantle/the-norfolk-hotel',
+    )
+  })
+})

--- a/src/lib/urls.test.ts
+++ b/src/lib/urls.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { pubUrl, suburbUrl, absolutePubUrl, toSuburbSlug } from './urls'
+import { pubUrl, suburbUrl, absolutePubUrl, absoluteSuburbUrl, toSuburbSlug } from './urls'
 
 // SEO TRIPWIRE — frozen snapshot of every live suburb's URL slug, captured
 // 2026-05-30 from the production `pubs` table (150 distinct suburbs). Pub and
@@ -199,5 +199,8 @@ describe('url builders', () => {
       absolutePubUrl({ suburb: 'Fremantle', slug: 'the-norfolk-hotel' }),
       'https://perthpintprices.com/fremantle/the-norfolk-hotel',
     )
+  })
+  it('absoluteSuburbUrl prefixes the production origin (input is already a slug)', () => {
+    assert.equal(absoluteSuburbUrl('oconnor'), 'https://perthpintprices.com/oconnor')
   })
 })

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -1,13 +1,29 @@
-import { toSuburbSlug } from './supabase'
-
 const BASE_URL = 'https://perthpintprices.com'
+
+/**
+ * Canonical suburb -> URL slug for every pub and suburb page on the site.
+ * Lowercases, strips straight apostrophes, collapses any other non-alphanumeric
+ * run to a single hyphen, then trims leading/trailing hyphens.
+ *
+ * This is the single source of truth for the site's live, Google-indexed URLs,
+ * so its output is pinned byte-for-byte by urls.test.ts. It lives here (not in
+ * supabase.ts) so this URL seam is a pure, dependency-free kernel; supabase.ts
+ * imports and re-exports it for back-compat.
+ */
+export function toSuburbSlug(suburb: string): string {
+  return suburb
+    .toLowerCase()
+    .replace(/['']/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+}
 
 /** Build a relative pub URL: /{suburb-slug}/{pub-slug} */
 export function pubUrl(pub: { slug: string; suburb: string }): string {
   return `/${toSuburbSlug(pub.suburb)}/${pub.slug}`
 }
 
-/** Build a relative suburb URL: /{suburb-slug} */
+/** Build a relative suburb URL: /{suburb-slug}. Pass isSlug=true if the input is already a slug. */
 export function suburbUrl(suburbSlugOrName: string, isSlug = false): string {
   return `/${isSlug ? suburbSlugOrName : toSuburbSlug(suburbSlugOrName)}`
 }

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -1,4 +1,5 @@
-const BASE_URL = 'https://perthpintprices.com'
+/** Canonical production origin — the single source of truth for absolute URLs. */
+export const BASE_URL = 'https://perthpintprices.com'
 
 /**
  * Canonical suburb -> URL slug for every pub and suburb page on the site.


### PR DESCRIPTION
**Phase 1 of the architecture refactor.** Collapses 14 copy-pasted suburb-slug functions into a single source of truth and routes every pub/suburb link through the `urls.ts` seam.

## What changed
- **One slug kernel.** `toSuburbSlug` now lives in the pure `urls.ts` seam (it was in `supabase.ts` — a backwards dependency for a URL helper). `supabase.ts` imports + re-exports it for back-compat.
- **Deleted 13 byte-identical inline `toSuburbSlug` copies** across components and pages; links now use `pubUrl` / `suburbUrl` / `absolutePubUrl`.
- **Fixed a live 404.** `SuburbLeague` had a *divergent* `toSlug` that omitted the apostrophe-strip, so it linked `O'Connor` to `/o-connor` (404) instead of the real `/oconnor`. Now via `suburbUrl` → `/oconnor`.
- **SEO tripwire.** `urls.test.ts` snapshots all **150 live production suburb slugs** (captured from Supabase). Any future slug-logic change that would move an indexed URL fails CI first.
- Trimmed 3 pre-existing dead seam imports in `[suburb]/page.tsx`.

The only remaining raw `toSuburbSlug` callers are `generateStaticParams` and the redirect guard in `[suburb]/[pub]/page.tsx`, which legitimately need the bare slug (not a URL).

## Verification
- `tsc --noEmit` clean
- **166/166 tests pass** — snapshot stable ⇒ **zero URL drift** for all 150 live suburbs
- `next build` green with `SUPABASE_SERVICE_ROLE_KEY` unset (CI-equivalent)
- `sitemap.xml`: 1022 canonical URLs, `/oconnor` present, **`/o-connor` count = 0**
- Routes resolve: `/oconnor` 200, pub page 200, legacy `/pub/*` 301

🤖 Generated with [Claude Code](https://claude.com/claude-code)