### PR TITLE
chore: voice cleanup — backlog #102 + #103

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -341,7 +341,7 @@ function HomeContent({ initialPubs }: { initialPubs: Pub[] }) {
             className="hidden sm:inline-flex font-mono text-[0.72rem] font-bold uppercase tracking-[0.05em] text-ink bg-white border-3 border-ink rounded-pill px-5 py-2.5 shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all cursor-pointer"
             data-submit-trigger
           >
-            Submit a Price
+            Report a price
           </button>
           <MobileNav />
         </div>

--- a/src/app/[suburb]/SuburbClient.tsx
+++ b/src/app/[suburb]/SuburbClient.tsx
@@ -313,7 +313,7 @@ export default function SuburbClient({ suburb, pubs, nearbySuburbs, perthAvgPric
             href="/?submit=1"
             className="inline-flex font-mono text-[0.85rem] font-bold uppercase tracking-[0.05em] text-ink bg-amber-light border-3 border-ink rounded-pill px-9 py-4 shadow-hard-sm hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-hard-hover transition-all no-underline"
           >
-            Submit a Price
+            Report a price
           </Link>
         </div>
       </section>

--- a/src/app/api/price-report/route.ts
+++ b/src/app/api/price-report/route.ts
@@ -86,8 +86,8 @@ export async function POST(req: NextRequest) {
     await revalidateReportedPub(pub_slug)
 
     const message = isOutdatedReport
-      ? 'Thanks for flagging! We\'ll check this price.'
-      : 'Price reported! Thanks for contributing.'
+      ? 'Thanks for flagging — we\'ll check this price.'
+      : 'Price reported. Thanks for contributing.'
 
     return NextResponse.json({ success: true, message })
   } catch {

--- a/src/app/api/pub-submission/route.ts
+++ b/src/app/api/pub-submission/route.ts
@@ -49,7 +49,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Failed to submit' }, { status: 500 });
     }
 
-    return NextResponse.json({ success: true, message: 'Pub submitted! We\'ll review it shortly.' });
+    return NextResponse.json({ success: true, message: 'Pub submitted. We\'ll review it shortly.' });
   } catch {
     return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
   }

--- a/src/app/discover/DiscoverClient.tsx
+++ b/src/app/discover/DiscoverClient.tsx
@@ -215,7 +215,7 @@ export default function DiscoverClient() {
               <p className="text-sm text-gray-mid mb-4">Starting soon near you</p>
               <div className="space-y-1">
                 {upcomingHappyHours.length === 0 && (
-                  <p className="text-sm text-gray-mid py-4 text-center">No happy hours active or upcoming right now. Check back later!</p>
+                  <p className="text-sm text-gray-mid py-4 text-center">No happy hours active or upcoming right now. Check back later.</p>
                 )}
                 {upcomingHappyHours.map(({ pub, status }) => (
                   <Link key={pub.id} href={pubUrl(pub)} className="flex items-center justify-between p-2.5 rounded-card border-l-2 border-l-transparent hover:border-l-amber hover:bg-off-white transition-all group no-underline">
@@ -257,8 +257,8 @@ export default function DiscoverClient() {
               {[
                 { emoji: 'sunset', title: 'Sunset Sippers', desc: 'West-facing patios and rooftop bars for golden hour pints.', bg: 'bg-amber-pale', count: pubPickCounts.sunset, href: '/guides/sunset-sippers' },
                 { emoji: 'users', title: 'The Dad Bar', desc: 'No fairy lights, no craft beer menu. Just honest pints and the footy on.', bg: 'bg-white', count: pubPickCounts.dad, href: '/guides/dad-bar' },
-                { emoji: 'sun', title: 'Beer Weather', desc: 'Live BOM data matched to beer garden picks. Is it a beer garden arvo?', bg: 'bg-green-pale', count: pubPickCounts.beer, href: '/guides/beer-weather' },
-                { emoji: 'umbrella', title: 'Cozy Corners', desc: 'Fireplaces, booths, and warmth for when it\'s bucketing down.', bg: 'bg-white', count: pubPickCounts.cozy, href: '/guides/cozy-corners' },
+                { emoji: 'sun', title: 'Beer Weather', desc: 'Live BOM data matched to beer garden picks — so you know before you walk.', bg: 'bg-green-pale', count: pubPickCounts.beer, href: '/guides/beer-weather' },
+                { emoji: 'umbrella', title: 'Cosy Corners', desc: 'Fireplaces, booths, and warmth for when it\'s bucketing down.', bg: 'bg-white', count: pubPickCounts.cozy, href: '/guides/cozy-corners' },
                 { emoji: 'trophy', title: 'Punt & Pints', desc: 'TAB screens, cold pints, and a flutter on the trots.', bg: 'bg-white', count: pubPickCounts.punt, href: '/guides/punt-and-pints' },
                 { emoji: 'clock', title: 'Happy Hours', desc: 'Live deals happening right now across Perth.', bg: 'bg-amber-pale', count: pubPickCounts.happy, href: '/happy-hour' },
               ].map((card) => (
@@ -290,7 +290,7 @@ export default function DiscoverClient() {
               href="/?submit=1"
               className="inline-flex font-mono text-[0.85rem] font-bold uppercase tracking-[0.05em] text-ink bg-amber-light border-3 border-ink rounded-pill px-9 py-4 shadow-hard-sm hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-hard-hover transition-all no-underline"
             >
-              Submit a Price
+              Report a price
             </Link>
             <p className="text-white/40 text-sm mt-4">{pubs.length} venues tracked · Updated weekly</p>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -49,7 +49,7 @@ function HomeJsonLd() {
       name: 'Perth Pint Prices',
       alternateName: 'Arvo',
       url: 'https://perthpintprices.com',
-      description: "Perth's pint prices, sorted. Real prices from real people.",
+      description: "What a pint costs across Perth's pubs — checked, dated, and sorted cheapest first.",
     },
     {
       '@context': 'https://schema.org',
@@ -84,7 +84,7 @@ function HomeJsonLd() {
           name: 'Can I submit a price?',
           acceptedAnswer: {
             '@type': 'Answer',
-            text: 'Absolutely. Hit "Submit a Price" in the top nav or use the Report button on any pub page.',
+            text: 'Absolutely. Hit "Report a price" in the top nav or use the Report button on any pub page.',
           },
         },
         {
@@ -92,7 +92,7 @@ function HomeJsonLd() {
           name: 'Why is a pub showing "Price TBC"?',
           acceptedAnswer: {
             '@type': 'Answer',
-            text: 'We only display prices we\'ve confirmed. "Price TBC" means we know the pub exists but haven\'t verified its current pint price yet. You can help by submitting it!',
+            text: 'We only display prices we\'ve confirmed. "Price TBC" means we know the pub exists but haven\'t verified its current pint price yet. You can help by submitting it.',
           },
         },
         {

--- a/src/components/CrowdReporter.tsx
+++ b/src/components/CrowdReporter.tsx
@@ -60,8 +60,8 @@ export default function CrowdReporter({ pubId, pubName, onClose, onReport }: Cro
           {isSuccess ? (
             <div className="text-center py-8">
               <CircleCheck className="w-16 h-16 text-amber mb-4" />
-              <p className="text-white font-semibold text-lg">Thanks!</p>
-              <p className="text-gray-400 text-sm">Your report helps others find the vibe!</p>
+              <p className="text-white font-semibold text-lg">Thanks.</p>
+              <p className="text-gray-400 text-sm">Your report helps others know how busy it is.</p>
             </div>
           ) : (
             <>

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -22,7 +22,7 @@ export default function FAQ() {
     },
     {
       q: 'Can I submit a price?',
-      a: 'Absolutely. Hit "Submit a Price" in the top nav or use the Report button on any pub page.',
+      a: 'Absolutely. Hit "Report a price" in the top nav or use the Report button on any pub page.',
     },
     {
       q: 'Why is a pub showing "Price TBC"?',

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -61,7 +61,7 @@ export default function HeroSection({ pubs }: HeroSectionProps) {
           </Link>
         ) : (
           <div className="border-3 border-ink rounded-card px-5 py-3.5 text-center min-w-[100px] bg-amber shadow-hard-sm animate-fade-up stagger-7">
-            <span className="font-mono text-[1.6rem] font-extrabold tracking-[-0.02em] block leading-[1.1] text-white">${cheapest}</span>
+            <span className="font-mono text-[1.6rem] font-extrabold tracking-[-0.02em] block leading-[1.1] text-white">TBC</span>
             <span className="font-mono text-[0.6rem] font-bold uppercase tracking-[0.08em] text-white/80 block mt-0.5">Cheapest</span>
           </div>
         )}

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -21,7 +21,7 @@ const features = [
   },
   {
     icon: CheckCircle,
-    heading: 'Always verified',
+    heading: 'Dated, not guessed',
     desc: 'Every price shows when it was last checked. Stale data gets flagged so you know what\'s fresh.',
   },
 ]

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -97,7 +97,7 @@ export default function MobileNav({ onSubmitClick }: MobileNavProps) {
                   className="w-full font-mono text-[0.82rem] font-bold uppercase tracking-[0.05em] text-white bg-amber border-3 border-ink rounded-pill py-3.5 shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all cursor-pointer text-center"
                 >
                   <Beer className="w-4 h-4 inline mr-1.5 -mt-0.5" />
-                  Submit a Price
+                  Report a price
                 </button>
               ) : (
                 <Link
@@ -106,7 +106,7 @@ export default function MobileNav({ onSubmitClick }: MobileNavProps) {
                   className="block w-full font-mono text-[0.82rem] font-bold uppercase tracking-[0.05em] text-white bg-amber border-3 border-ink rounded-pill py-3.5 shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all no-underline text-center"
                 >
                   <Beer className="w-4 h-4 inline mr-1.5 -mt-0.5" />
-                  Submit a Price
+                  Report a price
                 </Link>
               )}
             </div>

--- a/src/components/SocialProof.tsx
+++ b/src/components/SocialProof.tsx
@@ -39,7 +39,7 @@ export default function SocialProof({ avgPrice, venueCount, onSubmitClick }: Soc
           onClick={onSubmitClick}
           className="inline-flex items-center gap-2 font-mono text-[0.85rem] font-bold uppercase tracking-[0.05em] text-ink bg-amber-light border-3 border-ink rounded-pill px-9 py-4 shadow-hard hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-hard-hover active:translate-x-[4px] active:translate-y-[4px] active:shadow-none transition-all cursor-pointer"
         >
-          Submit a Price →
+          Report a price →
         </button>
       </div>
     </section>

--- a/src/components/SubPageNav.tsx
+++ b/src/components/SubPageNav.tsx
@@ -102,7 +102,7 @@ export default function SubPageNav({ breadcrumbs, title, subtitle, showSubmit = 
             href="/?submit=1"
             className="hidden sm:inline-flex font-mono text-[0.72rem] font-bold uppercase tracking-[0.05em] text-ink bg-white border-3 border-ink rounded-pill px-5 py-2.5 shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all no-underline flex-shrink-0"
           >
-            Submit a Price
+            Report a price
           </Link>
         )}
       </div>

--- a/src/components/SubmitPubForm.tsx
+++ b/src/components/SubmitPubForm.tsx
@@ -529,7 +529,7 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
     : 'Report an Issue';
 
   const modeSubtitle = mode === 'existing'
-    ? 'Know a cheap pint? Let us know!'
+    ? 'Know a cheap pint? Tell us.'
     : mode === 'new'
     ? 'Add a pub we\'re missing'
     : mode === 'scan-menu'
@@ -537,12 +537,12 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
     : 'Closed, renovating, or something else?';
 
   const submittedMessage = mode === 'existing'
-    ? 'Price submitted! We\'ll review it shortly.'
+    ? 'Price submitted. We\'ll review it shortly.'
     : mode === 'report-outdated'
-    ? 'Thanks for the heads up! We\'ll look into it.'
+    ? 'Thanks for the heads up — we\'ll look into it.'
     : mode === 'scan-menu'
-    ? 'Prices submitted! We\'ll review them shortly.'
-    : 'Pub submitted! We\'ll review and add it soon.';
+    ? 'Prices submitted. We\'ll review them shortly.'
+    : 'Pub submitted. We\'ll review and add it soon.';
 
   // Pub search widget (shared by 'existing' and 'report-outdated')
   const pubSearchWidget = (
@@ -708,7 +708,7 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
               </svg>
             </div>
             <h3 className="font-mono font-extrabold text-xl text-ink mb-2">
-              Thanks legend! <Beer className="w-4 h-4 inline" />
+              Thanks — that&apos;s logged. <Beer className="w-4 h-4 inline" />
             </h3>
             <p className="text-gray-mid text-sm">
               {submittedMessage}

--- a/src/components/TonightsMoves.tsx
+++ b/src/components/TonightsMoves.tsx
@@ -275,7 +275,7 @@ export default function TonightsMoves({ pubs, userLocation }: TonightsMovesProps
             {activeDeals.length === 0 && (
               <div className="bg-off-white rounded-card p-3 text-center">
                 <p className="font-mono text-[0.75rem] text-gray-mid flex items-center justify-center gap-2">
-                  <Moon className="w-4 h-4" /> No happy hours active right now. Check back later!
+                  <Moon className="w-4 h-4" /> No happy hours active right now. Check back later.
                 </p>
               </div>
             )}


### PR DESCRIPTION
Wraps up the two voice-backlog issues now that the 8 slices are merged.

## #103 — CTA rename
"Submit a Price" → **"Report a price"** (outcome-led per the brief) across all 9 visible labels. Form logic + analytics event names untouched.

## #102 — off-voice copy sweep
- **Confirmations/empty-states:** dropped exclamation boosterism + "legend" from SubmitPubForm, CrowdReporter, TonightsMoves, and the price-report / pub-submission API `message` strings.
- **Discover carousel:** dropped "Is it a beer garden arvo?", fixed American "Cozy Corners" → "Cosy Corners", dropped the empty-state "!".
- **HowItWorks:** "Always verified" → "Dated, not guessed" (the card itself says stale data gets flagged — "always" overclaimed).
- **Homepage JSON-LD:** aligned the WebSite description to the voice + dropped the FAQ-mirror "submitting it!" (copy strings only; schema structure untouched — that's #3).
- **HeroSection:** renders **"TBC"** instead of **"$0"** in the Cheapest tile when no pub has a verified price (truthful absence).

**Deferred (optional, noted):** the sitewide `$X.00 → $X` price-format reformat — pre-existing convention across the whole app, large and low-value, not introduced by the voice work.

## Verification
- `npx tsc --noEmit` + `npm run lint` clean (only the pre-existing warnings).

Closes #102
Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)
