### PR TITLE
docs: accuracy sweep — reconcile docs + issues with live state (2026-05-31)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Perth Pint Prices
 
 ## Project overview
-Perth Pint Prices (perthpintprices.com) tracks pint prices across 300+ Perth pubs. Users discover cheap pints, find happy hours, plan pub crawls, and report prices.
+Perth Pint Prices (perthpintprices.com) tracks pint prices across 300+ Perth pubs. Users discover cheap pints, find happy hours, and report prices.
 
 - **Stack:** Next.js 14 (App Router), Tailwind CSS, TypeScript strict, Supabase
 - **Hosting:** Vercel (auto-deploys from `main`), dev server on port 3001
@@ -17,11 +17,11 @@ Perth Pint Prices (perthpintprices.com) tracks pint prices across 300+ Perth pub
 - `phone_call_log` — full transcript + cost log of every Andrew call (post-call webhook)
 - `push_subscriptions` — web push notification subscribers
 
-## Routes (19 pages)
+## Routes (17 content pages + 4 redirects)
 - **Core:** `/` homepage, `/discover`, `/happy-hour`, `/[suburb]/[pub]` (e.g. `/fremantle/the-norfolk-hotel`), `/[suburb]` (e.g. `/fremantle`), `/suburbs`
-- **Legacy redirect stubs:** `/pub/[slug]` and `/suburb/[slug]` return 308 redirects to the current URL structure
-- **Guides (5):** `/guides` index, `/guides/beer-weather`, `/guides/cozy-corners`, `/guides/dad-bar`, `/guides/punt-and-pints`, `/guides/sunset-sippers`
-- **Insights (5):** `/insights` index, `/insights/pint-index`, `/insights/pint-of-the-day`, `/insights/suburb-rankings`, `/insights/tonights-best-bets`, `/insights/venue-breakdown`
+- **Legacy redirect stubs:** `/pub/[slug]` and `/suburb/[slug]` return 301 redirects to the current URL structure
+- **Guides:** `/guides` 308-redirects to `/discover`; the 5 guide pages are `/guides/beer-weather`, `/guides/cozy-corners`, `/guides/dad-bar`, `/guides/punt-and-pints`, `/guides/sunset-sippers`
+- **Insights:** `/insights` 308-redirects to `/discover`; the 5 insight pages are `/insights/pint-index`, `/insights/pint-of-the-day`, `/insights/suburb-rankings`, `/insights/tonights-best-bets`, `/insights/venue-breakdown`
 - **Admin:** `/admin`
 
 ## Components (32 in `src/components/`)
@@ -32,8 +32,10 @@ BeerWeather, BreadcrumbJsonLd, CrowdReporter, DadBar, ErrorBoundary, FAQ, Featur
 - `SubPageNav` for breadcrumb navigation on sub-pages
 - `BreadcrumbJsonLd` for schema.org breadcrumb structured data (uses `url` property, not `item`)
 
-## Lib files (11 in `src/lib/`)
-freshness, happyHour, happyHourLive, location, mapTheme, mapTile, perthClock, priceLabel, sunPosition, supabase, utils
+## Lib files (13 in `src/lib/`)
+freshness, happyHour, happyHourLive, location, mapTheme, mapTile, perthClock, priceLabel, sunPosition, supabase, supabaseGateway, urls, utils
+
+(`supabaseGateway` = `anonClient()` / `serviceClient()` seam; `urls` = canonical suburb-slug + pub/suburb URL builders. `happyHour` + `happyHourLive` both still exist — the HappyHourEngine consolidation is still pending.)
 
 ## API routes
 - **User-facing**: `/api/pubs`, `/api/price-report`, `/api/pub-submission`, `/api/menu-scan`, `/api/pint-of-the-day`
@@ -92,4 +94,4 @@ freshness, happyHour, happyHourLive, location, mapTheme, mapTile, perthClock, pr
 - Container: `max-w-container` (800px) with `px-6`
 - All pages must include `<Footer />`
 - Sub-pages use `<SubPageNav />` for header
