### PR TITLE
feat: insight standfirsts in the dry voice (#92)

### DIFF
--- a/src/app/insights/pint-index/page.tsx
+++ b/src/app/insights/pint-index/page.tsx
@@ -4,7 +4,7 @@ import PintIndexPage from './PintIndexPage'
 
 export const metadata: Metadata = {
   title: 'Perth Pint Index™: Live Beer Price Tracker',
-  description: "Track Perth's average pint price over time. The Perth Pint Index™ monitors beer pricing trends across 300+ venues with weekly snapshots.",
+  description: "The median pint in Perth, tracked across the pubs we cover and updated as prices come in — the spread by suburb, the quarter's moves, and who's still under $10.",
   alternates: { canonical: 'https://perthpintprices.com/insights/pint-index' },
   openGraph: {
     title: 'Perth Pint Index™: Live Beer Price Tracker | Perth Pint Prices',
@@ -28,7 +28,7 @@ export default function Page() {
       ]} />
       <div className="sr-only" aria-hidden="true">
         <h1>Perth Pint Index - Live Beer Price Tracker</h1>
-        <p>Track Perth&apos;s average pint price over time. The Perth Pint Index monitors beer pricing trends across 300+ venues with weekly snapshots and historical data.</p>
+        <p>The median pint in Perth, tracked across every pub we cover and updated as prices come in. The Index shows the spread by suburb, which way prices moved this quarter, and the pubs still holding under $10.</p>
         <a href="/">Home</a>
         <a href="/discover">Discover</a>
         <a href="/happy-hour">Happy Hours</a>

--- a/src/app/insights/pint-of-the-day/page.tsx
+++ b/src/app/insights/pint-of-the-day/page.tsx
@@ -4,7 +4,7 @@ import PintOfTheDayPage from './PintOfTheDayPage'
 
 export const metadata: Metadata = {
   title: "Perth Pint of the Day: Today's Best Value Beer",
-  description: "Today's best value pint in Perth, algorithmically picked from 300+ venues. Updated daily with verified prices from real pub-goers.",
+  description: "One pub, one price, picked daily for value — today's pint, how it compares to the suburb average, and the date we last checked it.",
   alternates: { canonical: 'https://perthpintprices.com/insights/pint-of-the-day' },
   openGraph: {
     title: "Perth Pint of the Day | Perth Pint Prices",
@@ -28,7 +28,7 @@ export default function Page() {
       ]} />
       <div className="sr-only" aria-hidden="true">
         <h1>Perth Pint of the Day - Today&#39;s Best Value Beer</h1>
-        <p>Today&#39;s best value pint in Perth, algorithmically selected from 300+ venues. Updated daily with community-verified prices from real pub-goers across Perth suburbs.</p>
+        <p>One pub, one price, picked daily for value. Today&#39;s pint, how it compares to the suburb average, and the date we last checked — updated every day from verified prices.</p>
         <a href="/">Home</a>
         <a href="/discover">Discover</a>
         <a href="/happy-hour">Happy Hours</a>

--- a/src/app/insights/suburb-rankings/page.tsx
+++ b/src/app/insights/suburb-rankings/page.tsx
@@ -4,7 +4,7 @@ import SuburbRankingsPage from './SuburbRankingsPage'
 
 export const metadata: Metadata = {
   title: 'Perth Suburb Pint Rankings: Cheapest Areas',
-  description: "Compare pint prices across every Perth suburb. Find the cheapest suburbs for a beer, from Fremantle to Joondalup. Ranked by average pint price.",
+  description: "Perth suburbs ranked cheapest to dearest by average verified pint, each price dated. Which areas run cheap, and which don't.",
   alternates: { canonical: 'https://perthpintprices.com/insights/suburb-rankings' },
   openGraph: {
     title: 'Perth Suburb Pint Price Rankings | Perth Pint Prices',
@@ -28,7 +28,7 @@ export default function Page() {
       ]} />
       <div className="sr-only" aria-hidden="true">
         <h1>Perth Suburb Pint Rankings - Cheapest Areas for a Beer</h1>
-        <p>Compare pint prices across every Perth suburb. See which areas offer the cheapest pints on average, from Fremantle to Joondalup, ranked by community-verified prices.</p>
+        <p>Every Perth suburb ranked cheapest to dearest by its average verified pint, each price dated. See which areas run cheap and which sit at the top.</p>
         <a href="/">Home</a>
         <a href="/discover">Discover</a>
         <a href="/happy-hour">Happy Hours</a>

--- a/src/app/insights/tonights-best-bets/page.tsx
+++ b/src/app/insights/tonights-best-bets/page.tsx
@@ -4,7 +4,7 @@ import TonightsBestBetsPage from './TonightsBestBetsPage'
 
 export const metadata: Metadata = {
   title: "Tonight's Best Pints in Perth",
-  description: "Find the cheapest pints in Perth right now. Live happy hour deals, tonight's best bets, and where to get the most value on your next round.",
+  description: "The cheapest pints and live happy hours in Perth right now, updating as the night moves — what's on, what it costs, and where.",
   alternates: { canonical: 'https://perthpintprices.com/insights/tonights-best-bets' },
   openGraph: {
     title: "Tonight's Best Pints in Perth | Perth Pint Prices",
@@ -28,7 +28,7 @@ export default function Page() {
       ]} />
       <div className="sr-only" aria-hidden="true">
         <h1>Tonight&#39;s Best Pints in Perth</h1>
-        <p>Find the cheapest pints available in Perth right now. Live happy hour deals, tonight&#39;s best value picks, and real-time pricing across 300+ Perth venues.</p>
+        <p>The cheapest pints and live happy hours in Perth right now. What&#39;s on, what the pint costs, and where — updated as the night moves.</p>
         <a href="/">Home</a>
         <a href="/discover">Discover</a>
         <a href="/happy-hour">Happy Hours</a>

--- a/src/app/insights/venue-breakdown/page.tsx
+++ b/src/app/insights/venue-breakdown/page.tsx
@@ -4,7 +4,7 @@ import VenueBreakdownPage from './VenueBreakdownPage'
 
 export const metadata: Metadata = {
   title: 'Perth Pub Prices by Bracket',
-  description: "How Perth's 300+ pubs stack up by price bracket. See which venues are cheap, which are overpriced, and where the value actually is.",
+  description: "How Perth's pubs stack up by the numbers — the price spread, how many sit under $10, and which suburbs run cheap.",
   alternates: { canonical: 'https://perthpintprices.com/insights/venue-breakdown' },
   openGraph: {
     title: 'Perth Pub Prices by Bracket | Perth Pint Prices',
@@ -28,7 +28,7 @@ export default function Page() {
       ]} />
       <div className="sr-only" aria-hidden="true">
         <h1>Perth Pub Prices by Bracket</h1>
-        <p>See how Perth&#39;s 300+ pubs stack up by price bracket. Discover which venues offer genuine value, which are overpriced, and where the best deals are hiding.</p>
+        <p>How every Perth pub we track stacks up by the numbers — the price spread, how many sit under $10, and which suburbs run cheap. The data behind the Index.</p>
         <a href="/">Home</a>
         <a href="/discover">Discover</a>
         <a href="/happy-hour">Happy Hours</a>


### PR DESCRIPTION
## Summary

Closes #92 — the 5 insight pages' SEO + voice surface (meta description + sr-only intro) reworked to the content-pack §9 standfirsts (headline-first, dry).

## What
pint-index, pint-of-the-day, suburb-rankings, tonights-best-bets, venue-breakdown — each now leads with its headline framing in the dry voice. Also drops the stale hardcoded **"300+ venues"** (actual is 857; the live numbers render in each interactive component, so static meta no longer claims a fixed count). AU spelling, no exclamation marks.

## Verification
- `npx tsc --noEmit` + `next lint` clean.
- Visual review deferred to the end-of-batch site sweep.

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)
