### PR TITLE
feat: answer-first standfirsts on the three hubs (#88)

### DIFF
--- a/src/app/discover/DiscoverClient.tsx
+++ b/src/app/discover/DiscoverClient.tsx
@@ -103,11 +103,17 @@ export default function DiscoverClient() {
     happy: pubs.filter(p => p.happyHour !== null && p.happyHour !== '').length,
   }), [pubs, verifiedPubs])
 
+  const cityStats = useMemo(() => {
+    const prices = verifiedPubs.map(p => p.price!).sort((a, b) => a - b)
+    const median = prices.length ? prices[Math.floor((prices.length - 1) / 2)] : null
+    return { venueCount: pubs.length, median, cheapest: bestBuys[0] ?? null }
+  }, [pubs, verifiedPubs, bestBuys])
+
   // ─── Loading State ───
   if (isLoading) {
     return (
       <main className="min-h-screen bg-[#FDF8F0]">
-        <h1 className="sr-only">Discover Perth&apos;s Best Pints</h1>
+        <h1 className="sr-only">Where to find a cheap pint in Perth</h1>
         <SubPageNav breadcrumbs={[{ label: 'Discover' }]} />
         <div className="flex items-center justify-center py-20">
           <div className="w-12 h-12 border-4 border-gray border-t-amber rounded-full animate-spin" />
@@ -118,16 +124,34 @@ export default function DiscoverClient() {
 
   return (
     <main className="min-h-screen bg-[#FDF8F0]">
-      <h1 className="sr-only">Discover Perth&apos;s Best Pints</h1>
+      <h1 className="sr-only">Where to find a cheap pint in Perth</h1>
       <SubPageNav breadcrumbs={[{ label: 'Discover' }]} />
 
       <div className="max-w-container mx-auto px-6">
 
         {/* ════════════════════════════════════════════
+            0. ANSWER-FIRST STANDFIRST
+            ════════════════════════════════════════════ */}
+        <section className="pt-8 sm:pt-10 mb-10 sm:mb-14">
+          <p className="font-body text-[0.95rem] leading-relaxed text-ink">
+            We track the price of a pint across {cityStats.venueCount} Perth pubs and check them often enough to be worth trusting.
+            {cityStats.cheapest && cityStats.median !== null && (
+              <> Right now the cheapest verified pint is <span className="font-mono font-bold">${cityStats.cheapest.price!.toFixed(2)}</span> at {cityStats.cheapest.name}, in {cityStats.cheapest.suburb}. The median across the city sits at <span className="font-mono font-bold">${cityStats.median.toFixed(2)}</span>.</>
+            )}
+          </p>
+          <p className="font-body text-[0.9rem] leading-relaxed text-gray-mid mt-3">
+            The practical layer the glossy bar guides skip — not the fit-out or the cocktail list, just what a pint costs, when it&apos;s cheaper, and where&apos;s cheaper nearby. Prices come from punters reporting in and from Andrew, our recorded line that rings pubs and asks. Each one carries the date we last checked.
+          </p>
+          <p className="font-body text-[0.9rem] leading-relaxed text-gray-mid mt-3">
+            Start with <Link href="#best-buys" className="text-amber font-bold hover:underline">tonight&apos;s cheapest pints</Link>, filter by <Link href="/suburbs" className="text-amber font-bold hover:underline">suburb</Link>, or see which pubs have a <Link href="/happy-hour" className="text-amber font-bold hover:underline">happy hour on now</Link>.
+          </p>
+        </section>
+
+        {/* ════════════════════════════════════════════
             1. HERO: Pint of the Day
             ════════════════════════════════════════════ */}
         {pintOfTheDay && (
-          <section className="pt-8 sm:pt-10 mb-10 sm:mb-14">
+          <section className="mb-10 sm:mb-14">
             <div className="border-3 border-ink rounded-card shadow-hard-sm bg-white py-10 px-6 text-center">
               <p className="font-mono text-[0.68rem] font-bold uppercase tracking-[0.1em] text-gray-mid mb-2">
                 <Star className="w-3.5 h-3.5 inline -mt-0.5 mr-1" />Pint of the Day

--- a/src/app/happy-hour/HappyHourClient.tsx
+++ b/src/app/happy-hour/HappyHourClient.tsx
@@ -86,6 +86,11 @@ export default function HappyHourClient({ initialPubs }: HappyHourClientProps) {
 
   const hasLocation = locationState === 'granted' && userLocation !== null
 
+  const minHhPrice = pubs.reduce((min, p) => {
+    const pr = p.happyHourPrice ?? p.price ?? p.regularPrice
+    return pr != null && pr < min ? pr : min
+  }, Infinity)
+
   return (
     <div className="min-h-screen bg-[#FDF8F0]">
       <SubPageNav title="Happy Hours" />
@@ -94,7 +99,7 @@ export default function HappyHourClient({ initialPubs }: HappyHourClientProps) {
         {/* Page heading */}
         <div className="mb-6">
           <h1 className="font-mono font-extrabold text-[clamp(1.8rem,5vw,2.4rem)] tracking-[-0.03em] text-ink leading-[1.1]">
-            Happy Hours
+            Perth happy hours, on now
           </h1>
 
           {!loading && pubs.length > 0 && (
@@ -105,6 +110,14 @@ export default function HappyHourClient({ initialPubs }: HappyHourClientProps) {
               </span>
             </div>
           )}
+
+          <p className="font-body text-[0.9rem] leading-relaxed text-gray-mid mt-3">
+            {pubs.length > 0 ? (
+              <><span className="text-ink font-bold">{pubs.length}</span> Perth {pubs.length === 1 ? 'pub has' : 'pubs have'} a happy hour running right now{minHhPrice !== Infinity && <>, pints from <span className="font-mono font-bold text-ink">${minHhPrice.toFixed(2)}</span></>}. We list them live — what&apos;s on, what the pint drops to, and when we last confirmed it — so you&apos;re not turning up to a board that changed last month.</>
+            ) : (
+              <>No happy hours we&apos;ve confirmed running right now. They move around — check back later, or browse <Link href="/discover" className="text-amber font-bold hover:underline">all the pubs</Link>.</>
+            )}
+          </p>
 
           {lastRefresh && !loading && (
             <p className="text-gray-mid text-[0.7rem] mt-2">

--- a/src/app/suburbs/SuburbsClient.tsx
+++ b/src/app/suburbs/SuburbsClient.tsx
@@ -28,6 +28,13 @@ export default function SuburbsClient({ suburbs }: SuburbsClientProps) {
 
   const letters = Object.keys(grouped).sort()
 
+  const venueCount = suburbs.reduce((sum, s) => sum + s.pubCount, 0)
+  const withAvg = [...suburbs]
+    .filter(s => parseFloat(s.avgPrice) > 0)
+    .sort((a, b) => parseFloat(a.avgPrice) - parseFloat(b.avgPrice))
+  const cheapestSuburb = withAvg[0] ?? null
+  const dearestSuburb = withAvg.length ? withAvg[withAvg.length - 1] : null
+
   return (
     <div className="min-h-screen bg-[#FDF8F0]">
       <SubPageNav title="Suburbs" subtitle={`${suburbs.length} suburbs`} />
@@ -36,10 +43,13 @@ export default function SuburbsClient({ suburbs }: SuburbsClientProps) {
         {/* Header */}
         <div className="mb-8">
           <h1 className="font-mono font-extrabold text-[clamp(1.8rem,5vw,2.4rem)] tracking-[-0.03em] text-ink leading-[1.1] mb-2">
-            All Suburbs
+            Pint prices by Perth suburb
           </h1>
-          <p className="text-[0.9rem] text-gray-mid">
-            {suburbs.length} suburbs across Perth. Find pint prices in your area.
+          <p className="font-body text-[0.9rem] leading-relaxed text-gray-mid">
+            Every Perth suburb we cover, with the cheapest pint, the average, and how many pubs — <span className="text-ink font-bold">{suburbs.length}</span> suburbs, <span className="text-ink font-bold">{venueCount}</span> pubs, each price showing when we last checked.
+            {cheapestSuburb && dearestSuburb && cheapestSuburb.slug !== dearestSuburb.slug && (
+              <> <Link href={`/${cheapestSuburb.slug}`} className="text-amber font-bold hover:underline">{cheapestSuburb.name}</Link> runs cheapest right now at a ${parseFloat(cheapestSuburb.avgPrice).toFixed(2)} average; <Link href={`/${dearestSuburb.slug}`} className="text-amber font-bold hover:underline">{dearestSuburb.name}</Link> the dearest at ${parseFloat(dearestSuburb.avgPrice).toFixed(2)}.</>
+            )}
           </p>
         </div>
 


### PR DESCRIPTION
## Summary

Closes #88 — data-fed answer-first standfirsts in the PPP voice on the three high-intent hubs (content-pack §3/§4/§5).

## What

- **/discover** — lead standfirst with venue count, cheapest verified pint (pub + suburb), and city median; decision-led H1 "Where to find a cheap pint in Perth".
- **/happy-hour** — live count + min HH price, H1 "Perth happy hours, on now", with a truthful-absence line when nothing's on.
- **/suburbs** — suburb count + total venues + cheapest/dearest suburb by average; H1 "Pint prices by Perth suburb".

Every slot renders from existing client/server data; truthful-absence guards when data is missing.

## Truthful-accuracy adjustments

Matched the copy to what the pages actually do rather than the spec verbatim: §5 said "cheapest pint first" but /suburbs is A–Z/searchable; §4 mentioned sort modes the page doesn't have. Adjusted so we don't claim features that aren't there.

## Verification

- `npx tsc --noEmit` + `next lint` clean (no warnings/errors on the three files).
- Visual review: local dev has no Supabase creds, so the data-fed copy can't render locally — the holistic visual + voice review runs at the end of the batch on the Vercel previews (the site sweep).

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)
