### PR TITLE
feat: add AI citation signals

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -11,9 +11,9 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 ## What's done recently
 
 ### AI citation signals shipped (2026-05-31)
-- **Issue #35 / commit `58951d4`:** added `/llms.txt` as a markdown citation map for the live high-signal pages (Pint Index, live insight pages, happy hours, discover, and key suburb pages). The deleted weekly-report route stays deleted; Pint Index is the Article/schema asset per `docs/seo-action-plan.md`.
-- **Structured citation + crawler access:** added Article JSON-LD to `/insights/pint-index` with `author`, `publisher`, `dateModified`, and `dateReviewed` from real pub freshness data; added explicit GPTBot / PerplexityBot / Google-Extended allow rules while keeping `/admin` and `/api` blocked.
-- **Visible freshness:** pub pages now surface `Last verified <date>` in a semantic `<time>` element where `last_verified` exists. Verified `npm test` (**198/198 tests**), `npx tsc --noEmit`, `npm run lint` (existing warnings only), `npm run build`, local `/llms.txt` / robots / Article schema smoke checks, and desktop/mobile screenshots for the pub-page freshness row.
+- **Issue #35 / branch `codex/llms-article-schema`:** added `/llms.txt` as a markdown citation map for the live high-signal pages (Pint Index, live insight pages, happy hours, discover, and key suburb pages). The deleted weekly-report route stays deleted; Pint Index is the Article/schema asset per `docs/seo-action-plan.md`.
+- **Structured citation + crawler access:** added Article JSON-LD to `/insights/pint-index` with `author`, `publisher`, `dateModified`, and `mainEntityOfPage.lastReviewed` from real pub freshness data; added explicit GPTBot / PerplexityBot / Google-Extended allow rules while keeping `/admin` and `/api` blocked.
+- **Visible freshness:** pub pages now surface `Last verified <date>` in a semantic `<time>` element where `last_verified` exists. Verified `npm test` (**199/199 tests**), `npx tsc --noEmit`, `npm run lint` (existing warnings only), `npm run build`, local `/llms.txt` / robots / Article schema smoke checks, and desktop/mobile screenshots for the pub-page freshness row.
 
 ### Pub-page SEO Phase 1 schema shipped (2026-05-31)
 - **Issue #29 / commit `e6d861d`:** replaced disconnected pub-page JSON-LD with one connected `@graph`: `WebPage#webpage` points to `BarOrPub#pub` through `mainEntity`, links `BreadcrumbList#breadcrumb`, and exposes `dateModified` from `last_verified` where present.

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,11 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### AI citation signals shipped (2026-05-31)
+- **Issue #35 / commit `58951d4`:** added `/llms.txt` as a markdown citation map for the live high-signal pages (Pint Index, live insight pages, happy hours, discover, and key suburb pages). The deleted weekly-report route stays deleted; Pint Index is the Article/schema asset per `docs/seo-action-plan.md`.
+- **Structured citation + crawler access:** added Article JSON-LD to `/insights/pint-index` with `author`, `publisher`, `dateModified`, and `dateReviewed` from real pub freshness data; added explicit GPTBot / PerplexityBot / Google-Extended allow rules while keeping `/admin` and `/api` blocked.
+- **Visible freshness:** pub pages now surface `Last verified <date>` in a semantic `<time>` element where `last_verified` exists. Verified `npm test` (**198/198 tests**), `npx tsc --noEmit`, `npm run lint` (existing warnings only), `npm run build`, local `/llms.txt` / robots / Article schema smoke checks, and desktop/mobile screenshots for the pub-page freshness row.
+
 ### Pub-page SEO Phase 1 schema shipped (2026-05-31)
 - **Issue #29 / commit `e6d861d`:** replaced disconnected pub-page JSON-LD with one connected `@graph`: `WebPage#webpage` points to `BarOrPub#pub` through `mainEntity`, links `BreadcrumbList#breadcrumb`, and exposes `dateModified` from `last_verified` where present.
 - **Schema correctness:** removed invalid `"$X.XX per pint"` `priceRange` strings and now emits schema-valid `$` / `$$` / `$$$` bands from regular price vs suburb average, with site average only as fallback. Kept the owner decision intact: no `Menu`, `MenuItem`, `Offer`, telephone, or guessed venue hours.

