### PR TITLE
feat: seededVariant — deterministic anti-sameness picker (#86)

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,11 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Site voice workstream kicked off (2026-05-31)
+- **Voice standard + copy specs landed (PR #84, `ab4704a`):** adopted `docs/brand-voice-brief.md` — the dry/deadpan perthisok register (no exclamation marks, AU spelling, freshness as the trust signal, the 7-question Voice Test as the per-surface gate) — and `docs/content-pack-v1.md`, whole-site surface copy written as data-fed string builders. Captured as PRD #83 under new milestone **#8 "Site Voice & Content"**.
+- **PRD #83 sliced into 8 tracer-bullet issues (#86–#93):** `seededVariant` (#86), corny-drift cleanup (#87), hub standfirsts (#88), `/[suburb]` lead + `suburbObservation` (#89), homepage + global chrome (#90), 5 guide standfirsts (#91), 5 insight standfirsts (#92), pub-page voice strings `voiceCopy` (#93, blocked by #86). Copy slices gated AFK + screenshots-on-PR against the Voice Test; all tracked on board #6.
+- **#86 `seededVariant` shipped:** deterministic anti-sameness phrasing picker (rendezvous/HRW hashing over a cyrb53 string hash) so the ~850 templated pages don't converge — same id always renders the same wording, picks spread across the pool, and appending a variant only ever moves a bounded share onto the new entry (minimal-disruption growth, asserted). Pure `src/lib` module + co-located tests; no UI, so the screenshot gate doesn't apply. Verified `npx tsc --noEmit` and **189/189 tests** (`tsx --test`).
+
 ### Pub-page SEO Phase 0 shipped (2026-05-31, PR #82)
 - **Issues #69/#70/#71 / merge commit `da2ec80`:** shipped the indexability/freshness foundation from `docs/pub-page-content-plan.md` (merged in PR #81). Pub pages now use a tested Tier A/B/C `dataScore` helper: Tier-C price-less husks stay live for users/internal links but emit `noindex,follow`; Tier A/B pages remain indexable.
 - **Sitemap honesty:** `sitemap.xml` now includes only Tier A/B pub URLs, uses real `last_verified` / `updated_at` / `last_updated` freshness dates instead of build-time `Date.now()`, and derives suburb/static `lastModified` from all child pub freshness rather than only the indexable subset. Live-data check: 857 routable pubs, 232 indexable pub rows, 397 sitemap URLs.

--- a/src/lib/seededVariant.test.ts
+++ b/src/lib/seededVariant.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { seededVariant } from './seededVariant'
+
+const POOL = ['alpha', 'bravo', 'charlie'] as const
+
+describe('seededVariant', () => {
+  it('returns the same element for the same id across repeated calls', () => {
+    const first = seededVariant('the-norfolk-hotel', POOL)
+    for (let i = 0; i < 5; i++) {
+      assert.equal(seededVariant('the-norfolk-hotel', POOL), first)
+    }
+  })
+
+  it('pins specific id -> phrasing picks (regression against hash drift)', () => {
+    // Goldens observed from the shipped cyrb53 + HRW impl. If the hash or the
+    // selection changes, these break — which is the point: ~850 live pages would
+    // silently re-word otherwise.
+    assert.equal(seededVariant('the-norfolk-hotel', POOL), 'alpha')
+    assert.equal(seededVariant('the-river', POOL), 'bravo')
+    assert.equal(seededVariant('fremantle', POOL), 'alpha')
+    assert.equal(seededVariant('northbridge', POOL), 'bravo')
+  })
+
+  it('always returns an element of the pool', () => {
+    for (let i = 0; i < 200; i++) {
+      assert.ok(POOL.includes(seededVariant(`pub-${i}`, POOL)))
+    }
+  })
+
+  it('treats a numeric id the same as its string form', () => {
+    assert.equal(seededVariant(42, POOL), seededVariant('42', POOL))
+    assert.equal(seededVariant(0, POOL), seededVariant('0', POOL))
+  })
+
+  it('returns the sole element for a single-entry pool', () => {
+    assert.equal(seededVariant('anything', ['only']), 'only')
+  })
+
+  it('throws on an empty pool', () => {
+    assert.throws(() => seededVariant('x', []), /pool must not be empty/)
+  })
+
+  it('spreads picks across the pool without starving or dominating any entry', () => {
+    const counts: Record<string, number> = { alpha: 0, bravo: 0, charlie: 0 }
+    const n = 1000
+    for (let i = 0; i < n; i++) counts[seededVariant(`pub-${i}`, POOL)]++
+    for (const entry of POOL) {
+      const share = counts[entry] / n
+      assert.ok(share > 0.25 && share < 0.42, `${entry} share ${share.toFixed(3)} out of band`)
+    }
+  })
+
+  it('only reassigns an id onto the appended entry when the pool grows', () => {
+    const before = ['alpha', 'bravo', 'charlie'] as const
+    const after = ['alpha', 'bravo', 'charlie', 'delta'] as const
+    let movedToNew = 0
+    for (let i = 0; i < 1000; i++) {
+      const id = `pub-${i}`
+      const was = seededVariant(id, before)
+      const now = seededVariant(id, after)
+      if (now !== was) {
+        // The only legal move is onto the new entry — never between existing ones.
+        assert.equal(now, 'delta', `id ${id} moved ${was} -> ${now}, not onto the new entry`)
+        movedToNew++
+      }
+    }
+    assert.ok(movedToNew > 0, 'appended entry was dead on arrival')
+    // HRW theory puts the migrated share near 1/4 (3 -> 4 entries); 0.4n leaves
+    // headroom while still failing a picker that reshuffles most ids.
+    assert.ok(movedToNew < 1000 * 0.4, `${movedToNew} ids moved — not minimal disruption`)
+  })
+})

--- a/src/lib/seededVariant.ts
+++ b/src/lib/seededVariant.ts
@@ -1,0 +1,53 @@
+// Deterministic anti-sameness picker for the ~850 templated pub/suburb pages.
+// The same id always renders the same wording (predictable review diffs), and
+// picks spread across the pool so no two pages collapse onto one phrasing — the
+// scaled-content fingerprint Google penalises.
+//
+// Implemented with rendezvous (highest-random-weight) hashing rather than
+// `hash(id) % pool.length`. The modulo approach reshuffles every id's pick when
+// the pool grows; rendezvous gives a minimal-disruption growth contract:
+// appending a phrasing reassigns an id ONLY to the new entry (never between
+// existing entries), so adding a variant migrates a bounded ~1/n share onto it
+// and leaves everyone else untouched.
+
+// cyrb53 — a fast, well-distributed deterministic 53-bit string hash. No clock,
+// no Math.random: identical output across runs and process restarts.
+function cyrb53(str: string): number {
+  let h1 = 0xdeadbeef
+  let h2 = 0x41c6ce57
+  for (let i = 0; i < str.length; i++) {
+    const ch = str.charCodeAt(i)
+    h1 = Math.imul(h1 ^ ch, 2654435761)
+    h2 = Math.imul(h2 ^ ch, 1597334677)
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507)
+  h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909)
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507)
+  h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909)
+  return 4294967296 * (2097151 & h2) + (h1 >>> 0)
+}
+
+/**
+ * Deterministically pick one element of `pool`, seeded by `id`.
+ *
+ * Same `id` + same `pool` always returns the same element. Picks spread across
+ * the pool. Appending an entry only ever moves an id onto the new entry.
+ *
+ * @throws if `pool` is empty.
+ */
+export function seededVariant<T>(id: string | number, pool: readonly T[]): T {
+  if (pool.length === 0) {
+    throw new Error('seededVariant: pool must not be empty')
+  }
+  const key = String(id)
+  let bestIndex = 0
+  let bestWeight = cyrb53(`${key}:0`)
+  for (let i = 1; i < pool.length; i++) {
+    const weight = cyrb53(`${key}:${i}`)
+    if (weight > bestWeight) {
+      bestWeight = weight
+      bestIndex = i
+    }
+  }
+  return pool[bestIndex]
+}


