### PR TITLE
feat: guide standfirsts in the dry voice (#91)

### DIFF
--- a/src/app/guides/beer-weather/page.tsx
+++ b/src/app/guides/beer-weather/page.tsx
@@ -4,7 +4,7 @@ import BeerWeatherPage from './BeerWeatherPage'
 
 export const metadata: Metadata = {
   title: 'Beer Weather Perth',
-  description: "What's the weather saying about your next pint? Live Perth weather matched to pub picks. Scorcher? Hit a beer garden. Rainy? Find a cozy corner.",
+  description: "What the forecast says about where to drink in Perth — beach pubs and beer gardens when it's hot, somewhere with a roof when it's not.",
   alternates: { canonical: 'https://perthpintprices.com/guides/beer-weather' },
   openGraph: {
     title: 'Beer Weather Perth | Perth Pint Prices',
@@ -28,7 +28,7 @@ export default function Page() {
       ]} />
       <div className="sr-only" aria-hidden="true">
         <h1>Beer Weather Perth - Today&apos;s Best Pub Picks</h1>
-        <p>Live Perth weather matched to pub recommendations. Find beer gardens for sunny days, cozy corners for rainy weather, and rooftop bars for warm evenings across Perth&apos;s best venues.</p>
+        <p>Today&apos;s Perth forecast matched to the right pub — beer gardens for hot days, sheltered corners for the rain, and rooftop spots for warm evenings.</p>
         <a href="/">Home</a>
         <a href="/discover">Discover</a>
         <a href="/happy-hour">Happy Hours</a>

--- a/src/app/guides/cozy-corners/CozyCornersPage.tsx
+++ b/src/app/guides/cozy-corners/CozyCornersPage.tsx
@@ -5,9 +5,9 @@ import RainyDay from '@/components/RainyDay'
 
 export default function CozyCornersPage() {
   return (
-    <FeaturePageShell title="Cozy Corners Perth" breadcrumbs={[
+    <FeaturePageShell title="Cosy Corners Perth" breadcrumbs={[
       { label: 'Guides', href: '/guides' },
-      { label: 'Cozy Corners' },
+      { label: 'Cosy Corners' },
     ]}>
       {({ pubs, userLocation }) => (
         <RainyDay pubs={pubs} userLocation={userLocation} />

--- a/src/app/guides/cozy-corners/page.tsx
+++ b/src/app/guides/cozy-corners/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
   alternates: { canonical: 'https://perthpintprices.com/guides/cozy-corners' },
   openGraph: {
     title: 'Cosy Corners Perth: Best Rainy Day Pubs | Perth Pint Prices',
-    description: "Perth's cosiest pubs for rainy days. Warm, sheltered, and perfect for a pint.",
+    description: "Perth's cosiest pubs for a rainy day — low light, a fireplace, and a slow pint when it's wet out.",
     url: 'https://perthpintprices.com/guides/cozy-corners',
     type: 'website',
     siteName: 'Perth Pint Prices',
@@ -28,7 +28,7 @@ export default function Page() {
       ]} />
       <div className="sr-only" aria-hidden="true">
         <h1>Cosy Corners Perth - Best Rainy Day Pubs</h1>
-        <p>Perth&apos;s cosiest pubs for when the weather turns. Discover sheltered venues with fireplaces, covered beer gardens, and warm indoor spaces perfect for a pint on a rainy day.</p>
+        <p>Perth&apos;s cosiest pubs for when the weather turns — sheltered venues with fireplaces, covered beer gardens, and warm corners for a slow pint when it&apos;s wet out.</p>
         <a href="/">Home</a>
         <a href="/discover">Discover</a>
         <a href="/happy-hour">Happy Hours</a>

--- a/src/app/guides/cozy-corners/page.tsx
+++ b/src/app/guides/cozy-corners/page.tsx
@@ -3,17 +3,17 @@ import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 import CozyCornersPage from './CozyCornersPage'
 
 export const metadata: Metadata = {
-  title: 'Cozy Corners Perth: Best Rainy Day Pubs',
-  description: "When Perth's weather turns, these cozy pubs have you covered. Find warm, sheltered venues with fireplaces, covered areas, and comfort food.",
+  title: 'Cosy Corners Perth: Best Rainy Day Pubs',
+  description: "Low light, a fireplace, a corner you don't have to share. The Perth pubs built for a slow pint when it's cold or wet out.",
   alternates: { canonical: 'https://perthpintprices.com/guides/cozy-corners' },
   openGraph: {
-    title: 'Cozy Corners Perth: Best Rainy Day Pubs | Perth Pint Prices',
+    title: 'Cosy Corners Perth: Best Rainy Day Pubs | Perth Pint Prices',
     description: "Perth's cosiest pubs for rainy days. Warm, sheltered, and perfect for a pint.",
     url: 'https://perthpintprices.com/guides/cozy-corners',
     type: 'website',
     siteName: 'Perth Pint Prices',
     locale: 'en_AU',
-    images: [{ url: 'https://perthpintprices.com/og-image.png', width: 1200, height: 630, alt: 'Cozy Corners Perth - Best Rainy Day Pubs | Perth Pint Prices' }],
+    images: [{ url: 'https://perthpintprices.com/og-image.png', width: 1200, height: 630, alt: 'Cosy Corners Perth - Best Rainy Day Pubs | Perth Pint Prices' }],
   },
   twitter: { card: 'summary_large_image' },
 }
@@ -24,10 +24,10 @@ export default function Page() {
       <BreadcrumbJsonLd items={[
         { name: 'Home', url: 'https://perthpintprices.com' },
         { name: 'Discover', url: 'https://perthpintprices.com/discover' },
-        { name: 'Cozy Corners', url: 'https://perthpintprices.com/guides/cozy-corners' },
+        { name: 'Cosy Corners', url: 'https://perthpintprices.com/guides/cozy-corners' },
       ]} />
       <div className="sr-only" aria-hidden="true">
-        <h1>Cozy Corners Perth - Best Rainy Day Pubs</h1>
+        <h1>Cosy Corners Perth - Best Rainy Day Pubs</h1>
         <p>Perth&apos;s cosiest pubs for when the weather turns. Discover sheltered venues with fireplaces, covered beer gardens, and warm indoor spaces perfect for a pint on a rainy day.</p>
         <a href="/">Home</a>
         <a href="/discover">Discover</a>

--- a/src/app/guides/punt-and-pints/page.tsx
+++ b/src/app/guides/punt-and-pints/page.tsx
@@ -4,7 +4,7 @@ import PuntAndPintsPage from './PuntAndPintsPage'
 
 export const metadata: Metadata = {
   title: 'Punt & Pints: Perth Pubs with TAB Facilities',
-  description: "Find Perth pubs with TAB facilities. Watch the races, place a bet, and enjoy a cold pint. Verified prices across Perth.",
+  description: "A TAB, the races on, and a pint that won't clean you out. The Perth pubs that do both, with verified prices.",
   alternates: { canonical: 'https://perthpintprices.com/guides/punt-and-pints' },
   openGraph: {
     title: 'Punt & Pints: Perth Pubs with TAB | Perth Pint Prices',

--- a/src/app/guides/sunset-sippers/page.tsx
+++ b/src/app/guides/sunset-sippers/page.tsx
@@ -4,7 +4,7 @@ import SunsetSippersPage from './SunsetSippersPage'
 
 export const metadata: Metadata = {
   title: 'Sunset Sippers Perth: Best Golden Hour Pubs',
-  description: "Find Perth's best sunset pubs. Watch the sun go down with a cold pint at venues with west-facing views and beer gardens.",
+  description: "West-facing, a view, and a pint timed to the sunset. Where to be when the sun drops over the Indian Ocean.",
   alternates: { canonical: 'https://perthpintprices.com/guides/sunset-sippers' },
   openGraph: {
     title: 'Sunset Sippers Perth: Best Golden Hour Pubs | Perth Pint Prices',


### PR DESCRIPTION
## Summary

Closes #91 — the 5 guide pages' SEO + voice surface (meta description + sr-only intro) reworked to the content-pack §8 standfirsts.

## What
- **beer-weather** — drops the corny "Scorcher? Hit a beer garden. Rainy? Find a cozy corner" the brief flags (this also clears the meta-description "Scorcher" I flagged from #87).
- **cozy-corners** — American "Cozy" → "Cosy" in all prose (title, OG, breadcrumb, sr-only H1, description). The `cozy-corners` URL slug and the `CozyCornersPage` component name stay (SEO + code identifiers).
- **punt-and-pints**, **sunset-sippers** — dry §8 standfirsts.
- **dad-bar** — left as-is; §8 says its one-liners are already on-voice.

## Verification
- `npx tsc --noEmit` + `next lint` clean.
- Visual review deferred to the end-of-batch site sweep.

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)