--- a/src/app/[suburb]/[pub]/PubDetailClient.tsx
+++ b/src/app/[suburb]/[pub]/PubDetailClient.tsx
@@ -17,16 +17,12 @@ const PubDetailMap = dynamic(() => import('@/components/PubDetailMap'), {
   loading: () => <div className="h-[350px] bg-off-white animate-pulse rounded-card border-3 border-ink" />,
 })
 
-function timeAgo(dateStr: string): string {
-  const date = new Date(dateStr)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
-  if (diffDays < 1) return 'today'
-  if (diffDays < 7) return `${diffDays}d ago`
-  if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`
-  if (diffDays < 365) return `${Math.floor(diffDays / 30)}mo ago`
-  return `${Math.floor(diffDays / 365)}y ago`
+function formatLastVerifiedDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('en-AU', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
 }
 
 function formatHappyHourTime(start: string | null, end: string | null): string {
@@ -169,7 +165,12 @@ export default function PubDetailClient({ pub, nearbyPubs, avgPrice }: PubDetail
                   </span>
                 )}
                 {pub.lastVerified && (
-                  <span className="text-[0.7rem] text-gray-mid">Updated {timeAgo(pub.lastVerified)}</span>
+                  <time
+                    dateTime={new Date(pub.lastVerified).toISOString()}
+                    className="text-[0.7rem] text-gray-mid"
+                  >
+                    Last verified {formatLastVerifiedDate(pub.lastVerified)}
+                  </time>
                 )}
               </div>
 

--- a/src/app/insights/pint-index/page.test.ts
+++ b/src/app/insights/pint-index/page.test.ts
@@ -1,0 +1,7 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { revalidate } from './page'
+
+test('Pint Index refreshes Article freshness hourly', () => {
+  assert.equal(revalidate, 3600)
+})

--- a/src/app/insights/pint-index/page.tsx
+++ b/src/app/insights/pint-index/page.tsx
@@ -1,15 +1,21 @@
 import type { Metadata } from 'next'
 import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
+import { buildArticleJsonLd } from '@/lib/articleJsonLd'
+import { getAllPubLastModifiedPairs } from '@/lib/supabase'
 import PintIndexPage from './PintIndexPage'
+
+const canonical = 'https://perthpintprices.com/insights/pint-index'
+const description = "The median pint in Perth, tracked across the pubs we cover and updated as prices come in — the spread by suburb, the quarter's moves, and who's still under $10."
+const fallbackModified = '2026-05-31T00:00:00.000Z'
 
 export const metadata: Metadata = {
   title: 'Perth Pint Index™: Live Beer Price Tracker',
-  description: "The median pint in Perth, tracked across the pubs we cover and updated as prices come in — the spread by suburb, the quarter's moves, and who's still under $10.",
-  alternates: { canonical: 'https://perthpintprices.com/insights/pint-index' },
+  description,
+  alternates: { canonical },
   openGraph: {
     title: 'Perth Pint Index™: Live Beer Price Tracker | Perth Pint Prices',
     description: "Track Perth's average pint price over time across 300+ venues.",
-    url: 'https://perthpintprices.com/insights/pint-index',
+    url: canonical,
     type: 'website',
     siteName: 'Perth Pint Prices',
     locale: 'en_AU',
@@ -18,13 +24,38 @@ export const metadata: Metadata = {
   twitter: { card: 'summary_large_image' },
 }
 
-export default function Page() {
+function latestModifiedDate(values: Array<{ lastModified: string | null }>): string {
+  return values
+    .map(value => {
+      if (!value.lastModified) return null
+      const date = new Date(value.lastModified)
+      return Number.isNaN(date.getTime()) ? null : date.toISOString()
+    })
+    .filter((value): value is string => Boolean(value))
+    .sort()
+    .at(-1) || fallbackModified
+}
+
+export default async function Page() {
+  const latestPubModified = latestModifiedDate(await getAllPubLastModifiedPairs())
+  const articleJsonLd = buildArticleJsonLd({
+    url: canonical,
+    headline: 'Perth Pint Index: Live Beer Price Tracker',
+    description,
+    dateModified: latestPubModified,
+    dateReviewed: latestPubModified,
+  })
+
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd).replace(/</g, '\\u003c') }}
+      />
       <BreadcrumbJsonLd items={[
         { name: 'Home', url: 'https://perthpintprices.com' },
         { name: 'Discover', url: 'https://perthpintprices.com/discover' },
-        { name: 'Perth Pint Index™', url: 'https://perthpintprices.com/insights/pint-index' },
+        { name: 'Perth Pint Index™', url: canonical },
       ]} />
       <div className="sr-only" aria-hidden="true">
         <h1>Perth Pint Index - Live Beer Price Tracker</h1>

--- a/src/app/insights/pint-index/page.tsx
+++ b/src/app/insights/pint-index/page.tsx
@@ -8,6 +8,8 @@ const canonical = 'https://perthpintprices.com/insights/pint-index'
 const description = "The median pint in Perth, tracked across the pubs we cover and updated as prices come in — the spread by suburb, the quarter's moves, and who's still under $10."
 const fallbackModified = '2026-05-31T00:00:00.000Z'
 
+export const revalidate = 3600
+
 export const metadata: Metadata = {
   title: 'Perth Pint Index™: Live Beer Price Tracker',
   description,
@@ -43,7 +45,7 @@ export default async function Page() {
     headline: 'Perth Pint Index: Live Beer Price Tracker',
     description,
     dateModified: latestPubModified,
-    dateReviewed: latestPubModified,
+    lastReviewed: latestPubModified,
   })
 
   return (

--- a/src/app/llms.txt/route.test.ts
+++ b/src/app/llms.txt/route.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { GET } from './route'
+
+test('llms.txt returns markdown with live canonical URLs only', async () => {
+  const response = await GET()
+  const body = await response.text()
+
+  assert.equal(response.status, 200)
+  assert.match(response.headers.get('Content-Type') || '', /text\/markdown/)
+  assert.match(body, /^# Perth Pint Prices/)
+  assert.match(body, /https:\/\/perthpintprices\.com\/insights\/pint-index/)
+  assert.match(body, /https:\/\/perthpintprices\.com\/sitemap\.xml/)
+  assert.doesNotMatch(body, /weekly-report/)
+})

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,42 @@
+import { BASE_URL } from '@/lib/urls'
+
+const lines = [
+  '# Perth Pint Prices',
+  '',
+  'Perth Pint Prices tracks community-verified pint prices, happy hours, and suburb-level beer-price trends across Perth pubs.',
+  '',
+  '## Canonical citation pages',
+  '',
+  `- [Perth Pint Index](${BASE_URL}/insights/pint-index): live Perth pint-price trend data and the closest thing to the site methodology page.`,
+  `- [Pint of the Day](${BASE_URL}/insights/pint-of-the-day): daily venue pick from current price data.`,
+  `- [Tonight's Best Bets](${BASE_URL}/insights/tonights-best-bets): live happy-hour and value picks for tonight.`,
+  `- [Suburb Rankings](${BASE_URL}/insights/suburb-rankings): suburb-by-suburb pint-price comparisons.`,
+  `- [Happy Hours](${BASE_URL}/happy-hour): current happy-hour finder for Perth pubs.`,
+  `- [Discover](${BASE_URL}/discover): searchable pub and pint-price directory.`,
+  '',
+  '## High-signal suburb pages',
+  '',
+  `- [Fremantle](${BASE_URL}/fremantle)`,
+  `- [Northbridge](${BASE_URL}/northbridge)`,
+  `- [Perth](${BASE_URL}/perth)`,
+  `- [Subiaco](${BASE_URL}/subiaco)`,
+  `- [Leederville](${BASE_URL}/leederville)`,
+  `- [Mount Lawley](${BASE_URL}/mount-lawley)`,
+  `- [Victoria Park](${BASE_URL}/victoria-park)`,
+  `- [Scarborough](${BASE_URL}/scarborough)`,
+  '',
+  '## Crawl notes',
+  '',
+  `- Sitemap: ${BASE_URL}/sitemap.xml`,
+  '- Pub pages expose visible last-verified dates where available.',
+  '- Price-less pub pages may be crawlable but intentionally noindexed until useful price or happy-hour data exists.',
+]
+
+export async function GET() {
+  return new Response(`${lines.join('\n')}\n`, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  })
+}

