### PR TITLE
fix: connect pub page JSON-LD graph

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,11 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Pub-page SEO Phase 1 schema shipped (2026-05-31)
+- **Issue #29 / commit `e6d861d`:** replaced disconnected pub-page JSON-LD with one connected `@graph`: `WebPage#webpage` points to `BarOrPub#pub` through `mainEntity`, links `BreadcrumbList#breadcrumb`, and exposes `dateModified` from `last_verified` where present.
+- **Schema correctness:** removed invalid `"$X.XX per pint"` `priceRange` strings and now emits schema-valid `$` / `$$` / `$$$` bands from regular price vs suburb average, with site average only as fallback. Kept the owner decision intact: no `Menu`, `MenuItem`, `Offer`, telephone, or guessed venue hours.
+- **Review + verification:** peer review first blocked merge on site-average banding; fixed with `getSuburbAveragePrice`, tightened partial-coordinate and invalid-time guards, and re-reviewed cleanly ("Ready to merge? Yes"). Verified `npm test` (**195/195 tests**), `npx tsc --noEmit`, `npm run lint` (existing warnings only), `npm run build`, and live-row schema checks for Tier-A and Tier-C pubs.
+
 ### Site voice workstream kicked off (2026-05-31)
 - **Voice standard + copy specs landed (PR #84, `ab4704a`):** adopted `docs/brand-voice-brief.md` — the dry/deadpan perthisok register (no exclamation marks, AU spelling, freshness as the trust signal, the 7-question Voice Test as the per-surface gate) — and `docs/content-pack-v1.md`, whole-site surface copy written as data-fed string builders. Captured as PRD #83 under new milestone **#8 "Site Voice & Content"**.
 - **PRD #83 sliced into 8 tracer-bullet issues (#86–#93):** `seededVariant` (#86), corny-drift cleanup (#87), hub standfirsts (#88), `/[suburb]` lead + `suburbObservation` (#89), homepage + global chrome (#90), 5 guide standfirsts (#91), 5 insight standfirsts (#92), pub-page voice strings `voiceCopy` (#93, blocked by #86). Copy slices gated AFK + screenshots-on-PR against the Voice Test; all tracked on board #6.

--- a/src/app/[suburb]/[pub]/page.tsx
+++ b/src/app/[suburb]/[pub]/page.tsx
@@ -1,9 +1,10 @@
 import { Metadata } from 'next'
 import { unstable_cache } from 'next/cache'
 import { notFound, permanentRedirect } from 'next/navigation'
-import { getPubBySlug, getAllPubSlugPairs, getNearbyPubs, getSiteStats } from '@/lib/supabase'
+import { getPubBySlug, getAllPubSlugPairs, getNearbyPubs, getSiteStats, getSuburbAveragePrice } from '@/lib/supabase'
 import { getPubIndexability } from '@/lib/pubIndexability'
-import { absolutePubUrl, absoluteSuburbUrl, toSuburbSlug } from '@/lib/urls'
+import { buildPubJsonLd } from '@/lib/pubJsonLd'
+import { absolutePubUrl, toSuburbSlug } from '@/lib/urls'
 import PubDetailClient from './PubDetailClient'
 
 interface PageProps {
@@ -95,6 +96,7 @@ export async function generateStaticParams() {
   return pairs.map(pair => ({ suburb: toSuburbSlug(pair.suburb), pub: pair.slug }))
 }
 
+export const dynamicParams = true
 export const revalidate = 3600
 
 export default async function PubPage({ params }: PageProps) {
@@ -107,49 +109,19 @@ export default async function PubPage({ params }: PageProps) {
     permanentRedirect(`/${suburbSlug}/${pub.slug}`)
   }
 
-  const [nearbyPubs, stats] = await Promise.all([
+  const [nearbyPubs, stats, suburbAvgPrice] = await Promise.all([
     getNearbyPubs(pub.suburb, pub.id, 8),
     getSiteStats(),
+    getSuburbAveragePrice(pub.suburb),
   ])
 
-  const jsonLd = [
-    {
-      '@context': 'https://schema.org',
-      '@type': 'BreadcrumbList',
-      itemListElement: [
-        { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://perthpintprices.com' },
-        { '@type': 'ListItem', position: 2, name: pub.suburb, item: `https://perthpintprices.com/${suburbSlug}` },
-        { '@type': 'ListItem', position: 3, name: pub.name, item: `https://perthpintprices.com/${suburbSlug}/${pub.slug}` },
-      ],
-    },
-    {
-      '@context': 'https://schema.org',
-      '@type': 'BarOrPub',
-      name: pub.name,
-      address: {
-        '@type': 'PostalAddress',
-        streetAddress: pub.address,
-        addressLocality: pub.suburb,
-        addressRegion: 'WA',
-        addressCountry: 'AU',
-      },
-      geo: {
-        '@type': 'GeoCoordinates',
-        latitude: pub.lat,
-        longitude: pub.lng,
-      },
-      ...(pub.website ? { url: pub.website } : {}),
-      ...(pub.price ? {
-        priceRange: `$${pub.price.toFixed(2)} per pint`,
-      } : {}),
-    },
-  ]
+  const jsonLd = buildPubJsonLd(pub, suburbAvgPrice ?? Number(stats.avgPrice))
 
   return (
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c') }}
       />
 
       {/* Server-rendered links for crawlers — ensures this pub page has strong internal linking */}

--- a/src/lib/pubJsonLd.test.ts
+++ b/src/lib/pubJsonLd.test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { Pub } from '@/types/pub'
+import { buildPubJsonLd } from './pubJsonLd'
+
+function makePub(overrides: Partial<Pub> = {}): Pub {
+  return {
+    id: 1,
+    slug: 'the-test-pub',
+    name: 'The Test Pub',
+    address: '1 Test Street',
+    suburb: 'Fremantle',
+    lat: -32.0569,
+    lng: 115.7439,
+    price: 10,
+    regularPrice: 10,
+    effectivePrice: 10,
+    beerType: 'Lager',
+    happyHour: null,
+    website: 'https://example.com',
+    description: null,
+    priceVerified: true,
+    hasTab: false,
+    kidFriendly: false,
+    cozyPub: false,
+    happyHourPrice: null,
+    happyHourDays: null,
+    happyHourStart: null,
+    happyHourEnd: null,
+    lastVerified: '2026-05-30T08:00:00+08:00',
+    isHappyHourNow: false,
+    happyHourLabel: null,
+    happyHourMinutesRemaining: null,
+    imageUrl: null,
+    vibeTag: null,
+    ...overrides,
+  }
+}
+
+test('builds one connected pub page @graph with stable IDs', () => {
+  const jsonLd = buildPubJsonLd(makePub(), 9.5)
+  const graph = jsonLd['@graph'] as Record<string, unknown>[]
+  const [webPage, barOrPub, breadcrumb] = graph
+
+  assert.equal(jsonLd['@context'], 'https://schema.org')
+  assert.equal(graph.length, 3)
+  assert.equal(webPage['@id'], 'https://perthpintprices.com/fremantle/the-test-pub#webpage')
+  assert.deepEqual(webPage.mainEntity, { '@id': 'https://perthpintprices.com/fremantle/the-test-pub#pub' })
+  assert.deepEqual(webPage.breadcrumb, { '@id': 'https://perthpintprices.com/fremantle/the-test-pub#breadcrumb' })
+  assert.equal(webPage.dateModified, '2026-05-30T00:00:00.000Z')
+  assert.equal(barOrPub['@id'], 'https://perthpintprices.com/fremantle/the-test-pub#pub')
+  assert.equal(breadcrumb['@id'], 'https://perthpintprices.com/fremantle/the-test-pub#breadcrumb')
+})
+
+test('emits schema-valid priceRange bands, not pint-price sentences', () => {
+  const cheap = buildPubJsonLd(makePub({ regularPrice: 7, price: 7 }), 10)
+  const fair = buildPubJsonLd(makePub({ regularPrice: 10, price: 10 }), 10)
+  const pricey = buildPubJsonLd(makePub({ regularPrice: 13, price: 13 }), 10)
+
+  assert.equal(((cheap['@graph'] as Record<string, unknown>[])[1]).priceRange, '$')
+  assert.equal(((fair['@graph'] as Record<string, unknown>[])[1]).priceRange, '$$')
+  assert.equal(((pricey['@graph'] as Record<string, unknown>[])[1]).priceRange, '$$$')
+  assert.doesNotMatch(JSON.stringify(fair), /per pint/)
+})
+
+test('omits priceRange and dateModified when source data is missing', () => {
+  const jsonLd = buildPubJsonLd(makePub({ regularPrice: null, price: null, lastVerified: null }), 10)
+  const [webPage, barOrPub] = jsonLd['@graph'] as Record<string, unknown>[]
+
+  assert.equal(webPage.dateModified, undefined)
+  assert.equal(barOrPub.priceRange, undefined)
+})
+
+test('adds happy-hour openingHoursSpecification only for structured happy hour windows', () => {
+  const jsonLd = buildPubJsonLd(makePub({
+    happyHourPrice: 8,
+    happyHourDays: '{Mon,Tue,Wed,Thu,Fri}',
+    happyHourStart: '17:00:00',
+    happyHourEnd: '18:30:00',
+  }), 10)
+  const barOrPub = (jsonLd['@graph'] as Record<string, unknown>[])[1]
+  const openingHours = barOrPub.openingHoursSpecification as Record<string, unknown>
+
+  assert.equal(openingHours['@type'], 'OpeningHoursSpecification')
+  assert.deepEqual(openingHours.dayOfWeek, [
+    'https://schema.org/Monday',
+    'https://schema.org/Tuesday',
+    'https://schema.org/Wednesday',
+    'https://schema.org/Thursday',
+    'https://schema.org/Friday',
+  ])
+  assert.equal(openingHours.opens, '17:00:00')
+  assert.equal(openingHours.closes, '18:30:00')
+})
+
+test('omits geo and hasMap when either coordinate is missing', () => {
+  const missingLat = buildPubJsonLd(makePub({ lat: 0, lng: 115.7439 }), 10)
+  const missingLng = buildPubJsonLd(makePub({ lat: -32.0569, lng: 0 }), 10)
+
+  for (const jsonLd of [missingLat, missingLng]) {
+    const barOrPub = (jsonLd['@graph'] as Record<string, unknown>[])[1]
+    assert.equal(barOrPub.geo, undefined)
+    assert.equal(barOrPub.hasMap, undefined)
+  }
+})
+
+test('omits happy-hour openingHoursSpecification for invalid time values', () => {
+  const jsonLd = buildPubJsonLd(makePub({
+    happyHourPrice: 8,
+    happyHourDays: 'Friday',
+    happyHourStart: '99:00:00',
+    happyHourEnd: '18:00:00',
+  }), 10)
+  const barOrPub = (jsonLd['@graph'] as Record<string, unknown>[])[1]
+
+  assert.equal(barOrPub.openingHoursSpecification, undefined)
+})

--- a/src/lib/pubJsonLd.ts
+++ b/src/lib/pubJsonLd.ts
@@ -1,0 +1,175 @@
+import { Pub } from '@/types/pub'
+import { absolutePubUrl, absoluteSuburbUrl, BASE_URL, toSuburbSlug } from './urls'
+
+type JsonLdNode = Record<string, unknown>
+
+const DAY_URLS: Record<string, string> = {
+  mon: 'https://schema.org/Monday',
+  monday: 'https://schema.org/Monday',
+  tue: 'https://schema.org/Tuesday',
+  tuesday: 'https://schema.org/Tuesday',
+  wed: 'https://schema.org/Wednesday',
+  wednesday: 'https://schema.org/Wednesday',
+  thu: 'https://schema.org/Thursday',
+  thursday: 'https://schema.org/Thursday',
+  fri: 'https://schema.org/Friday',
+  friday: 'https://schema.org/Friday',
+  sat: 'https://schema.org/Saturday',
+  saturday: 'https://schema.org/Saturday',
+  sun: 'https://schema.org/Sunday',
+  sunday: 'https://schema.org/Sunday',
+}
+
+const ORDERED_DAY_KEYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']
+
+function toIsoDate(value: string | null): string | null {
+  if (!value) return null
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date.toISOString()
+}
+
+function parseHappyHourDays(days: string | null): string[] {
+  if (!days) return []
+
+  const normalized = days.trim().toLowerCase()
+  if (['7 days', 'daily', 'everyday', 'every day'].includes(normalized)) {
+    return ORDERED_DAY_KEYS.map(day => DAY_URLS[day])
+  }
+
+  const rawDays = normalized.startsWith('{') && normalized.endsWith('}')
+    ? normalized.slice(1, -1).split(',').map(day => day.trim())
+    : normalized.includes('-')
+      ? expandDayRange(normalized)
+      : normalized.split(',').map(day => day.trim())
+
+  return rawDays
+    .map(day => DAY_URLS[day] || DAY_URLS[day.slice(0, 3)])
+    .filter((day): day is string => Boolean(day))
+}
+
+function expandDayRange(range: string): string[] {
+  const [startRaw, endRaw] = range.split('-').map(day => day.trim().slice(0, 3))
+  const start = ORDERED_DAY_KEYS.indexOf(startRaw)
+  const end = ORDERED_DAY_KEYS.indexOf(endRaw)
+  if (start === -1 || end === -1) return []
+
+  const days: string[] = []
+  let current = start
+  while (true) {
+    days.push(ORDERED_DAY_KEYS[current])
+    if (current === end) break
+    current = (current + 1) % ORDERED_DAY_KEYS.length
+  }
+  return days
+}
+
+function toSchemaTime(value: string | null): string | null {
+  if (!value) return null
+  const match = value.match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?/)
+  if (!match) return null
+  const parsedHours = Number(match[1])
+  const parsedMinutes = Number(match[2])
+  const parsedSeconds = Number(match[3] || '0')
+  if (
+    parsedHours < 0 || parsedHours > 23
+    || parsedMinutes < 0 || parsedMinutes > 59
+    || parsedSeconds < 0 || parsedSeconds > 59
+  ) {
+    return null
+  }
+  const hours = match[1].padStart(2, '0')
+  const minutes = match[2]
+  const seconds = match[3] || '00'
+  return `${hours}:${minutes}:${seconds}`
+}
+
+function buildHappyHourOpeningHours(pub: Pub): JsonLdNode | null {
+  const dayOfWeek = parseHappyHourDays(pub.happyHourDays)
+  const opens = toSchemaTime(pub.happyHourStart)
+  const closes = toSchemaTime(pub.happyHourEnd)
+
+  if (dayOfWeek.length === 0 || !opens || !closes) return null
+
+  return {
+    '@type': 'OpeningHoursSpecification',
+    dayOfWeek,
+    opens,
+    closes,
+  }
+}
+
+function buildPriceRange(price: number | null, avgPrice: number): string | null {
+  if (price === null || price <= 0) return null
+  if (avgPrice > 0) {
+    if (price < avgPrice * 0.85) return '$'
+    if (price <= avgPrice * 1.15) return '$$'
+    return '$$$'
+  }
+  if (price < 8) return '$'
+  if (price <= 12) return '$$'
+  return '$$$'
+}
+
+export function buildPubJsonLd(pub: Pub, avgPrice: number): JsonLdNode {
+  const suburbSlug = toSuburbSlug(pub.suburb)
+  const canonical = absolutePubUrl(pub)
+  const webpageId = `${canonical}#webpage`
+  const pubId = `${canonical}#pub`
+  const breadcrumbId = `${canonical}#breadcrumb`
+  const dateModified = toIsoDate(pub.lastVerified)
+  const priceRange = buildPriceRange(pub.regularPrice ?? pub.price, avgPrice)
+  const openingHoursSpecification = buildHappyHourOpeningHours(pub)
+
+  const barOrPub: JsonLdNode = {
+    '@type': 'BarOrPub',
+    '@id': pubId,
+    name: pub.name,
+    address: {
+      '@type': 'PostalAddress',
+      streetAddress: pub.address,
+      addressLocality: pub.suburb,
+      addressRegion: 'WA',
+      addressCountry: 'AU',
+    },
+  }
+
+  if (Number.isFinite(pub.lat) && Number.isFinite(pub.lng) && pub.lat !== 0 && pub.lng !== 0) {
+    barOrPub.geo = {
+      '@type': 'GeoCoordinates',
+      latitude: pub.lat,
+      longitude: pub.lng,
+    }
+    barOrPub.hasMap = `https://www.google.com/maps/search/?api=1&query=${pub.lat},${pub.lng}`
+  }
+
+  if (pub.website) barOrPub.url = pub.website
+  if (priceRange) barOrPub.priceRange = priceRange
+  if (openingHoursSpecification) {
+    barOrPub.openingHoursSpecification = openingHoursSpecification
+  }
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebPage',
+        '@id': webpageId,
+        url: canonical,
+        name: `${pub.name} pint prices in ${pub.suburb}`,
+        mainEntity: { '@id': pubId },
+        breadcrumb: { '@id': breadcrumbId },
+        ...(dateModified ? { dateModified } : {}),
+      },
+      barOrPub,
+      {
+        '@type': 'BreadcrumbList',
+        '@id': breadcrumbId,
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Home', item: BASE_URL },
+          { '@type': 'ListItem', position: 2, name: pub.suburb, item: absoluteSuburbUrl(suburbSlug) },
+          { '@type': 'ListItem', position: 3, name: pub.name, item: canonical },
+        ],
+      },
+    ],
+  }
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -478,6 +478,22 @@ export async function getAllSuburbs(): Promise<SuburbInfo[]> {
   return suburbs
 }
 
+export async function getSuburbAveragePrice(suburbName: string): Promise<number | null> {
+  const { data, error } = await supabase
+    .from('pubs')
+    .select('price')
+    .eq('suburb', suburbName)
+    .not('price', 'is', null)
+    .gt('price', 0)
+
+  if (error || !data || data.length === 0) return null
+
+  const prices = data.map(row => Number(row.price)).filter(price => Number.isFinite(price) && price > 0)
+  if (prices.length === 0) return null
+
+  return prices.reduce((sum, price) => sum + price, 0) / prices.length
+}
+
 export async function getSuburbBySlug(slug: string): Promise<SuburbInfo | null> {
   const suburbs = await getAllSuburbs()
   return suburbs.find(s => s.slug === slug) || null


### PR DESCRIPTION
## Summary
- Replace disconnected pub-page JSON-LD nodes with a connected `@graph` for `WebPage`, `BarOrPub`, and `BreadcrumbList`
- Add stable `@id`s, `dateModified` from `lastVerified`, valid `$` / `$$` / `$$$` `priceRange` bands, and structured happy-hour windows
- Add focused tests plus defensive guards for partial coordinates and invalid happy-hour times

## Review
- Peer review initially found the site-average `priceRange` banding mismatch
- Fixed by adding `getSuburbAveragePrice(pub.suburb)` and using site average only as fallback
- Second peer review: Ready to merge? Yes

## Test Plan
- `npm test` (195/195)
- `npx tsc --noEmit`
- `npm run lint` (existing warnings only)
- `npm run build`
- Live-row schema spot check for one Tier-A and one Tier-C pub

Closes #29