### PR TITLE
feat: suburbObservation + answer-first /[suburb] lead (#89)

### DIFF
--- a/src/app/[suburb]/SuburbClient.tsx
+++ b/src/app/[suburb]/SuburbClient.tsx
@@ -6,6 +6,7 @@ import { CheckCircle2, HelpCircle } from 'lucide-react'
 import { Pub } from '@/types/pub'
 import { SuburbInfo } from '@/lib/supabase'
 import { getFreshness, formatVerifiedDate, FreshnessLevel } from '@/lib/freshness'
+import { suburbObservation } from '@/lib/suburbObservation'
 import SubPageNav from '@/components/SubPageNav'
 import Footer from '@/components/Footer'
 
@@ -32,6 +33,21 @@ export default function SuburbClient({ suburb, pubs, nearbySuburbs, perthAvgPric
   const diffText = avgNum > 0
     ? `${Math.abs(Math.round(priceDiff))}% ${isCheaper ? 'cheaper' : 'more expensive'} than Perth average`
     : null
+
+  // ─── Answer-first lead (content-pack §6) ───
+  const cheapestNum = Number(suburb.cheapestPrice)
+  const cheapestPubObj = pubs.find(p => p.slug === suburb.cheapestPubSlug) ?? null
+  const hasLead = suburb.cheapestPrice !== 'TBC' && cheapestNum > 0 && avgNum > 0 && !!suburb.cheapestPub
+  const leadDelta = hasLead ? avgNum - cheapestNum : 0
+  const checkedDate = cheapestPubObj?.lastVerified
+    ? new Date(cheapestPubObj.lastVerified).toLocaleDateString('en-AU', { day: 'numeric', month: 'short' })
+    : null
+  const observation = suburbObservation({
+    happyHourNowCount: pubs.filter(p => p.isHappyHourNow).length,
+    verifiedPrices: pubs.filter(p => p.priceVerified && p.price !== null).map(p => p.price as number),
+    pubCount: suburb.pubCount,
+  })
+  const neighbours = nearbySuburbs.slice(0, 2)
 
   return (
     <main className="min-h-screen bg-[#FDF8F0]">
@@ -78,13 +94,35 @@ export default function SuburbClient({ suburb, pubs, nearbySuburbs, perthAvgPric
           ))}
         </div>
 
-        {/* Auto-generated content paragraph — unique per suburb, good for SEO */}
-        <p className="text-gray-mid text-[0.82rem] leading-relaxed mt-5">
-          {suburb.name} has {suburb.pubCount} {suburb.pubCount === 1 ? 'venue' : 'venues'} tracked on Perth Pint Prices
-          {suburb.cheapestPrice !== 'TBC' && suburb.cheapestPub && (<>, with pints starting from ${suburb.cheapestPrice} at {suburb.cheapestPub}</>)}
-          {suburb.happyHourCount > 0 && (<>. {suburb.happyHourCount} {suburb.happyHourCount === 1 ? 'venue offers' : 'venues offer'} happy hour deals</>)}
-          {diffText && (<>. {suburb.name} is {diffText}</>)}
-          . All prices are community-verified and updated regularly.
+        {/* Answer-first lead (content-pack §6) — data-fed, truthful absence */}
+        <p className="font-body text-[0.9rem] leading-relaxed text-ink mt-5">
+          {hasLead ? (
+            <>
+              The cheapest pint in {suburb.name} is <span className="font-mono font-bold">${suburb.cheapestPrice}</span>
+              {suburb.cheapestPubSlug
+                ? <> at <Link href={`/${suburbSlug}/${suburb.cheapestPubSlug}`} className="text-amber font-bold hover:underline">{suburb.cheapestPub}</Link></>
+                : <> at {suburb.cheapestPub}</>}
+              {checkedDate && <> (checked {checkedDate})</>}
+              {leadDelta >= 0.5
+                ? <> — <span className="font-mono font-bold">${leadDelta.toFixed(2)}</span> under the suburb average of ${suburb.avgPrice} across {suburb.pubCount} {suburb.pubCount === 1 ? 'pub' : 'pubs'}.</>
+                : <> — about the ${suburb.avgPrice} average across {suburb.pubCount} {suburb.pubCount === 1 ? 'pub' : 'pubs'}.</>}
+              {observation && <> {observation}</>}
+              {neighbours.length > 0 && (
+                <> Or see what&apos;s cheaper nearby in {neighbours.map((ns, i) => (
+                  <span key={ns.slug}>{i > 0 ? ' or ' : ''}<Link href={`/${ns.slug}`} className="text-amber font-bold hover:underline">{ns.name}</Link></span>
+                ))}.</>
+              )}
+            </>
+          ) : (
+            <>
+              {suburb.name} has {suburb.pubCount} {suburb.pubCount === 1 ? 'venue' : 'venues'} tracked, but no verified price here yet.
+              {neighbours.length > 0 && (
+                <> Try nearby {neighbours.map((ns, i) => (
+                  <span key={ns.slug}>{i > 0 ? ' or ' : ''}<Link href={`/${ns.slug}`} className="text-amber font-bold hover:underline">{ns.name}</Link></span>
+                ))}, or report a price if you know one.</>
+              )}
+            </>
+          )}
         </p>
       </section>
 

--- a/src/lib/suburbObservation.ts
+++ b/src/lib/suburbObservation.ts
@@ -1,0 +1,49 @@
+// Picks the single strongest *real* signal for a suburb lead line, by priority:
+// happy-hour density → price spread → thin-data fallback. Renders only from real
+// stats, never a stock phrase — so the line is always backed by data (anti-corny,
+// anti-sameness). Returns null when there's nothing true and specific to say.
+
+export interface SuburbStats {
+  /** Pubs in the suburb with a happy hour running right now. */
+  happyHourNowCount: number
+  /** Verified pint prices in the suburb (one per priced pub). */
+  verifiedPrices: number[]
+  /** Total pubs tracked in the suburb. */
+  pubCount: number
+}
+
+const NUMBER_WORDS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine']
+
+function spell(n: number, capitalised = false): string {
+  if (n < 0 || n > 9) return String(n)
+  const word = NUMBER_WORDS[n]
+  return capitalised ? word[0].toUpperCase() + word.slice(1) : word
+}
+
+export function suburbObservation(stats: SuburbStats): string | null {
+  const { happyHourNowCount, verifiedPrices, pubCount } = stats
+
+  // 1. Happy-hour density — the strongest, most time-sensitive signal.
+  if (happyHourNowCount >= 2) {
+    return `${spell(happyHourNowCount, true)} have a happy hour on right now.`
+  }
+
+  // 2. Price spread — needs enough verified prices to be meaningful.
+  if (verifiedPrices.length >= 4) {
+    const sorted = [...verifiedPrices].sort((a, b) => a - b)
+    const p25 = sorted[Math.floor((sorted.length - 1) * 0.25)]
+    const p75 = sorted[Math.floor((sorted.length - 1) * 0.75)]
+    if (p75 - p25 <= 2) {
+      return `Prices run tight here — most sit between $${p25.toFixed(2)} and $${p75.toFixed(2)}.`
+    }
+    return `Prices range from $${sorted[0].toFixed(2)} to $${sorted[sorted.length - 1].toFixed(2)} across the suburb.`
+  }
+
+  // 3. Thin data — honest about coverage, feeds the report-a-price loop.
+  if (verifiedPrices.length > 0 && verifiedPrices.length < pubCount) {
+    const n = verifiedPrices.length
+    return `Only ${spell(n)} ${n === 1 ? 'has' : 'have'} a verified price so far, so this list will grow.`
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary

Closes #89 — the content-pack §6 answer-first lead on `/[suburb]`, fed by a new pure picker module.

## What

- **`src/lib/suburbObservation.ts`** — `suburbObservation(stats)` picks the single strongest *real* signal by priority: happy-hour density (≥2 on now) → price spread (tight band or range) → thin-data fallback ("only N have a verified price… this list will grow"). Returns `null` when there's nothing true to say — never a stock phrase.
- **SuburbClient lead** — replaces the generic "community-verified and updated regularly" paragraph with: cheapest pint + pub + checked date, delta under the suburb average across N pubs, the derived observation line, and cheaper-nearby neighbour links. Truthful-absence branch when there's no verified price (points to neighbours + report-a-price).

## Verification

- `npx tsc --noEmit` + `next lint` clean.
- `suburbObservation` is pure/co-located-test-ready (tests not mandated this round per the PRD).
- Visual review deferred to the end-of-batch site sweep (local dev has no Supabase creds; Vercel preview has real data).

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