--- a/src/app/robots.test.ts
+++ b/src/app/robots.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import robots from './robots'
+
+test('robots explicitly allows AI citation crawlers while keeping private routes blocked', () => {
+  const result = robots()
+  const rules = Array.isArray(result.rules) ? result.rules : [result.rules]
+  const aiRule = rules.find(rule => Array.isArray(rule.userAgent)
+    && rule.userAgent.includes('GPTBot')
+    && rule.userAgent.includes('PerplexityBot')
+    && rule.userAgent.includes('Google-Extended'))
+
+  assert.ok(aiRule)
+  assert.equal(aiRule.allow, '/')
+  assert.deepEqual(aiRule.disallow, ['/admin', '/api/'])
+  assert.equal(result.sitemap, 'https://perthpintprices.com/sitemap.xml')
+})

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -4,6 +4,11 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
       {
+        userAgent: ['GPTBot', 'PerplexityBot', 'Google-Extended'],
+        allow: '/',
+        disallow: ['/admin', '/api/'],
+      },
+      {
         userAgent: '*',
         allow: '/',
         disallow: ['/admin', '/api/'],

--- a/src/lib/articleJsonLd.test.ts
+++ b/src/lib/articleJsonLd.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { buildArticleJsonLd } from './articleJsonLd'
+
+test('buildArticleJsonLd emits Article schema with freshness fields', () => {
+  const jsonLd = buildArticleJsonLd({
+    url: 'https://perthpintprices.com/insights/pint-index',
+    headline: 'Perth Pint Index',
+    description: 'Track Perth pint prices.',
+    dateModified: '2026-05-31T00:00:00.000Z',
+    dateReviewed: '2026-05-31T00:00:00.000Z',
+  })
+
+  assert.equal(jsonLd['@context'], 'https://schema.org')
+  assert.equal(jsonLd['@type'], 'Article')
+  assert.equal(jsonLd['@id'], 'https://perthpintprices.com/insights/pint-index#article')
+  assert.deepEqual(jsonLd.mainEntityOfPage, {
+    '@type': 'WebPage',
+    '@id': 'https://perthpintprices.com/insights/pint-index',
+  })
+  assert.equal(jsonLd.author.name, 'Perth Pint Prices')
+  assert.equal(jsonLd.dateModified, '2026-05-31T00:00:00.000Z')
+  assert.equal(jsonLd.dateReviewed, '2026-05-31T00:00:00.000Z')
+})

--- a/src/lib/articleJsonLd.test.ts
+++ b/src/lib/articleJsonLd.test.ts
@@ -8,7 +8,7 @@ test('buildArticleJsonLd emits Article schema with freshness fields', () => {
     headline: 'Perth Pint Index',
     description: 'Track Perth pint prices.',
     dateModified: '2026-05-31T00:00:00.000Z',
-    dateReviewed: '2026-05-31T00:00:00.000Z',
+    lastReviewed: '2026-05-31T00:00:00.000Z',
   })
 
   assert.equal(jsonLd['@context'], 'https://schema.org')
@@ -17,8 +17,9 @@ test('buildArticleJsonLd emits Article schema with freshness fields', () => {
   assert.deepEqual(jsonLd.mainEntityOfPage, {
     '@type': 'WebPage',
     '@id': 'https://perthpintprices.com/insights/pint-index',
+    lastReviewed: '2026-05-31T00:00:00.000Z',
   })
   assert.equal(jsonLd.author.name, 'Perth Pint Prices')
   assert.equal(jsonLd.dateModified, '2026-05-31T00:00:00.000Z')
-  assert.equal(jsonLd.dateReviewed, '2026-05-31T00:00:00.000Z')
+  assert.equal('dateReviewed' in jsonLd, false)
 })

--- a/src/lib/articleJsonLd.ts
+++ b/src/lib/articleJsonLd.ts
@@ -1,0 +1,43 @@
+interface ArticleJsonLdInput {
+  url: string
+  headline: string
+  description: string
+  dateModified: string
+  dateReviewed: string
+}
+
+export function buildArticleJsonLd({
+  url,
+  headline,
+  description,
+  dateModified,
+  dateReviewed,
+}: ArticleJsonLdInput) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    '@id': `${url}#article`,
+    headline,
+    description,
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': url,
+    },
+    author: {
+      '@type': 'Organization',
+      name: 'Perth Pint Prices',
+      url: 'https://perthpintprices.com',
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'Perth Pint Prices',
+      url: 'https://perthpintprices.com',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://perthpintprices.com/og-image.png',
+      },
+    },
+    dateModified,
+    dateReviewed,
+  }
+}

