### PR TITLE
feat: gate thin pub pages from sitemap

### DIFF
--- a/src/app/[suburb]/[pub]/page.tsx
+++ b/src/app/[suburb]/[pub]/page.tsx
@@ -1,6 +1,8 @@
 import { Metadata } from 'next'
+import { unstable_cache } from 'next/cache'
 import { notFound, permanentRedirect } from 'next/navigation'
 import { getPubBySlug, getAllPubSlugPairs, getNearbyPubs, getSiteStats } from '@/lib/supabase'
+import { getPubIndexability } from '@/lib/pubIndexability'
 import { absolutePubUrl, absoluteSuburbUrl, toSuburbSlug } from '@/lib/urls'
 import PubDetailClient from './PubDetailClient'
 
@@ -8,12 +10,40 @@ interface PageProps {
   params: { suburb: string; pub: string }
 }
 
+function getCachedPubBySlug(slug: string) {
+  return unstable_cache(
+    () => getPubBySlug(slug),
+    ['pub', slug],
+    {
+      tags: [`pub:${slug}`],
+      revalidate: 3600,
+    },
+  )()
+}
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-  const pub = await getPubBySlug(params.pub)
+  const pub = await getCachedPubBySlug(params.pub)
   if (!pub) return { title: 'Pub Not Found' }
 
   const priceText = pub.price !== null ? `$${pub.price.toFixed(2)} pints` : 'Price TBC'
   const title = `${pub.name}, ${pub.suburb}: ${priceText}`
+  const indexability = getPubIndexability({
+    price: pub.regularPrice,
+    priceVerified: pub.priceVerified,
+    lastVerified: pub.lastVerified,
+    happyHour: pub.happyHour,
+    happyHourPrice: pub.happyHourPrice,
+    happyHourDays: pub.happyHourDays,
+    happyHourStart: pub.happyHourStart,
+    happyHourEnd: pub.happyHourEnd,
+    beerType: pub.beerType,
+    vibeTag: pub.vibeTag,
+    hasTab: pub.hasTab,
+    kidFriendly: pub.kidFriendly,
+    cozyPub: pub.cozyPub,
+    sunsetSpot: pub.sunsetSpot,
+    website: pub.website,
+  })
 
   // Build description with progressive enrichment (target 70-160 chars)
   const descParts: string[] = []
@@ -40,6 +70,9 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     title,
     description,
     alternates: { canonical },