### PR DESCRIPTION
## Summary

Ships #86 — `seededVariant`, the deterministic anti-sameness phrasing picker the ~850 templated pub pages will lean on so they don't converge into the scaled-content fingerprint Google penalises. Foundation for the pub-page voice strings (#93).

## What

- `src/lib/seededVariant.ts` — `seededVariant(id, pool)` picks a pool element by **rendezvous / highest-random-weight (HRW) hashing** over a cyrb53 string hash. The same id always renders the same wording (predictable review diffs); picks spread across the pool; and appending a variant only ever moves a bounded (~¼) share onto the new entry (minimal-disruption growth) — never reshuffling between existing entries.
- Chosen over `hash(id) % len` deliberately: modulo reshuffles *every* page's wording the moment a variant is added; HRW doesn't.

## Tests (`tsx --test`, co-located)

Determinism, golden regressions (pin against hash drift), membership, numeric-id coercion (incl. `0`), single-element pool, empty-pool throw, distribution (no starvation/dominance), and the growth contract (only-moves-to-new-entry + bounded share).

## Review

`/code-review` with 3 independent reviewers — **no correctness bugs** (cyrb53 verified bit-for-bit against the canonical impl; HRW property holds; delimiter safe by construction). Applied 2 test-integrity fixes from the review (tightened the growth bound to `<0.4n`; added the `id=0` coercion assertion).

## Verification

- `npx tsc --noEmit` clean
- `npm test` → **189/189**
- Pure lib, no UI surface — the voice screenshot gate is N/A.

## Notes

Also backfills the PROJECT-STATUS entry for the voice-docs merge (#84) — confirmed PR #85 doesn't cover it — and records the #83 → #86–93 slicing.

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)