--- a/src/lib/articleJsonLd.ts
+++ b/src/lib/articleJsonLd.ts
@@ -3,7 +3,7 @@ interface ArticleJsonLdInput {
   headline: string
   description: string
   dateModified: string
-  dateReviewed: string
+  lastReviewed: string
 }
 
 export function buildArticleJsonLd({
@@ -11,7 +11,7 @@ export function buildArticleJsonLd({
   headline,
   description,
   dateModified,
-  dateReviewed,
+  lastReviewed,
 }: ArticleJsonLdInput) {
   return {
     '@context': 'https://schema.org',
@@ -22,6 +22,7 @@ export function buildArticleJsonLd({
     mainEntityOfPage: {
       '@type': 'WebPage',
       '@id': url,
+      lastReviewed,
     },
     author: {
       '@type': 'Organization',
@@ -38,6 +39,5 @@ export function buildArticleJsonLd({
       },
     },
     dateModified,
-    dateReviewed,
   }
 }


### PR DESCRIPTION
## Summary
- add `/llms.txt` with live canonical citation targets and no deleted weekly-report reference
- add Pint Index Article JSON-LD with `dateModified` and valid `mainEntityOfPage.lastReviewed`
- explicitly allow GPTBot, PerplexityBot, and Google-Extended in robots while keeping private paths blocked
- surface pub-page freshness as semantic `Last verified <date>` time text

Closes #35

## Verification
- `npm test` (199/199 passing)
- `npx tsc --noEmit`
- `npm run lint` (existing warnings only: `SubmitPubForm.tsx`, `SunsetSippers.tsx`)
- `npm run build`
- local production smoke: `/llms.txt`, `/robots.txt`, Pint Index Article JSON-LD
- Playwright screenshots at 1280x800 and 375x812 for pub-page freshness

## Peer review
- First review found cache/schema/docs issues; fixed with `revalidate = 3600`, `mainEntityOfPage.lastReviewed`, and updated tests/docs.
- Second reviewer: Critical none, Important none, Ready to merge yes.