+    robots: indexability.isIndexable
+      ? { index: true, follow: true }
+      : { index: false, follow: true },
     openGraph: {
       title: `${pub.name}: ${priceText}`,
       description,
@@ -62,10 +95,10 @@ export async function generateStaticParams() {
   return pairs.map(pair => ({ suburb: toSuburbSlug(pair.suburb), pub: pair.slug }))
 }
 
-export const revalidate = 300
+export const revalidate = 3600
 
 export default async function PubPage({ params }: PageProps) {
-  const pub = await getPubBySlug(params.pub)
+  const pub = await getCachedPubBySlug(params.pub)
   if (!pub) notFound()
 
   // Verify the suburb slug matches — redirect to correct URL if not

--- a/src/app/api/agents/record-price/[slug]/handler.ts
+++ b/src/app/api/agents/record-price/[slug]/handler.ts
@@ -29,6 +29,7 @@ interface RecordPriceDeps {
     from(table: string): any
   }
   now?: Date
+  afterWrite?: (pub: { slug: string; suburb: string }) => void
 }
 
 export async function handleRecordPrice(
@@ -80,7 +81,7 @@ export async function handleRecordPrice(
 
   const { data: pub, error: fetchErr } = await supabase
     .from('pubs')
-    .select('id, name, price, price_verified')
+    .select('id, slug, name, suburb, price, price_verified')
     .eq('slug', pubSlug)
     .single()
   if (fetchErr || !pub) {
@@ -119,6 +120,8 @@ export async function handleRecordPrice(
       source: body.conversation_id ? `ElevenLabs ${body.conversation_id}` : 'phone_agent',
     })
   }
+
+  deps.afterWrite?.({ slug: pub.slug || pubSlug, suburb: pub.suburb })
 
   console.log(`[agent tool] wrote price=${pintPrice} beer=${body.beer_type || 'n/a'} for ${pub.name}`)
 

--- a/src/app/api/agents/record-price/[slug]/route.ts
+++ b/src/app/api/agents/record-price/[slug]/route.ts
@@ -1,7 +1,16 @@
 import { NextRequest } from 'next/server'
+import { revalidatePath, revalidateTag } from 'next/cache'
 import { serviceClient } from '@/lib/supabaseGateway'
+import { toSuburbSlug } from '@/lib/urls'
 import { handleRecordPrice } from './handler'
 
 export async function POST(req: NextRequest, { params }: { params: { slug: string } }) {
-  return handleRecordPrice(req, { params }, { getSupabase: serviceClient, now: new Date() })
+  return handleRecordPrice(req, { params }, {
+    getSupabase: serviceClient,
+    now: new Date(),
+    afterWrite: pub => {
+      revalidateTag(`pub:${pub.slug}`)
+      revalidatePath(`/${toSuburbSlug(pub.suburb)}/${pub.slug}`)
+    },
+  })
 }

--- a/src/app/api/price-report/route.ts
+++ b/src/app/api/price-report/route.ts
@@ -1,7 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { revalidatePath, revalidateTag } from 'next/cache'
 import { anonClient } from '@/lib/supabaseGateway'
+import { toSuburbSlug } from '@/lib/urls'
 
 const supabase = anonClient()
+
+async function revalidateReportedPub(pubSlug: string) {
+  revalidateTag(`pub:${pubSlug}`)
+
+  const { data: pub } = await supabase
+    .from('pubs')
+    .select('slug, suburb')
+    .eq('slug', pubSlug)
+    .single()
+
+  if (pub?.slug && pub.suburb) {
+    revalidatePath(`/${toSuburbSlug(pub.suburb)}/${pub.slug}`)
+  }
+}
 
 export async function POST(req: NextRequest) {
   try {
@@ -66,6 +82,8 @@ export async function POST(req: NextRequest) {
       console.error('Error inserting price report:', error)
       return NextResponse.json({ error: 'Failed to submit report' }, { status: 500 })
     }
+
+    await revalidateReportedPub(pub_slug)
 
     const message = isOutdatedReport
       ? 'Thanks for flagging! We\'ll check this price.'

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,49 +1,70 @@
 import { MetadataRoute } from 'next'
-import { getAllPubSlugPairs, getAllSuburbs } from '@/lib/supabase'
-import { BASE_URL, absolutePubUrl, absoluteSuburbUrl } from '@/lib/urls'
+import { getAllPubLastModifiedPairs, getIndexablePubSlugPairs, getAllSuburbs } from '@/lib/supabase'
+import { BASE_URL, absolutePubUrl, absoluteSuburbUrl, toSuburbSlug } from '@/lib/urls'
 
 // Regenerate hourly so new pubs added to Supabase appear in the sitemap
 // within 60 min. Without this, Next defaults to build-time generation and
 // the sitemap would only refresh on redeploy.
 export const revalidate = 3600
 
+const FALLBACK_LAST_MODIFIED = '2026-05-31T00:00:00.000Z'
+
+function toLastModified(value: string | null | undefined): string {
+  if (!value) return FALLBACK_LAST_MODIFIED
+  return new Date(value).toISOString()
+}
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const [slugPairs, suburbs] = await Promise.all([
-    getAllPubSlugPairs(),
+  const [slugPairs, allPubDates, suburbs] = await Promise.all([
+    getIndexablePubSlugPairs(),
+    getAllPubLastModifiedPairs(),
     getAllSuburbs(),
   ])
-  const now = new Date().toISOString()
+  const latestPubModified = allPubDates
+    .map(pair => toLastModified(pair.lastModified))
+    .sort()
+    .at(-1) || FALLBACK_LAST_MODIFIED
+
+  const latestBySuburb = new Map<string, string>()
+  for (const pubDate of allPubDates) {
+    const suburbSlug = toSuburbSlug(pubDate.suburb)
+    const lastModified = toLastModified(pubDate.lastModified)
+    const existing = latestBySuburb.get(suburbSlug)
+    if (!existing || lastModified > existing) {
+      latestBySuburb.set(suburbSlug, lastModified)
+    }
+  }
 
   const staticRoutes: MetadataRoute.Sitemap = [
-    { url: BASE_URL, lastModified: now, changeFrequency: 'daily', priority: 1.0 },
-    { url: `${BASE_URL}/discover`, lastModified: now, changeFrequency: 'daily', priority: 0.9 },
-    { url: `${BASE_URL}/insights`, lastModified: now, changeFrequency: 'daily', priority: 0.9 },
-    { url: `${BASE_URL}/guides`, lastModified: now, changeFrequency: 'weekly', priority: 0.9 },
-    { url: `${BASE_URL}/insights/pint-of-the-day`, lastModified: now, changeFrequency: 'daily', priority: 0.8 },
-    { url: `${BASE_URL}/insights/pint-index`, lastModified: now, changeFrequency: 'daily', priority: 0.8 },
-    { url: `${BASE_URL}/insights/tonights-best-bets`, lastModified: now, changeFrequency: 'daily', priority: 0.8 },
-    { url: `${BASE_URL}/insights/suburb-rankings`, lastModified: now, changeFrequency: 'weekly', priority: 0.7 },
-    { url: `${BASE_URL}/insights/venue-breakdown`, lastModified: now, changeFrequency: 'weekly', priority: 0.7 },
-    { url: `${BASE_URL}/guides/beer-weather`, lastModified: now, changeFrequency: 'daily', priority: 0.8 },
-    { url: `${BASE_URL}/guides/sunset-sippers`, lastModified: now, changeFrequency: 'weekly', priority: 0.7 },
-    { url: `${BASE_URL}/guides/punt-and-pints`, lastModified: now, changeFrequency: 'weekly', priority: 0.7 },
-    { url: `${BASE_URL}/guides/dad-bar`, lastModified: now, changeFrequency: 'weekly', priority: 0.7 },
-    { url: `${BASE_URL}/guides/cozy-corners`, lastModified: now, changeFrequency: 'weekly', priority: 0.7 },
-    { url: `${BASE_URL}/happy-hour`, lastModified: now, changeFrequency: 'daily', priority: 0.8 },
+    { url: BASE_URL, lastModified: latestPubModified, changeFrequency: 'daily', priority: 1.0 },
+    { url: `${BASE_URL}/discover`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.9 },
+    { url: `${BASE_URL}/insights`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.9 },
+    { url: `${BASE_URL}/guides`, lastModified: latestPubModified, changeFrequency: 'weekly', priority: 0.9 },
+    { url: `${BASE_URL}/insights/pint-of-the-day`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },
+    { url: `${BASE_URL}/insights/pint-index`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },
+    { url: `${BASE_URL}/insights/tonights-best-bets`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },
+    { url: `${BASE_URL}/insights/suburb-rankings`, lastModified: latestPubModified, changeFrequency: 'weekly', priority: 0.7 },
+    { url: `${BASE_URL}/insights/venue-breakdown`, lastModified: latestPubModified, changeFrequency: 'weekly', priority: 0.7 },
+    { url: `${BASE_URL}/guides/beer-weather`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },
+    { url: `${BASE_URL}/guides/sunset-sippers`, lastModified: latestPubModified, changeFrequency: 'weekly', priority: 0.7 },
+    { url: `${BASE_URL}/guides/punt-and-pints`, lastModified: latestPubModified, changeFrequency: 'weekly', priority: 0.7 },
+    { url: `${BASE_URL}/guides/dad-bar`, lastModified: latestPubModified, changeFrequency: 'weekly', priority: 0.7 },
+    { url: `${BASE_URL}/guides/cozy-corners`, lastModified: latestPubModified, changeFrequency: 'weekly', priority: 0.7 },
+    { url: `${BASE_URL}/happy-hour`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },
   ]
 
   const suburbRoutes: MetadataRoute.Sitemap = suburbs.map(s => ({
     url: absoluteSuburbUrl(s.slug),
-    lastModified: now,
+    lastModified: latestBySuburb.get(s.slug) || latestPubModified,
     changeFrequency: 'weekly' as const,
     priority: 0.8,
   }))
 
   const pubRoutes: MetadataRoute.Sitemap = slugPairs.map(pair => ({
     url: absolutePubUrl(pair),
-    lastModified: now,
+    lastModified: toLastModified(pair.lastModified),
     changeFrequency: 'weekly' as const,
-    priority: 0.6,
+    priority: pair.indexabilityTier === 'A' ? 0.6 : 0.5,
   }))
 
   return [...staticRoutes, ...suburbRoutes, ...pubRoutes]

--- a/src/lib/pubIndexability.test.ts
+++ b/src/lib/pubIndexability.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { getPubIndexability } from './pubIndexability'
+
+describe('getPubIndexability', () => {
+  it('noindexes NAP-only pub pages', () => {
+    const result = getPubIndexability({
+      price: null,
+      happyHour: null,
+      happyHourPrice: null,
+    })
+
+    assert.equal(result.tier, 'C')
+    assert.equal(result.isIndexable, false)
+  })
+
+  it('indexes pubs with a price even when other data is sparse', () => {
+    const result = getPubIndexability({
+      price: 12,
+      priceVerified: false,
+      lastVerified: null,
+    })
+
+    assert.equal(result.tier, 'B')
+    assert.equal(result.isIndexable, true)
+  })
+
+  it('promotes verified priced pubs to Tier A', () => {
+    const result = getPubIndexability({
+      price: 11.5,
+      priceVerified: true,
+      lastVerified: '2026-05-31T00:00:00.000Z',
+    })
+
+    assert.equal(result.tier, 'A')
+    assert.equal(result.isIndexable, true)
+  })
+
+  it('indexes happy-hour pubs without a regular price', () => {
+    const result = getPubIndexability({
+      price: null,
+      happyHour: 'Mon-Fri 5-6pm',
+      vibeTag: 'sports bar',
+    })
+
+    assert.equal(result.tier, 'A')
+    assert.equal(result.isIndexable, true)
+  })
+})

--- a/src/lib/pubIndexability.ts
+++ b/src/lib/pubIndexability.ts
@@ -1,0 +1,69 @@
+export type PubIndexabilityTier = 'A' | 'B' | 'C'
+
+export interface PubIndexabilityInput {
+  price: number | null
+  priceVerified?: boolean | null
+  lastVerified?: string | null
+  happyHour?: string | null
+  happyHourPrice?: number | null
+  happyHourDays?: string | null
+  happyHourStart?: string | null
+  happyHourEnd?: string | null
+  beerType?: string | null
+  vibeTag?: string | null
+  hasTab?: boolean | null
+  kidFriendly?: boolean | null
+  cozyPub?: boolean | null
+  sunsetSpot?: boolean | null
+  website?: string | null
+}
+
+export interface PubIndexability {
+  dataScore: number
+  tier: PubIndexabilityTier
+  isIndexable: boolean
+}
+
+function hasPositiveNumber(value: number | null | undefined): boolean {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+}
+
+function hasText(value: string | null | undefined): boolean {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+export function getPubIndexability(pub: PubIndexabilityInput): PubIndexability {
+  const hasPrice = hasPositiveNumber(pub.price)
+  const hasVerifiedPrice = hasPrice && pub.priceVerified !== false && hasText(pub.lastVerified)
+  const hasHappyHour = hasText(pub.happyHour)
+    || hasPositiveNumber(pub.happyHourPrice)
+    || (hasText(pub.happyHourDays) && hasText(pub.happyHourStart) && hasText(pub.happyHourEnd))
+
+  const attributeCount = [
+    pub.beerType,
+    pub.vibeTag,
+    pub.website,
+  ].filter(hasText).length + [
+    pub.hasTab,
+    pub.kidFriendly,
+    pub.cozyPub,
+    pub.sunsetSpot,
+  ].filter(Boolean).length
+
+  const dataScore = [
+    hasPrice ? 2 : 0,
+    hasVerifiedPrice ? 1 : 0,
+    hasHappyHour ? 2 : 0,
+    Math.min(attributeCount, 2),
+  ].reduce((sum, score) => sum + score, 0)
+
+  if (hasVerifiedPrice || (hasHappyHour && attributeCount > 0)) {
+    return { dataScore, tier: 'A', isIndexable: true }
+  }
+
+  if (hasPrice || hasHappyHour) {
+    return { dataScore, tier: 'B', isIndexable: true }
+  }
+
+  return { dataScore, tier: 'C', isIndexable: false }
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 import { Pub } from '@/types/pub'
 import { getHappyHourStatus } from '@/lib/happyHourLive'
+import { getPubIndexability, PubIndexabilityTier } from '@/lib/pubIndexability'
 import { toSuburbSlug } from './urls'
 
 function titleCase(str: string): string {
@@ -225,7 +226,7 @@ export async function getAllPubSlugs(): Promise<string[]> {
   return data.map(row => row.slug).filter(Boolean)
 }
 
-// Fetch all pub slug + suburb pairs (for sitemap and generateStaticParams with suburb context)
+// Fetch all pub slug + suburb pairs (for routing only)
 export async function getAllPubSlugPairs(): Promise<{ slug: string; suburb: string }[]> {
   const { data, error } = await supabase
     .from('pubs')
@@ -234,6 +235,78 @@ export async function getAllPubSlugPairs(): Promise<{ slug: string; suburb: stri
 
   if (error || !data) return []
   return data.filter(row => row.slug && row.suburb).map(row => ({ slug: row.slug, suburb: row.suburb }))
+}
+
+export interface IndexablePubSlugPair {
+  slug: string
+  suburb: string
+  lastModified: string | null
+  dataScore: number
+  indexabilityTier: PubIndexabilityTier
+}
+
+export interface PubLastModifiedPair {
+  suburb: string
+  lastModified: string | null
+}
+
+export async function getAllPubLastModifiedPairs(): Promise<PubLastModifiedPair[]> {
+  const { data, error } = await supabase
+    .from('pubs')
+    .select('suburb, last_verified, last_updated, updated_at')
+
+  if (error || !data) return []
+
+  return data
+    .filter(row => row.suburb)
+    .map(row => ({
+      suburb: row.suburb,
+      lastModified: row.last_verified || row.updated_at || row.last_updated || null,
+    }))
+}
+
+export async function getIndexablePubSlugPairs(): Promise<IndexablePubSlugPair[]> {
+  const { data, error } = await supabase
+    .from('pubs')
+    .select('slug, suburb, price, price_verified, last_verified, last_updated, updated_at, happy_hour, happy_hour_price, happy_hour_days, happy_hour_start, happy_hour_end, beer_type, vibe_tag, has_tab, kid_friendly, cozy_pub, sunset_spot, website')
+    .order('slug')
+
+  if (error || !data) return []
+
+  return data
+    .filter(row => row.slug && row.suburb)
+    .map(row => {
+      const price = row.price != null ? Number(row.price) : null
+      const happyHourPrice = row.happy_hour_price != null ? Number(row.happy_hour_price) : null
+      const indexability = getPubIndexability({
+        price,
+        priceVerified: row.price_verified,
+        lastVerified: row.last_verified || null,
+        happyHour: row.happy_hour || null,
+        happyHourPrice,
+        happyHourDays: row.happy_hour_days || null,
+        happyHourStart: row.happy_hour_start || null,
+        happyHourEnd: row.happy_hour_end || null,
+        beerType: row.beer_type || null,
+        vibeTag: row.vibe_tag || null,
+        hasTab: row.has_tab,
+        kidFriendly: row.kid_friendly,
+        cozyPub: row.cozy_pub,
+        sunsetSpot: row.sunset_spot,
+        website: row.website || null,
+      })
+
+      return {
+        slug: row.slug,
+        suburb: row.suburb,
+        lastModified: row.last_verified || row.updated_at || row.last_updated || null,
+        dataScore: indexability.dataScore,
+        indexabilityTier: indexability.tier,
+        isIndexable: indexability.isIndexable,
+      }
+    })
+    .filter(row => row.isIndexable)
+    .map(({ isIndexable, ...row }) => row)
 }
 
 // Fetch nearby pubs (same suburb, excluding current)


### PR DESCRIPTION
## Summary
- add pub-page dataScore / Tier A-B-C indexability helper and tests
- emit noindex,follow for Tier-C pub pages while keeping routes live
- filter sitemap to Tier A/B pub URLs and use real pub freshness dates for pub/suburb/static lastmod
- raise pub ISR to 3600 and revalidate pub path/tag from price write paths

Closes #69
Closes #70
Closes #71

## Verification
- npm test
- npx tsc --noEmit
- npm run lint (existing warnings only)
- npm run build
- runtime spot check: Tier-C noindex, Tier-A index, sitemap excludes Tier-C and has 397 real lastmods
- peer review by sub-agent: Happy to merge: yes