-- Homepage header has 3 nav links: Discover, Happy Hours, Pint Report
+- Homepage nav (`MobileNav`) has 2 links — Discover, Happy Hours — plus a "Submit a Price" CTA

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Tailwind CSS](https://img.shields.io/badge/Tailwind-CSS-38bdf8)](https://tailwindcss.com)
 [![Supabase](https://img.shields.io/badge/Supabase-postgres-3ecf8e)](https://supabase.com)
 
-Perth's pint prices, sorted. A community-data site tracking pint prices across **300+ Perth pubs** so locals can find a cheap one, plan a pub crawl, and check happy hours.
+Perth's pint prices, sorted. A community-data site tracking pint prices across **300+ Perth pubs** so locals can find a cheap one and check happy hours.
 
 > Live at **[perthpintprices.com](https://perthpintprices.com)**
 
@@ -53,7 +53,7 @@ npm start        # serve the prod build
 
 ## Routes
 
-23 pages including suburb / pub silo (`/[suburb]/[pub]`), guides, insights, the Pint Index, weekly report, leaderboard, pub crawl, pub golf. Full route list lives in [`CLAUDE.md`](./CLAUDE.md).
+~17 content pages — the suburb / pub silo (`/[suburb]/[pub]`, `/[suburb]`), guides, and insights (incl. the Pint Index) — plus legacy `/pub/*` and `/suburb/*` redirects. Full route list lives in [`CLAUDE.md`](./CLAUDE.md).
 
 ## Reference docs
 

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,7 +10,7 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
-### Documentation accuracy sweep (2026-05-31)
+### Documentation accuracy sweep (2026-05-31, PR #55)
 - Audited every doc, the repo, and the open issues against what's actually live, then corrected or deprecated the drift. **Docs + issue metadata only — no code changes.**
 - **CLAUDE.md / README:** lib count 11→13 (added `supabaseGateway`, `urls`); legacy `/pub`+`/suburb` stubs corrected 308→**301**; `/guides`+`/insights` noted as 308-redirects to `/discover`; homepage nav fixed (no "Pint Report" — it's Discover + Happy Hours + a "Submit a Price" CTA); dropped stale "pub crawl / 23 pages / leaderboard / pub golf / weekly report" references.
 - **SEO-MASTER.md:** added a dated reconciliation banner; removed deleted features from the sitemap/ISR/keyword tables; repointed `/pub/[slug]`+`/suburb/[slug]` to the live `/[suburb]/[pub]`+`/[suburb]` routes; FID→**INP**; GBP marked deprioritised.

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -1,6 +1,6 @@
 # Perth Pint Prices Project Status
 
-Last updated: 2026-05-30
+Last updated: 2026-05-31
 
 ## What this is
 
@@ -9,6 +9,15 @@ Perth Pint Prices (perthpintprices.com) tracks pint prices across **857 Perth pu
 Stack, database, routes, components, and lib files are documented in `CLAUDE.md` (auto-loaded every session). This file covers history, recent work, and the backlog.
 
 ## What's done recently
+
+### Documentation accuracy sweep (2026-05-31)
+- Audited every doc, the repo, and the open issues against what's actually live, then corrected or deprecated the drift. **Docs + issue metadata only — no code changes.**
+- **CLAUDE.md / README:** lib count 11→13 (added `supabaseGateway`, `urls`); legacy `/pub`+`/suburb` stubs corrected 308→**301**; `/guides`+`/insights` noted as 308-redirects to `/discover`; homepage nav fixed (no "Pint Report" — it's Discover + Happy Hours + a "Submit a Price" CTA); dropped stale "pub crawl / 23 pages / leaderboard / pub golf / weekly report" references.
+- **SEO-MASTER.md:** added a dated reconciliation banner; removed deleted features from the sitemap/ISR/keyword tables; repointed `/pub/[slug]`+`/suburb/[slug]` to the live `/[suburb]/[pub]`+`/[suburb]` routes; FID→**INP**; GBP marked deprioritised.
+- **architecture-refactor-plan.html:** banner marking it **superseded** (CrawlPlanner/GolfScoring/Phase-6 moot post-deletion; CEO decisions resolved).
+- **seo-action-plan.md:** #1 (www→apex) downgraded — proven live that `www` already 308-redirects and 308 ≡ 301, so it's not the "biggest win"; #2 (legacy 301) marked **done**; #4 GA4 event list pruned of the deleted `pint_crawl_start`/`pub_golf_start`.
+- **Issues:** #25 corrected + downgraded; #28/#29/#31/#35 refreshed (deleted-feature refs removed, #31 unblocked).
+- Live verification today: 857 pubs (API), sitemap 1022 URLs and clean, all 4 deleted-feature routes 404, `/suburb/*`→301, `llms.txt` still 404 (#35 open), pub pages still missing FAQPage/MenuItem schema (#27/#29 open).
 
 ### Refactor Phase 2 (Pub mapper): one row→Pub mapper (2026-05-30)
 - **PR #52** (`39ef38d`). `getPubs` / `getPubBySlug` / `getNearbyPubs` / `getSimilarPricePubs` each carried a **byte-identical ~52-line block** that computed live happy-hour status + effective price and built the 30-field `Pub` object. Collapsed into a single `toPub(row)` in `src/lib/supabase.ts`; each accessor now delegates. **Net −133 lines**, behaviour unchanged.
@@ -123,7 +132,7 @@ Operating loop: each increment ships behind an independent code review + full ve
 
 ### SEO push — Q2 2026 (milestone #1, 11 open issues #25, #27–#36)
 See [`docs/seo-action-plan.md`](./seo-action-plan.md) for the prioritised punch list. Top of the list:
-- #25 Force www → apex 301 in Vercel (1h, p0) — board shows "In progress"; it's a manual Vercel setting the user owns
+- #25 www → apex (was p0) — **effectively resolved** (verified 2026-05-31): `www` already 308-redirects to apex and Google treats 308 as equivalent to a 301 (`vercel.json` is even set to 301). Downgraded; the only residual lever is a GSC reindex nudge, and it's not a ranking risk either way.
 - #27 Reclaim zero-click page-1 queries with answer-first blocks + FAQPage schema (4h, p1)
 - #28 Configure GA4 Key Events (30m, p1)
 - #29 Add answer-first block + MenuItem schema to all 300 pub pages (1-2d, p1)
@@ -155,12 +164,7 @@ See [`docs/seo-action-plan.md`](./seo-action-plan.md) for the prioritised punch 
 - #18 actions/setup-node 4 → 6
 
 ### Stale PRs to clean up (#1-#12)
-8 old PRs from Feb-Mar 2026 that have either been superseded by direct pushes or abandoned:
-- #12 Remove em dashes — done in `f3e93b5`
-- #9 Arvo restructure — superseded
-- #8 PintDex rebrand — superseded
-- #6 CLAUDE.md PR — superseded by direct commits
-- #5, #4, #3, #2, #1 — old, likely superseded
+Done — all of those old Feb–Mar 2026 PRs are now closed; **0 open PRs ≤ #12** remain (verified 2026-05-31). Only the 7 Dependabot PRs below are open.
 
 ### Features (ideas, not committed)
 - Price alerts / watchlist notifications

--- a/docs/SEO-MASTER.md
+++ b/docs/SEO-MASTER.md
@@ -1,8 +1,16 @@
 # SEO Master Reference — Perth Pint Prices (perthpintprices.com)
 
-Last updated: 2026-03-08
+Last updated: 2026-03-08 · Reconciled 2026-05-31
 
 This is the SEO playbook for Perth Pint Prices. Reference this document before making any SEO-related changes. All best practices sourced from Backlinko (backlinko.com) unless noted otherwise.
+
+> **Note — 2026-05-31 reconciliation.** This March-2026 playbook has been corrected inline, but read these deltas first:
+> - **Deleted features:** pub-golf, pint-crawl, leaderboard, and the weekly "Pint Report" page were removed (2026-05). Ignore any lingering reference to them.
+> - **Route structure:** pub/suburb detail pages are now `/[suburb]/[pub]` and `/[suburb]`. The old `/pub/[slug]` and `/suburb/[slug]` are 301 redirect stubs; `/guides` and `/insights` now 308-redirect to `/discover`.
+> - **Core Web Vitals:** FID was retired — the live metric is **INP < 200ms**.
+> - **Google Business Profile:** deprioritised — a service-area aggregator can't rank in the local 3-pack (`seo-research-2026.md §1`).
+> - **www → apex:** already redirects (308, which Google treats as equivalent to a 301); it is not the "critical" win the older action plan implied.
+> - Current late-2026 landscape (AEO/GEO, MenuItem schema, Information Gain): see **`seo-research-2026.md`**. Live status: **`PROJECT-STATUS.md`**.
 
 ---
 
@@ -15,10 +23,10 @@ Dynamic XML sitemap with tiered priorities:
 | Priority | Routes |
 |----------|--------|
 | 1.0 | Homepage |
-| 0.9 | discover, insights, guides, happy-hour, pub-golf, pint-crawl |
+| 0.9 | discover, happy-hour |
 | 0.8 | pint-of-the-day, pint-index, tonights-best-bets, beer-weather, sunset-sippers, suburb pages |
 | 0.7 | suburb-rankings, venue-breakdown, punt-and-pints, dad-bar, cozy-corners |
-| 0.6 | leaderboard, individual pub pages |
+| 0.6 | individual pub pages |
 
 All entries use current timestamp for `lastModified`. Dynamic routes (pubs, suburbs) generated from Supabase at build time.
 
@@ -53,8 +61,8 @@ Every page has: title, description, canonical URL, Open Graph tags. All set via 
 | Page | Schema types |
 |------|-------------|
 | Homepage | WebSite |
-| Pub detail (`/pub/[slug]`) | BreadcrumbList + BarOrPub (address, geo, priceRange) |
-| Suburb detail (`/suburb/[slug]`) | BreadcrumbList + ItemList (all pubs ranked by price) |
+| Pub detail (`/[suburb]/[pub]`) | BreadcrumbList + BarOrPub (address, geo, priceRange) |
+| Suburb detail (`/[suburb]`) | BreadcrumbList + ItemList (all pubs ranked by price) |
 | All content pages | BreadcrumbList (via `BreadcrumbJsonLd` component) |
 
 ### ISR (Incremental Static Regeneration)
@@ -62,7 +70,6 @@ Every page has: title, description, canonical URL, Open Graph tags. All set via 
 | Revalidation | Pages |
 |-------------|-------|
 | 300s (5 min) | Homepage, pub pages, suburb pages, suburbs list |
-| 3600s (1 hr) | Weekly report, pub golf, pint crawl |
 
 ### Static pre-generation
 
@@ -91,8 +98,8 @@ Set on every page via `alternates: { canonical: '...' }`. Format: `https://perth
 | Issue | Impact | Fix |
 |-------|--------|-----|
 | Some page titles >60 chars | Get truncated in Google search results | Trim titles: "Perth Suburb Pint Price Rankings: Cheapest Suburbs for Beer \| Perth Pint Prices" is 67 chars |
-| No Google Business Profile | Missing from local search entirely | Create GBP as "service area business" — free, high impact |
-| /guides and /insights redirect to /discover | If these are 302s (not 301s), link equity doesn't pass | Verify they're 301 redirects |
+| No Google Business Profile | Missing from local search entirely | Deprioritised — a service-area aggregator can't rank in the local 3-pack (`seo-research-2026.md §1`) |
+| /guides and /insights redirect to /discover | — | Done: both use Next `permanentRedirect` (308; Google treats as equivalent to 301) |
 | No internal search logging | Don't know what users search for on the site | Log filter/search queries to understand demand |
 
 ### Low priority
@@ -112,16 +119,15 @@ Set on every page via `alternates: { canonical: '...' }`. Format: `https://perth
 |---------|--------------|----------------|----------|--------|
 | cheapest pints in perth | Transactional | Dedicated landing page or enhanced homepage | High | Not started |
 | perth happy hour deals | Transactional | `/happy-hour` — needs more text content | High | Page exists, needs content |
-| best pubs in northbridge | Local + informational | `/suburb/northbridge` — needs editorial content | High | Page exists, needs content |
-| best pubs in fremantle | Local + informational | `/suburb/fremantle` — needs editorial content | High | Page exists, needs content |
+| best pubs in northbridge | Local + informational | `/northbridge` — needs editorial content | High | Page exists, needs content |
+| best pubs in fremantle | Local + informational | `/fremantle` — needs editorial content | High | Page exists, needs content |
 | perth beer prices | Informational | `/insights/pint-index` — needs intro text | Medium | Page exists, needs content |
-| pub crawl perth | Transactional | `/pint-crawl` — needs intro text about popular routes | Medium | Page exists, needs content |
 | cheap drinks perth | Transactional | Broader version of cheapest pints page | Medium | Not started |
 | perth pub guide | Informational | `/discover` — needs intro paragraph | Medium | Page exists, needs content |
-| best pubs in scarborough | Local | `/suburb/scarborough` — needs editorial | Medium | Page exists, needs content |
-| best pubs in cottesloe | Local | `/suburb/cottesloe` — needs editorial | Medium | Page exists, needs content |
-| best pubs in subiaco | Local | `/suburb/subiaco` — needs editorial | Medium | Page exists, needs content |
-| best pubs in leederville | Local | `/suburb/leederville` — needs editorial | Medium | Page exists, needs content |
+| best pubs in scarborough | Local | `/scarborough` — needs editorial | Medium | Page exists, needs content |
+| best pubs in cottesloe | Local | `/cottesloe` — needs editorial | Medium | Page exists, needs content |
+| best pubs in subiaco | Local | `/subiaco` — needs editorial | Medium | Page exists, needs content |
+| best pubs in leederville | Local | `/leederville` — needs editorial | Medium | Page exists, needs content |
 | perth beer garden | Informational | `/guides/beer-weather` or new page | Low | Partial |
 
 ### Keyword research process (Backlinko)
@@ -276,7 +282,7 @@ Source: backlinko.com/link-building
 - [ ] **FAQPage schema** on homepage FAQ section
 - [ ] **Google Business Profile** setup
 - [ ] **Google Search Console** — submit sitemap, monitor indexation
-- [ ] **Core Web Vitals audit** — measure LCP, FID, CLS
+- [ ] **Core Web Vitals audit** — measure LCP, INP, CLS
 - [ ] **301 redirect verification** for /guides → /discover and /insights → /discover
 - [ ] **Title tag audit** — trim any over 60 characters
 - [ ] **Internal search logging** — capture user filter/search queries
@@ -288,7 +294,7 @@ Source: backlinko.com/link-building
 
 - **Crawlability**: Make sure Google can find and crawl all important pages. Sitemap + internal links are your two tools. Block what shouldn't be indexed (admin, API).
 - **Indexation**: Monitor Search Console for "Excluded" pages. Fix "Discovered — currently not indexed" issues by adding internal links and content.
-- **Site speed**: Core Web Vitals matter. LCP < 2.5s, FID < 100ms, CLS < 0.1. Use next/image, compress assets, minimise third-party scripts.
+- **Site speed**: Core Web Vitals matter. LCP < 2.5s, INP < 200ms, CLS < 0.1. Use next/image, compress assets, minimise third-party scripts.
 - **Mobile-first**: Google indexes mobile version first. Test all pages on mobile. Touch targets > 48px.
 - **Structured data**: Use schema.org markup for rich snippets. Test with Google Rich Results Test.
 - **Canonical tags**: One canonical per page. Prevents duplicate content issues.
@@ -354,7 +360,7 @@ Source: backlinko.com/technical-seo-guide
 - Crawlability: XML sitemap, clean robots.txt, internal linking
 - Structured data: schema.org markup for rich results
 - HTTPS: security signal, required for modern SEO
-- Core Web Vitals: LCP, FID, CLS — measure and optimise
+- Core Web Vitals: LCP, INP, CLS — measure and optimise
 
 ### Content marketing (backlinko.com/content-marketing-strategy)
 
@@ -391,8 +397,9 @@ Source: backlinko.com/technical-seo-guide
 | `src/app/robots.ts` | Robots.txt configuration |
 | `src/app/layout.tsx` | Global metadata, OG image, analytics |
 | `src/app/page.tsx` | Homepage metadata + WebSite JSON-LD |
-| `src/app/pub/[slug]/page.tsx` | Pub detail metadata + BarOrPub JSON-LD |
-| `src/app/suburb/[slug]/page.tsx` | Suburb metadata + ItemList JSON-LD |
+| `src/app/[suburb]/[pub]/page.tsx` | Pub detail metadata + BarOrPub JSON-LD |
+| `src/app/[suburb]/page.tsx` | Suburb metadata + ItemList JSON-LD |
+| `src/app/pub/[slug]/route.ts`, `src/app/suburb/[slug]/route.ts` | Legacy 301 redirect stubs |
 | `src/components/BreadcrumbJsonLd.tsx` | Reusable breadcrumb schema component |
 | `src/components/FAQ.tsx` | Homepage FAQ (needs FAQPage schema) |
 | `public/og-image.png` | Static OG image (1200x630) |

--- a/docs/architecture-refactor-plan.html
+++ b/docs/architecture-refactor-plan.html
@@ -159,6 +159,9 @@
 <header class="hero">
   <div class="wrap">
     <p class="eyebrow">Perth Pint Prices · Architecture Plan · 30 May 2026</p>
+    <div style="border:3px solid var(--ink);border-radius:12px;background:var(--amber-pale);box-shadow:3px 3px 0 var(--ink);padding:14px 18px;margin:18px 0 4px;font-family:var(--mono);font-size:.82rem;line-height:1.5">
+      <strong>SUPERSEDED — 2026-05-31.</strong> This is a frozen point-in-time plan; for current refactor status see <strong>docs/PROJECT-STATUS.md</strong>. Since it was written: Phases -1/0/1/2 + the RLS security lockdown shipped; the game features (pub-golf, pint-crawl) and the weekly report were <strong>deleted</strong>, so the <em>CrawlPlanner</em>, <em>GolfScoring</em> and "Phase 6 game teardown" sections below are moot; and both "CEO decisions" listed here are resolved. <strong>HappyHourEngine</strong> remains the genuine next item.
+    </div>
     <h1>The whole-app<br><em>module refactor.</em></h1>
     <p class="thesis">Perth Pint Prices doesn't have many architectural problems — it has about <strong>8 problems copy-pasted 50+ times</strong>. This plan collapses each cluster into one deep module behind a small interface, lands the first real test suite on a near-zero-test live site, and closes two security holes along the way. ~90% mechanical de-duplication, sequenced so the site stays shippable at every step.</p>
     <div class="stats">

--- a/docs/seo-action-plan.md
+++ b/docs/seo-action-plan.md
@@ -2,6 +2,13 @@
 
 Companion doc to `SEO-MASTER.md` (the playbook) and `seo-research-2026.md` (what's new in late-2026 SEO). This file is a **prioritised punch list** built from real GSC + GA4 data pulled today, ranked by ROI per hour of effort.
 
+> **Note — 2026-05-31 reconciliation.** Some items have since shipped or been re-scoped:
+> - **#1 (www→apex):** downgraded. Verified live that `www` already 308-redirects to apex, all canonicals point to apex, and Google treats 308 as equivalent to a 301 — so this is **not** the "single biggest mechanical win." The only residual lever is a GSC reindex nudge.
+> - **#2 (legacy /pub + /suburb → 301):** **done** (shipped 2026-05-03).
+> - **#4 (GA4 events):** drop `pint_crawl_start` and `pub_golf_start` — those features were deleted.
+> - References to a **weekly report** page (in #5/#8/#11) are moot — it was deleted; use the Pint Index as the Article-schema / PR asset.
+> - The GSC/GA4 numbers below are a dated 2026-04-27 snapshot.
+
 ---
 
 ## State of play (data, last 90 days)
@@ -39,17 +46,17 @@ Order is roughly **highest ROI per hour first**. Items 1–4 are technical bleed
 
 ---
 
-### 1. Fix the www vs apex canonical (1 hour) ⚠️ critical
+### 1. Fix the www vs apex canonical — RESOLVED / DOWNGRADED (see 2026-05-31 banner)
 
 **Evidence**: GSC top pages shows `https://www.perthpintprices.com/` with **23 clicks / 522 impressions** AND `https://perthpintprices.com/` with **15 clicks / 424 impressions**. They're competing for the same content. Plus 39 pages flagged as "Duplicate, Google chose different canonical than user".
 
 **Action**: Pick one (recommend apex `perthpintprices.com` since it matches your `metadataBase` in `src/app/layout.tsx`) and 301 every `www.*` request to apex. Vercel project settings → Domains → set apex as primary, redirect `www` → apex. After deploying, request reindex of homepage in GSC.
 
-**Expected impact**: Consolidates ~38 clicks and ~946 impressions onto one URL. Single biggest mechanical win.
+**Expected impact**: ~~Consolidates ~38 clicks and ~946 impressions onto one URL. Single biggest mechanical win.~~ **Correction (2026-05-31):** `www` already 308-redirects to apex and 308 is equivalent to 301 for Google, so there is no split to "consolidate" via a redirect change. Low/no remaining value, and not a ranking risk either way.
 
 ---
 
-### 2. Force the legacy `/pub/[slug]` and `/suburb/[slug]` to actually 301 (2 hours)
+### 2. Force the legacy `/pub/[slug]` and `/suburb/[slug]` to actually 301 (2 hours) — DONE (shipped 2026-05-03)
 
 **Evidence**: GSC top pages still shows `/suburb/fremantle` (41 imp, 2 clicks) outranking the new `/fremantle` (20 imp, 3 clicks). Same for `/pub/northbridge-brewing-company` (16 imp) and `/pub/ocean-beach-hotel` (15 imp). They're 308s per `SEO-MASTER.md §2`, but 308 doesn't pass authority as cleanly as 301 in the wild.
 
@@ -89,7 +96,7 @@ Order is roughly **highest ROI per hour first**. Items 1–4 are technical bleed
 **Action**: Set these as Key Events in GA4 → Admin → Events:
 - `view_pub` (when a user lands on a `/[suburb]/[pub]` page)
 - `report_price` (when the price-report form submits — already an event presumably)
-- `pint_crawl_start`, `pub_golf_start` (already engagement-driving)
+- ~~`pint_crawl_start`, `pub_golf_start`~~ (removed — these features were deleted)
 - `outbound_pub_link` (clicks to pub website)
 - `crowd_report_submit`
 - `install_pwa`


### PR DESCRIPTION
## What
Documentation accuracy sweep — reconciles all docs + open issues with what's actually live today (2026-05-31). **Docs + issue metadata only; zero code changes** (tsc green; scope = 6 doc files).

## Why
A fresh read of the docs against the running site surfaced drift from the recent refactor + feature-deletion work (PRs #43–#54), plus a stale "p0" SEO item (#25 www→apex) that a live check proved is a near-no-op.

## Changes
- **CLAUDE.md / README** — lib count 11→13 (+`supabaseGateway`, `urls`); legacy `/pub`+`/suburb` stubs 308→**301**; `/guides`+`/insights` documented as 308-redirects to `/discover`; homepage nav corrected (Discover + Happy Hours + "Submit a Price" CTA — "Pint Report" doesn't exist in `src/`); removed deleted-feature refs (pub crawl, leaderboard, pub golf, weekly report, "23 pages").
- **docs/SEO-MASTER.md** — dated reconciliation banner; deleted features removed from sitemap/ISR/keyword tables; `/pub/[slug]`+`/suburb/[slug]` repointed to live `/[suburb]/[pub]`+`/[suburb]`; FID→**INP**; GBP deprioritised.
- **docs/architecture-refactor-plan.html** — "superseded" banner (CrawlPlanner/GolfScoring/Phase-6 moot; CEO decisions resolved).
- **docs/seo-action-plan.md** — #1 (www→apex) downgraded + corrected; #2 (legacy 301) marked done; #4 GA4 events pruned of deleted features.
- **docs/PROJECT-STATUS.md** — date bump, stale-PR section closed (0 remain ≤#12), #25 corrected, sweep logged.

## Verification (live, 2026-05-31)
- 857 pubs (`/api/pubs`); sitemap 1022 URLs, zero `/pub/`·`/suburb/`·`/o-connor`·www·deleted-feature URLs
- `www`→apex = 308 (Google treats ≡ 301); `/suburb/*`→301; all 4 deleted-feature routes 404
- `llms.txt` 404 (#35 still open); pub pages have no FAQPage/MenuItem schema (#27/#29 still open)

GitHub issue edits (#25/#28/#29/#31/#35) are applied directly, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
