### PR TITLE
docs: site voice brief + whole-site content pack

### DIFF
--- a/docs/brand-voice-brief.md
+++ b/docs/brand-voice-brief.md
@@ -1,0 +1,257 @@
+# Perth Pint Prices — Voice Brief
+
+Status: working guiding star for all site copy
+Purpose: write content that sounds like Perth Pint Prices and nobody else — before adding pub-page modules, suburb intros, guides, or feature copy.
+
+This is the reference to read before writing any user-facing words. It is not a CI gate; it is the standard. If new copy doesn't feel of-a-piece with the exemplars at the bottom, the voice has drifted.
+
+## The core voice
+
+Perth Pint Prices should sound like **a sharp local who knows the prices cold and won't oversell you** — checked this week, not last year. Dry, not loud. The data does the talking.
+
+It should be:
+
+- Plainspoken
+- Dry and understated — the wit is in a well-placed specific, not in slang or exclamation marks
+- Specific (a price, a pub, a year, a time — not vibes)
+- Data-first (every claim traces to a real number or we don't make it)
+- Quietly local (written by someone who drinks here, not performing it)
+- Honest about what we don't know yet
+
+It should not feel:
+
+- Corporate or brochure-y
+- **Corny or try-hard** — no "grab a cold one with ya mates", no exclamation-mark boosterism
+- Like a tourism listicle ("nestled in the heart of...")
+- Generic — copy that could run on any pub-finder in any city
+- Clever at the expense of useful
+- AI-generated
+- Like it's overclaiming ("the perfect pub", "always cheap")
+
+The humour is in the observation, not the slang. perthisok describes a pub as *"one of the few remaining pubs in Perth actually owned by Perth folk"* — dry, specific, knowing, not one exclamation mark. That's the register. Our edge is that the price is the punchline, delivered deadpan: *"$9 a pint — and we rang to make sure."* Never *"CHEAP PINTS!"*
+
+## Competitive voice landscape
+
+The space is crowded with pub-finders and what's-on lists. Most own a lane we don't want.
+
+- **Urban List / Broadsheet / The West** — own the glossy "best bars in Perth" listicle. Editorial, photographed, no prices, stale within a year. We are not a smaller version of them. Don't write listicle copy.
+- **perthlocalista / buggybuddys** — own local what's-on breadth. Familiar, broad, event-led. Our lane is narrower and sharper: what the pint costs and when it's cheaper.
+- **perthisok** — competes for attention, but **study its prose as our benchmark.** Dry, specific, understated, confident; humour from a well-placed detail; almost no slang and no exclamation marks. It even opens its pub guide on our exact value prop — *"sometimes you crave… a pint that's less than $10"* — delivered deadpan. That register is the target; we just have the live price it's pointing at.
+- **Yelp / Tripadvisor / Google** — own reviews and ratings. We don't compete on reviews; we never fake a rating. We compete on price and freshness.
+- **Fanzo** — owns "where's the game on". Adjacent, not us.
+
+**Our moat — say it in the copy:** live pint price, happy-hour freshness, price vs the suburb average, nearby cheaper options, and a verification loop (Andrew rings the pub; punters report prices). No competitor surfaces any of that. When in doubt, lean on a number they can't show.
+
+## Our ownable position
+
+> Perth's practical pub-price layer.
+
+Or, more simply:
+
+> Know what the pint costs before you go.
+
+We are not the prettiest pub guide, the biggest events site, or a review platform. We are the one place that tells you the price, how fresh that price is, and where's cheaper nearby.
+
+## Messaging principles
+
+### 1. Lead with the punter's decision
+
+Start from the moment the reader is in: where to go, what it costs, when it's cheaper, what's better nearby.
+
+Weaker: *Browse pubs across Perth.*
+Stronger: *Find tonight's cheapest pint near you.*
+
+### 2. Be specific — a number beats an adjective
+
+Specific copy is credible copy. A price, a date, a suburb, a named pub.
+
+Weaker: *Great happy-hour deals.*
+Stronger: *Happy hour's on now — pints down to $9 til 6pm.*
+
+### 3. Show the freshness, don't claim accuracy
+
+Freshness is our trust signal the way "verified" is for a data site — powerful, but only if handled honestly. Show **how recently** we checked, not a blanket promise.
+
+Weaker (claim): *100% accurate prices.*
+Stronger (method): *Last checked 28 May — verified by a call to the pub.*
+
+Useful proof points: last-verified date, "reported by a punter", "Andrew called and confirmed", price vs suburb average.
+
+Use carefully: *verified, always, cheapest, guaranteed, every pub.* True-when-true, trust risk when not.
+
+### 4. Data-first — never fabricate, and say so when we don't know
+
+Every price, happy-hour window, or claim renders from real data or it doesn't ship. When we don't have it, **truthful absence beats a guess**:
+
+> No verified price here yet — last Andrew call never. Three nearby pubs have checked prices →
+
+This honesty is a feature. It feeds the report-a-price loop and it's why people trust the numbers we *do* show.
+
+### 5. Local, but dry — slang is seasoning, not the meal
+
+The Perth feel should come from **specifics and a dry turn of phrase**, not a pile of slang. perthisok barely uses vernacular — its localness comes from knowing the pubs (a 1936 opening, who owns it, which night the blues club plays). Follow that.
+
+- One understated local turn per paragraph, maximum — *no muss, no fuss*, *safe as houses*, *Freo* — never a string of them.
+- **No exclamation-mark boosterism.** "Scorcher! Grab a cold one!" is the corniest tell there is. A scanner doesn't need shouting at.
+- Let the price be the dry punchline: *"A pint under $10. Yes, still."* beats *"Unreal cheap pints, legends!"*
+- Use *schooner / pint / pot* precisely; *Freo* in body, *Fremantle* in titles and schema.
+
+### 6. Lead decisions, not gestures (hardest on H1s and CTAs)
+
+Name the outcome, not the click. This is where copy slips into product-shorthand.
+
+Weaker (gesture): *Browse pubs* · *View suburb*
+Stronger (outcome): *Find the cheapest pint near you* · *See Northbridge prices*
+
+CTAs teach people how to think about us. *Report a price* (you're helping the map) beats *Submit* (you're filling a form).
+
+### 7. Front-load the value
+
+People scan. The first 5–7 words of any heading, sentence, or list item carry the load.
+
+Weaker: *The Norfolk Hotel in Fremantle currently has a pint price of $11...*
+Stronger: *$11 a pint at The Norfolk — about average for Freo.*
+
+### 8. Cheek must still inform
+
+Funny is welcome; funny-and-useless is not. If you cut the joke, is there still a fact left? If not, rewrite until there is.
+
+## House style
+
+### Australian English — non-negotiable
+
+A Perth site that reads American is a Perth site nobody local trusts. Use: *cosy, colour, flavour, favourite, neighbourhood, centre, metre, litre, organise, recognise, realise, travelled, licence (noun) / license (verb).*
+
+**Grep-able bugs** (American spellings in shipped prose): *cozy, color, flavor, favorite, neighborhood, center, meter, liter, organize, recognize, realize, traveled.* (Note: the `/guides/cozy-corners` URL slug stays — changing it breaks SEO — but the prose word is *cosy*.)
+
+Exceptions: proper nouns and pub names as written; quoted source material; code identifiers, URLs, CSS, JSON keys; universal terms (*bar, pub, beer garden*).
+
+### Local lexicon
+
+*Freo* is welcome in body copy; use *Fremantle* in titles, H1s, and schema. *Schooner / pint / pot* are precise — use the right one. *Sundowner, knock-off, bottle-o, servo, arvo* are fair game in cheeky surfaces, not in schema or meta descriptions.
+
+### Prices, numbers, units
+
+- Prices as `$11` or `$9.50` — no "AUD", no trailing `.00`.
+- Numerals for prices, counts, distances, times: *$9, 4 pubs, 300m walk, til 6pm.*
+- Spell out *one*–*nine* in prose where the number isn't the point.
+- Distance in metres/minutes walk for "nearby": *280m (a 3-min walk).*
+
+### Capitalisation & punctuation
+
+- **Sentence case** for headings, nav, buttons, labels. Pub names and proper nouns stay capitalised.
+- Yes: *Cheapest pints near you*, *Best time to go.* No: *Cheapest Pints Near You.*
+- Spaced em-dash — like this — not unspaced. One space after a full stop. Skip the Oxford comma unless it removes ambiguity.
+- **Exclamation marks: essentially never** in body copy — they're the fastest route to corny. If a line needs one to land, it isn't landing; rewrite it dryer.
+
+## High-leverage surfaces
+
+The voice slips most often on the surfaces read most. Extra scrutiny on:
+
+- **Pub-page answer block** — the price sentence is the single most-read line on the site. Specific, fresh, decision-led.
+- **H1s** — decision-led, never generic.
+- **CTAs** — *Report a price*, *Directions*, *See nearby prices* — outcome, not gesture.
+- **Suburb-page lead sentence** — *"The cheapest pint in Northbridge is $9 at [Pub] (checked 28 May); the average is $12 across 14 pubs."* This is what wins "pubs in [suburb]".
+- **FAQ questions** — phrased like a punter would ask, answer-first. Vary phrasings across pages (see anti-sameness).
+- **Meta descriptions** — let the price-delta / happy-hour window / nearest-cheaper-pub carry uniqueness; drop boilerplate suffixes.
+
+## Anti-sameness rule (for the 850 templated pages)
+
+The risk at scale is 850 pages that read identically — the scaled-content fingerprint. Two rules:
+
+1. **Every page earns its words from real per-pub data.** No blurb from nothing. If there's nothing true and specific to say about a pub, say *less* (the verification stub), not generic filler.
+2. **Vary phrasings from a small seeded pool, keyed to pub id** — so the same pub always reads the same way, but no two pubs share an identical sentence. Identical question strings or intro sentences across pages are the tell.
+
+(Hooks into the pub-page content plan §5 — the husk guard and the variant pool.)
+
+## Words to use more often
+
+cheap · cheapest · pint · schooner · happy hour · knock-off · sundowner · tonight · near you · last checked · verified {date} · suburb average · below average · save · within walking distance
+
+(Slang like *cold one* or *a mate* isn't banned, but it's rationed — one dry turn, not a costume. See principle 5.)
+
+## Words to use carefully
+
+verified · cheapest · best · always · free · every — true-when-true, trust risk when not. If a sentence uses "cheapest" twice, the second one is doing no work.
+
+## Words to avoid
+
+perfect · ultimate · hidden gem · nestled · boasts · vibrant · bustling · a must-visit · iconic (unless it literally is) · look no further · your one-stop · whether you're X or Y
+
+**Corny tells (watch these hardest):** exclamation marks · *scorcher* · *grab a cold one* · *ya mates* · *legends* · *the Perth way* · *no worries* · *cheeky* more than once a page · any stacked slang that's there for flavour, not information.
+
+### AI-tell phrases to avoid
+
+- *everything you need to know about* / *the ultimate guide to*
+- *in today's world* / *look no further*
+- *nestled in the heart of* / *boasts a vibrant atmosphere* (tourism-listicle tells)
+- *whether you're a local or just visiting* (and all paired "whether you're X or Y" rhythms)
+- *it's important to note that* / *at the end of the day* / *ultimately*
+- *X isn't just a pub, it's an experience* — sounds balanced, says nothing
+- *elevate* · *seamless* · *curated* · *vibrant* · *bustling* · *boasts*
+
+If the line could run on any pub-finder in any city without rewriting, it's not on-brand.
+
+## Voice exemplars
+
+Real lines from the live site that hit the brief. Treat as the canonical reference.
+
+**Homepage:**
+
+> Perth's pints, sorted.
+
+*Why it works:* the whole product in three words. Confident, local, not corporate.
+
+> Real prices across 300+ Perth pubs.
+
+*Why it works:* leads with the differentiator ("real prices"), specific count, no padding.
+
+**DadBar guide:**
+
+> I told my kids I'd buy them a drink at the pub. They got lemonade. I got a pint. Everyone won.
+
+*Why it works:* cheeky and human, written by a person not a brand, and it frames the actual use case (family-friendly pubs).
+
+> The Baysie has a 10m slide. My kids rate it 5 stars. I rate the beer garden 5 stars. Everyone's happy.
+
+*Why it works:* specific (a named pub, a real measurement), funny, and informative — tells you exactly what the pub offers.
+
+**Weather guides:**
+
+> Wet outside, warm inside.
+
+*Why it works:* four words, dry, specific. (The live line tags on *"That's the Perth way"* — borderline corny; it's stronger without it.)
+
+**The register to aim for — external benchmark, perthisok:**
+
+> Gramercy is a no muss, no fuss CBD pub that's safe as houses... one of the few remaining pubs in Perth actually owned by Perth folk.
+
+*Why it works:* dry, knowing, specific. Two light idioms, zero exclamation marks, a closing observation that's almost a wink. This is the tone for our pub one-liners — we just add the live price.
+
+### Drifted — fix these
+
+> Perfect excuse for a cheeky pint by the window.
+
+*The problem:* "Perfect" overclaims (words-to-avoid). *"a cheeky pint by the window"* is great — keep it. Fix: *A good excuse for a cheeky pint by the window.*
+
+> Cozy up inside with a cold one.
+
+*The problem:* "Cozy" is American. On a Perth site that's a trust bug. Fix: *Cosy up inside with a cold one.*
+
+> Scorcher! Head to the beach pubs for a cold one.
+
+*The problem:* exclamation-mark boosterism plus stacked slang (*scorcher*, *cold one*) — the corny tell the whole brief guards against. The fact (hot day → beach pubs) is fine; the delivery is loud. Fix: *Hot one today — head for the beach pubs.*
+
+## Voice test
+
+Before publishing copy, ask:
+
+1. Does this help a punter make a better decision (where / what / when / how much)?
+2. Is it specific enough to feel credible — is there a real number or named place in it?
+3. If it claims freshness or "cheapest", does it show how we know?
+4. Does it avoid sounding bigger or more certain than the data supports?
+5. Would it still sound human read out loud in a Perth accent?
+6. Could it run unchanged on any other pub-finder? (If yes — it's not on-brand. Rewrite.)
+7. Read it aloud: does it sound like a person being dry, or a brand trying to be fun? An exclamation mark or stacked slang is the tell it's the latter.
+
+If fewer than 6 of 7 pass, fix the high-leverage surfaces (headline, first sentence, CTA) before anything else.

--- a/docs/content-pack-v1.md
+++ b/docs/content-pack-v1.md
@@ -1,0 +1,190 @@
+# Site Content Pack v1 — Perth Pint Prices
+
+**Status:** Surface specs / not yet wired. Drafted 2026-05-31 in the recalibrated dry voice.
+**Standard:** [docs/brand-voice-brief.md](brand-voice-brief.md) — read it first. Target register: perthisok's dry, specific, deadpan tone. No exclamation marks, slang rationed, the price is the punchline.
+**Relationship to other docs:** Pub-page *modules* are owned by [docs/pub-page-content-plan.md](pub-page-content-plan.md) — this doc supplies the **voice strings** for those modules, it does not redefine them. Keyword targets come from [docs/SEO-MASTER.md](SEO-MASTER.md).
+
+## Conventions
+
+- `{slot}` = real data, rendered from Supabase. Never hand-typed, never invented.
+- `[bracket]` = illustrative example value, for review only.
+- Every line is a **string builder fed by real data** — true for every pub/suburb the moment data lands, or it doesn't render (truthful absence beats a guess).
+- Anti-sameness: where a surface repeats across many pages (pub pages, suburb pages), phrasings come from a **small pool seeded by pub/suburb id** so no two pages share a sentence. See pub-page-content-plan §5.
+
+---
+
+## 1. Global
+
+**Default title:** `Perth Pint Prices | Perth's pints, sorted.`
+**Default meta description:** `What a pint costs across {venueCount} Perth pubs — checked, dated, and sorted cheapest first.`
+**Nav (MobileNav):** `Discover` · `Happy hours` · CTA `Report a price`
+**Footer tagline:** `Real pint prices across {venueCount} Perth pubs. Community-powered, est. 2026.`
+**404:** `Couldn't find that one. Try the suburbs index, or search for a pub.`
+**Install prompt:** `Add Perth Pint Prices to your home screen — the cheapest pint, one tap away.`
+**Global CTAs:** `Report a price` (not "Submit") · `Directions` · `See nearby prices` · price-missing hero → `Know the price here? Add it →`
+
+---
+
+## 2. Homepage (`/`)
+
+**H1 (keep):** `Perth's pints, sorted.`
+**Subhead:** `What a pint actually costs, across {venueCount} Perth pubs.`
+**Meta strip (keep):** `Community-powered · Est. 2026`
+**Stat strip labels (keep):** `Venues` · `Suburbs` · `Cheapest`
+
+**How it works (3 steps, in voice):**
+1. `Punters and Andrew report what a pint costs.`
+2. `We date-stamp every price, so you see how fresh it is.`
+3. `You find the cheapest pint near you.`
+
+**Social proof (data-fed, no invented numbers):** `{reportCount} prices reported this month. {verifiedCount} pubs checked in the last 30 days.`
+
+**FAQ (visible Q&A — doubles as AEO; FAQPage rich results retire Jun 2026, so don't bank on a snippet):**
+- **How do you know the prices are real?** — `Two ways. Punters report what they paid, and Andrew — a recorded line — rings pubs and asks. Every price shows the date we last checked it. If we haven't confirmed one, we say so.`
+- **How often are prices updated?** — `As they come in. Some pubs we check weekly; others rely on punter reports. The date next to each price is the honest answer for that pub.`
+- **Is this every pub in Perth?** — `Most of them — {venueCount} and counting. Some don't have a verified price yet; those pages say as much and point you to nearby pubs that do.`
+- **What's the cheapest pint in Perth right now?** — `${minPrice} at {minPub} in {suburb}, checked {date}. The figure up top is always the current verified low.`
+
+---
+
+## 3. `/discover` (hub)
+
+*Targets: "perth pub guide", "cheapest pints perth", "cheap drinks perth"*
+
+> **# Where to find a cheap pint in Perth**
+>
+> We track the price of a pint across **{venueCount}** Perth pubs and check them often enough to be worth trusting. Right now the cheapest verified pint is **${minPrice}** at {minPub}, in {suburb}. The median across the city sits at **${median}**.
+>
+> This is the practical layer the glossy bar guides skip — not the fit-out or the cocktail list, just what a pint costs, when it's cheaper, and where's cheaper nearby. Prices come from punters reporting in and from Andrew, our recorded line that rings pubs and asks. Each one carries the date we last checked, so you can see how fresh it is.
+>
+> Start with **tonight's cheapest pints**, filter by **suburb**, or see which pubs have a **happy hour** on now.
+
+---
+
+## 4. `/happy-hour`
+
+*Targets: "perth happy hour deals", "happy hour perth"*
+
+> **# Perth happy hours, on now**
+>
+> **{liveCount}** Perth pubs have a happy hour running right now, pints from **${minHhPrice}**. We list them live — start, finish, and what the pint actually drops to — so you're not turning up to a board that changed last month.
+>
+> Happy hours move around. The ones below are the windows we've verified, each showing when we last confirmed it. Sort by what's on now, what starts within the hour, or by price.
+
+---
+
+## 5. `/suburbs` (index)
+
+*Targets: "pint prices by suburb perth", "perth suburbs pubs"*
+
+> **# Pint prices by Perth suburb**
+>
+> Every suburb we cover, cheapest pint first — **{suburbCount}** suburbs, **{venueCount}** pubs, each price showing when we last checked. {cheapestSuburb} is the cheapest right now at a ${cheapestAvg} average; {dearestSuburb} the dearest at ${dearestAvg}.
+
+---
+
+## 6. `/[suburb]` (suburb page)
+
+*Targets: "best pubs in {suburb}", "cheapest pint in {suburb}", "pubs in {suburb}"*
+
+**Lead block (template):**
+> The cheapest pint in **{Suburb}** is **${minPrice}** at {minPub} (checked {date}) — ${delta} under the suburb average of ${avg} across {n} pubs. {dataObservation} Sort by price below, or see what's cheaper nearby in {neighbour1} or {neighbour2}.
+
+`{dataObservation}` is **derived from the strongest real signal, not hand-written** (anti-corny + anti-sameness):
+- HH density → `Four have a happy hour on right now.`
+- price spread → `Prices run tight here — most sit between ${p25} and ${p75}.`
+- thin data → `Only {verifiedN} have a verified price, so this list will grow.`
+
+**Worked examples (illustrative):**
+- *Northbridge:* "The cheapest pint in Northbridge is $9 at [The Brisbane] (checked 28 May) — $3 under the suburb average of $12 across 14 pubs. Four have a happy hour on right now. Sort by price below, or see what's cheaper a short walk away in Perth or Highgate."
+- *Fremantle:* "The cheapest pint in Fremantle is $10 at [Pub] (checked 27 May) — about a dollar under the Freo average of $11 across 19 pubs. Prices run tight; most sit between $10 and $13. Sort by price, or look north to North Fremantle."
+
+**Suburb meta description:** `Cheapest pint in {Suburb}: ${minPrice} at {minPub}. Average ${avg} across {n} pubs, each with the date we checked.`
+
+---
+
+## 7. `/[suburb]/[pub]` (pub page)
+
+Modules are defined in [pub-page-content-plan.md §2](pub-page-content-plan.md). Below are the **voice strings per module state** that §7 item 8 calls for ("per-state voice templates as string builders, gate before module code").
+
+**H1 / subtitle (conditional on data per plan §5):**
+- `{Pub} — pint prices & happy hour` (only when data supports both)
+- subtitle folds in the one real `vibeTag`: `{vibeTag} in {Suburb}.`
+
+**Module 1 — Answer block (price + vs-average + freshness):**
+```
+price, below avg   →  ${price} a pint at {Pub} — ${delta} under the {Suburb} average. Checked {date}.
+price, above avg   →  ${price} a pint at {Pub}. That's ${delta} over the {Suburb} average, if you're counting. Checked {date}.
+price, at avg      →  ${price} a pint at {Pub} — about the {Suburb} average. Checked {date}.
+```
+
+**Module 2 — Best time to go:**
+```
+HH on now          →  Best time is right now — happy hour runs til {end}, pints at ${hhPrice} (${saving} off the usual).
+HH later today     →  Cheapest window today: {start}–{end}, pints drop to ${hhPrice}.
+no HH confirmed    →  No happy hour we've confirmed here. The price is the price: ${price}.
+```
+
+**Module 3 — Cheaper nearby (geo-radius):**
+```
+found              →  Cheaper within walking distance: {pub1} (${p1}, {d1} away), {pub2} (${p2}, {d2}).
+sparse             →  Nothing cheaper we've verified within {radius}. {Pub} is the local low.
+```
+
+**Module 4 — Mini-FAQ (seeded variant pool, renders only at ≥3 real answers):**
+| Question (2–3 variants, seeded by pub id) | Answer template |
+|---|---|
+| "How much is a pint at {Pub}?" / "What's a pint cost at {Pub}?" | `A pint at {Pub} is ${price} as of {date} — ${delta} the {Suburb} average.` |
+| "Does {Pub} have a happy hour?" / "When's happy hour at {Pub}?" | `{Pub}'s happy hour runs {days} {start}–{end}, pints down to ${hhPrice}.` *(or)* `No happy hour we've confirmed. {nearbyPub} nearby runs one {days}.` |
+| "Anywhere cheaper near {Pub}?" / "Cheaper pint near {Pub}?" | `{cheaperPub}, {distance} away, has a pint at ${price} — ${delta} less.` |
+
+**Module 5 — Verification stub (Tier-C / price-less pages):**
+> `No verified price here yet. Last Andrew call: {date | never}. {n} nearby pubs have a checked price — start with {nearestPub} at ${price} →`
+
+**Pub meta description:** `{Pub} pours a ${price} pint ({delta} the {Suburb} average), checked {date}. {hhClause | nearbyCheaperClause}`
+
+---
+
+## 8. Guides (5)
+
+Feature pages under `/guides/*`. Each needs a dry standfirst (the SEO + voice surface); the interactive component supplies the rest.
+
+- **`/guides/beer-weather`** — `# Beer weather in Perth` / `What the forecast says about where to drink. Hot one → beach pubs and beer gardens. Rain → somewhere with a roof and a fireplace. We match today's weather to the pubs that suit it.`
+- **`/guides/cozy-corners`** *(URL slug stays; prose is "cosy")* — `# Cosy Perth pubs` / `Low light, a fireplace, a corner you don't have to share. The Perth pubs built for a slow pint when it's cold or wet out.`
+- **`/guides/dad-bar`** — `# Perth pubs with a playground` / `Pubs where the kids can run riot and you can still get a pint. Beer gardens, playgrounds, and what a pint costs at each.` *(existing DadBar one-liners are on-voice — keep them.)*
+- **`/guides/punt-and-pints`** — `# Pubs for a punt and a pint` / `A TAB, the races on, and a pint that won't clean you out. The Perth pubs that do both.`
+- **`/guides/sunset-sippers`** — `# Perth pubs for a sundowner` / `West-facing, a view, and a pint timed to the sunset. Where to be when the sun drops over the Indian Ocean.`
+
+---
+
+## 9. Insights (5)
+
+Data pages under `/insights/*`. Each leads with the headline number.
+
+- **`/insights/pint-index`** — `# The Perth Pint Index` / `The median pint in Perth is ${median} this week. A year ago it was ${medianLastYear}. The Index tracks that number across {venueCount} pubs and updates as prices come in, so it moves with the city rather than with a press release. Below: the spread by suburb, which way prices have moved this quarter, and the pubs still holding the line under $10.`
+- **`/insights/pint-of-the-day`** — `# Pint of the day` / `One pub, one price, picked daily for value. Today it's {pub} in {suburb}: ${price}, ${delta} the suburb average, checked {date}.`
+- **`/insights/suburb-rankings`** — `# Perth suburbs ranked by pint price` / `Cheapest to dearest, by average verified pint. {cheapestSuburb} leads at ${x}; {dearestSuburb} sits at ${y}. {n} suburbs ranked, each price dated.`
+- **`/insights/tonights-best-bets`** — `# Tonight's best bets` / `The cheapest pints and live happy hours, right now. {liveCount} happy hours on, cheapest pint ${x} at {pub}. Updates as the night moves.`
+- **`/insights/venue-breakdown`** — `# Perth pubs by the numbers` / `How {venueCount} pubs stack up: the price spread, how many sit under $10, which suburbs run cheap. The data behind the Index.`
+
+---
+
+## 10. Corny-drift fixes (live copy the brief now flags)
+
+In the weather/guide components ([BeerWeather.tsx](../src/components/BeerWeather.tsx), [RainyDay.tsx](../src/components/RainyDay.tsx), [SunsetSippers.tsx](../src/components/SunsetSippers.tsx), [PuntNPints.tsx](../src/components/PuntNPints.tsx)):
+
+| Live (corny) | Fix (dry) |
+|---|---|
+| `Scorcher! Head to the beach pubs for a cold one` | `Hot one today — head for the beach pubs.` |
+| `Mint conditions. Get outside and grab a pint!` | `Good pub weather. Worth getting outside for.` |
+| `Cozy up inside with a cold one` | `Rain's in. Good day to be inside with a pint.` |
+| `Perfect excuse for a cheeky pint by the window` | `A good excuse for a pint by the window.` |
+| `Nothing beats rain on the roof and a cold one in hand` | `Rain on the roof, a pint in hand. Hard to beat.` |
+
+Full sweep + exact line list to be confirmed against the components during build.
+
+---
+
+## Acceptance (per surface)
+
+A surface is "done" when: (1) copy renders from real data slots (no invented values, truthful absence handled); (2) it passes the brief's 7-question Voice Test, especially Q7 (read aloud — dry, not a brand trying to be fun); (3) AU spelling clean; (4) repeated surfaces draw phrasing from a seeded pool (no identical sentences across pages); (5) title <60 chars, meta description <160, canonical + OG present (SEO-MASTER rules).


### PR DESCRIPTION
Adds the adopted Perth Pint Prices voice standard and the whole-site copy specs that implement it. **Docs only — no code.**

- `docs/brand-voice-brief.md` — the voice standard: dry/deadpan/specific (the perthisok register), no exclamation marks, slang rationed, AU spelling, freshness as the trust signal, anti-sameness for the templated pages. Its 7-question Voice Test is the per-surface acceptance gate.
- `docs/content-pack-v1.md` — whole-site surface copy specs: global chrome, homepage, `/discover`, `/happy-hour`, `/suburbs`, `/[suburb]`, pub-page module voice strings, 5 guides, 5 insights, the corny-drift fix table, and per-surface acceptance criteria.

Backs PRD #83 (milestone: Site Voice & Content). Seams: pub-page module *structure* stays with `docs/pub-page-content-plan.md`; FAQPage/landing-page *markup* stays with milestone #3 — this PR owns the **words**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
