### PR TITLE
deps: bump lucide-react 1.11.0, twilio 6.0.0, @vercel/analytics 2.0.1 (consolidated)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.2.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.106.2",
-        "@vercel/analytics": "^1.6.1",
+        "@vercel/analytics": "^2.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "heic2any": "^0.0.4",
         "leaflet": "^1.9.4",
         "leaflet.markercluster": "^1.5.3",
-        "lucide-react": "^0.572.0",
+        "lucide-react": "^1.11.0",
         "next": "^14.2.35",
         "openai": "^6.39.1",
         "radix-ui": "^1.4.3",
@@ -25,7 +25,7 @@
         "react-leaflet-cluster": "^2.1.0",
         "tailwind-merge": "^3.6.0",
         "tailwindcss-animate": "^1.0.7",
-        "twilio": "^5.13.1",
+        "twilio": "^6.0.0",
         "web-push": "^3.6.7"
       },
       "devDependencies": {
@@ -3347,14 +3347,15 @@
       ]
     },
     "node_modules/@vercel/analytics": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
-      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
-      "license": "MPL-2.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
       "peerDependencies": {
         "@remix-run/react": "^2",
         "@sveltejs/kit": "^1 || ^2",
         "next": ">= 13",
+        "nuxt": ">= 3",
         "react": "^18 || ^19 || ^19.0.0-rc",
         "svelte": ">= 4",
         "vue": "^3",
@@ -3368,6 +3369,9 @@
           "optional": true
         },
         "next": {
+          "optional": true
+        },
+        "nuxt": {
           "optional": true
         },
         "react": {
@@ -6502,9 +6506,9 @@
       "license": "ISC"
     },
     "node_modules/lucide-react": {
-      "version": "0.572.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.572.0.tgz",
-      "integrity": "sha512-GsRHauaTBqk+WziW9mW+SGEcdpvld2f2VdbZCAOyFZbTEOdNVLJq1nEt2qAKJbWeBqDnv7y1XH+sWF6Q6bjgUw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.11.0.tgz",
+      "integrity": "sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -8578,9 +8582,9 @@
       }
     },
     "node_modules/twilio": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-5.13.1.tgz",
-      "integrity": "sha512-sT+PkhptF4Mf7t8eXFFvPQx4w5VHnBIPXbltGPMFRe+R2GxfRdMuFbuNA/cEm0aQR6LFQOn33+fhClg+TjRVqQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-6.0.0.tgz",
+      "integrity": "sha512-MAie5DJ3KLpcKlDaYtNzsKMQXcCi+YHWKvZjuSpm27vJAO/l8PanJA0LkkJ03sbh+Kwe5NeL0Q2+y6IjNUYeUA==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.5",
@@ -8592,7 +8596,7 @@
         "xmlbuilder": "^13.0.2"
       },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/twilio/node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.106.2",
-    "@vercel/analytics": "^1.6.1",
+    "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "heic2any": "^0.0.4",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
-    "lucide-react": "^0.572.0",
+    "lucide-react": "^1.11.0",
     "next": "^14.2.35",
     "openai": "^6.39.1",
     "radix-ui": "^1.4.3",
@@ -28,7 +28,7 @@
     "react-leaflet-cluster": "^2.1.0",
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7",
-    "twilio": "^5.13.1",
+    "twilio": "^6.0.0",
     "web-push": "^3.6.7"
   },
   "devDependencies": {


### PR DESCRIPTION
## What
Consolidated major-version bumps: `lucide-react` 0.572.0 → 1.11.0, `twilio` 5.13.1 → 6.0.0, `@vercel/analytics` 1.6.1 → 2.0.1.

## Why one PR
All three Dependabot PRs (#22, #23, #24) edit `package-lock.json`, so merging them separately chain-conflicts. Consolidating regenerates a single clean lockfile and tests the three together against current main.

## Verification (local, mirrors CI)
- `tsc --noEmit` clean — lucide 1.x icons all resolve, analytics 2.0 import compiles, twilio types fine.
- `npm test` 167/167.
- `next build` green with `SUPABASE_SERVICE_ROLE_KEY` unset (all 857 pub pages prerender).

twilio is unused in `src/` (the separate phone system), so its bump is lockfile-only for this app.

Supersedes and closes #22, #23, #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)