### PR TITLE
feat: homepage + global chrome copy (#90)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,8 +19,8 @@ export const viewport: Viewport = {
 
 export async function generateMetadata(): Promise<Metadata> {
   const stats = await getSiteStats()
-  const desc = `Perth's pint prices, sorted. Real prices from real people across ${stats.venueCount}+ venues and ${stats.suburbCount} suburbs.`
-  const ogDesc = `Perth's pint prices, sorted. ${stats.venueCount}+ venues. Avg: $${stats.avgPrice}. Cheapest: $${stats.cheapestPrice}.`
+  const desc = `What a pint costs across ${stats.venueCount} Perth pubs — checked, dated, and sorted cheapest first.`
+  const ogDesc = `${stats.venueCount} Perth pubs, sorted cheapest first. Average $${stats.avgPrice}, cheapest $${stats.cheapestPrice} — each price dated.`
 
   return {
     metadataBase: new URL('https://perthpintprices.com'),
@@ -30,7 +30,7 @@ export async function generateMetadata(): Promise<Metadata> {
       apple: '/apple-touch-icon.png',
     },
     title: {
-      default: "Perth Pint Prices | Perth's pint prices, sorted.",
+      default: "Perth Pint Prices | Perth's pints, sorted.",
       template: '%s | Perth Pint Prices',
     },
     description: desc,
@@ -41,10 +41,10 @@ export async function generateMetadata(): Promise<Metadata> {
           url: '/og-image.png',
           width: 1200,
           height: 630,
-          alt: "Perth Pint Prices | Perth's pint prices, sorted",
+          alt: "Perth Pint Prices | Perth's pints, sorted",
         },
       ],
-      title: "Perth Pint Prices | Perth's pint prices, sorted.",
+      title: "Perth Pint Prices | Perth's pints, sorted.",
       description: ogDesc,
       url: 'https://perthpintprices.com',
       siteName: 'Perth Pint Prices',
@@ -53,8 +53,8 @@ export async function generateMetadata(): Promise<Metadata> {
     },
     twitter: {
       card: 'summary_large_image',
-      title: "Perth Pint Prices | Perth's pint prices, sorted.",
-      description: `Perth's pint prices, sorted. ${stats.venueCount}+ venues. Find cheap pints near you.`,
+      title: "Perth Pint Prices | Perth's pints, sorted.",
+      description: `What a pint costs across ${stats.venueCount} Perth pubs — checked and sorted cheapest first.`,
     },
   }
 }

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -26,7 +26,7 @@ export default function FAQ() {
     },
     {
       q: 'Why is a pub showing "Price TBC"?',
-      a: 'We only display prices we\'ve confirmed. "Price TBC" means we know the pub exists but haven\'t verified its current pint price yet. You can help by submitting it!',
+      a: 'We only display prices we\'ve confirmed. "Price TBC" means we know the pub exists but haven\'t verified its current pint price yet. You can help by submitting it.',
     },
     {
       q: 'Is Perth Pint Prices free?',

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -24,6 +24,10 @@ export default function Footer() {
           <span className="font-mono text-[0.95rem] sm:text-[1.05rem] font-extrabold tracking-[-0.04em] leading-none">Perth Pint Prices</span>
         </div>
 
+        <p className="font-body text-[0.8rem] text-white/55 leading-relaxed max-w-[420px] mb-8">
+          Real pint prices across Perth&apos;s pubs — checked, dated, and sorted cheapest first. Community-powered, est. 2026.
+        </p>
+
         {/* Nav links — single clean row that wraps */}
         <div className="flex flex-wrap gap-x-6 gap-y-2 mb-8">
           {NAV_LINKS.map((link) => (

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -37,7 +37,7 @@ export default function HeroSection({ pubs }: HeroSectionProps) {
           <span className="text-amber italic">sorted.</span>
         </h1>
         <p className="font-body text-[1rem] text-gray-mid font-medium animate-fade-up stagger-3">
-          Real prices across 300+ Perth pubs.
+          What a pint actually costs, across {venueCount} Perth pubs.
         </p>
         <p className="font-mono text-[0.65rem] font-bold uppercase tracking-[0.12em] text-gray-mid/60 mt-2 animate-fade-up stagger-4">
           Community-powered · Est. 2026

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -38,7 +38,7 @@ export default function HowItWorks({ venueCount = 0, suburbCount = 0 }: HowItWor
           If we can&apos;t confirm it, we say so.
         </p>
         <p className="font-body text-[0.9rem] text-gray-mid font-medium text-center mb-10">
-          Community-sourced, regularly verified, always transparent.
+          Reported by punters and Andrew, dated, and sorted cheapest first.
         </p>
 
         {/* Feature cards */}

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -83,7 +83,7 @@ export default function InstallPrompt() {
               {platform === 'ios' ? 'Add Perth Pint Prices to Home Screen' : 'Install Perth Pint Prices'}
             </p>
             <p className="text-xs text-gray-mid leading-tight mt-0.5">
-              {platform === 'ios' ? 'Tap Share → Add to Home Screen' : 'Quick access to Perth pint prices'}
+              {platform === 'ios' ? 'Tap Share → Add to Home Screen' : 'The cheapest pint, one tap away.'}
             </p>
           </div>
 


### PR DESCRIPTION
## Summary

Closes #90 — homepage + global chrome copy in the PPP voice (content-pack §1–2).

## What
- **Global meta (§1):** default title → "Perth's pints, sorted."; data-fed description "What a pint costs across {venueCount} Perth pubs — checked, dated, and sorted cheapest first."; OG + Twitter aligned.
- **Homepage (§2):** hero subhead now data-fed ("What a pint actually costs, across {venueCount} Perth pubs"); HowItWorks subhead + FAQ tightened to the dry voice (dropped the boostery exclamation); Footer tagline added; install-prompt tagline ("The cheapest pint, one tap away.").

## Deferred (tracked separately — not silently dropped)
- **Sitewide "Submit a Price" → "Report a price" CTA rename** — the brief prefers the outcome-led verb, but the string lives in 8 files including DiscoverClient/SuburbClient (already in open PRs #96/#97) and the global SubPageNav. Doing it here would collide; it's a clean post-merge follow-up (I'll file it under milestone #8).
- **§2 data-fed FAQ Q&A restructure** — needs price data threaded into the FAQ client component; the FAQ markup is milestone #3's #27. The hero already surfaces the live cheapest pint.

## Verification
- `npx tsc --noEmit` + `next lint` clean.
- Visual review deferred to the end-of-batch site sweep (local dev has no Supabase creds; Vercel preview has data).

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)
