### PR TITLE
feat: add Tier-C report-price hero

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,11 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Tier-C report-price hero shipped (2026-05-31)
+- **Issue #74 / branch `codex/tier-c-report-hero`:** price-less Tier-C pub pages now render the truthful absence stub with last Andrew call timing, verified nearby-price count, and a link to the nearest checked pub instead of leaving the page as a uniform husk.
+- **Report-price conversion path:** Tier-C pages flip the pub-page CTA to a primary `Report the price` hero button and tag resulting submissions with `source:tier-c-report-hero` in `price_reports.notes` for M8 measurement.
+- **Verification:** checked `/fremantle/federal-hotel` locally as a real Tier-C sample: `noindex` still present, stub renders, nearest checked pub link renders, and desktop/mobile screenshots show the hero CTA and copy fit. Verified `npm test` (**199/199 tests**), `npx tsc --noEmit`, `npm run lint` (existing warnings only), and `npm run build`.
+
 ### AI citation signals shipped (2026-05-31)
 - **Issue #35 / branch `codex/llms-article-schema`:** added `/llms.txt` as a markdown citation map for the live high-signal pages (Pint Index, live insight pages, happy hours, discover, and key suburb pages). The deleted weekly-report route stays deleted; Pint Index is the Article/schema asset per `docs/seo-action-plan.md`.
 - **Structured citation + crawler access:** added Article JSON-LD to `/insights/pint-index` with `author`, `publisher`, `dateModified`, and `mainEntityOfPage.lastReviewed` from real pub freshness data; added explicit GPTBot / PerplexityBot / Google-Extended allow rules while keeping `/admin` and `/api` blocked.

--- a/src/app/[suburb]/[pub]/PubDetailClient.tsx
+++ b/src/app/[suburb]/[pub]/PubDetailClient.tsx
@@ -11,6 +11,7 @@ import { PenLine } from 'lucide-react'
 import { formatHappyHourDays } from '@/lib/happyHourLive'
 import Footer from '@/components/Footer'
 import { pubUrl, suburbUrl } from '@/lib/urls'
+import { verificationStub } from '@/lib/voiceCopy'
 
 const PubDetailMap = dynamic(() => import('@/components/PubDetailMap'), {
   ssr: false,
@@ -40,9 +41,21 @@ interface PubDetailClientProps {
   pub: Pub
   nearbyPubs: Pub[]
   avgPrice: number
+  isTierCPage: boolean
+  latestAndrewCallAt: string | null
+  nearestVerifiedPub: Pub | null
+  nearbyVerifiedPriceCount: number
 }
 
-export default function PubDetailClient({ pub, nearbyPubs, avgPrice }: PubDetailClientProps) {
+export default function PubDetailClient({
+  pub,
+  nearbyPubs,
+  avgPrice,
+  isTierCPage,
+  latestAndrewCallAt,
+  nearestVerifiedPub,
+  nearbyVerifiedPriceCount,
+}: PubDetailClientProps) {
   const [distance, setDistance] = useState<string | null>(null)
   const [showSubmitForm, setShowSubmitForm] = useState(false)
 
@@ -74,6 +87,16 @@ export default function PubDetailClient({ pub, nearbyPubs, avgPrice }: PubDetail
   }
 
   const priceDiff = pub.effectivePrice && avgPrice ? pub.effectivePrice - avgPrice : 0
+  const hasStatusRow = pub.isHappyHourNow || (pub.priceVerified && pub.price !== null) || !!pub.lastVerified
+  const priceMissingCopy = isTierCPage
+    ? verificationStub({
+      lastAndrewCall: latestAndrewCallAt ? formatLastVerifiedDate(latestAndrewCallAt) : null,
+      nearbyCount: nearbyVerifiedPriceCount,
+      nearestPub: nearestVerifiedPub?.name ?? null,
+      nearestPrice: nearestVerifiedPub?.price ?? null,
+    })
+    : null
+  const reportCtaLabel = isTierCPage ? 'Report the price' : 'Know the price? Report it here'
 
   return (
     <div className="min-h-screen bg-[#FDF8F0]">
@@ -153,26 +176,42 @@ export default function PubDetailClient({ pub, nearbyPubs, avgPrice }: PubDetail
                 </div>
               </div>
               {/* Status row */}
-              <div className="flex flex-wrap gap-2 mt-4 pt-4 border-t border-gray-light">
-                {pub.isHappyHourNow && (
-                  <span className="inline-flex items-center gap-1.5 font-mono text-[0.6rem] font-bold uppercase tracking-wider text-red bg-red-pale px-2.5 py-1 rounded-full border border-red">
-                    HH{pub.happyHourMinutesRemaining ? ` · ${pub.happyHourMinutesRemaining < 1 ? 'ending soon' : pub.happyHourMinutesRemaining < 60 ? `${pub.happyHourMinutesRemaining}m left` : `${Math.floor(pub.happyHourMinutesRemaining / 60)}h ${pub.happyHourMinutesRemaining % 60 > 0 ? `${pub.happyHourMinutesRemaining % 60}m ` : ''}left`}` : ''}
-                  </span>
-                )}
-                {pub.priceVerified && pub.price !== null && (
-                  <span className="inline-flex items-center gap-1 font-mono text-[0.6rem] font-bold uppercase tracking-wider text-green bg-green-pale px-2.5 py-1 rounded-full border border-green">
-                    Verified
-                  </span>
-                )}
-                {pub.lastVerified && (
-                  <time
-                    dateTime={new Date(pub.lastVerified).toISOString()}
-                    className="text-[0.7rem] text-gray-mid"
-                  >
-                    Last verified {formatLastVerifiedDate(pub.lastVerified)}
-                  </time>
-                )}
-              </div>
+              {hasStatusRow && (
+                <div className="flex flex-wrap gap-2 mt-4 pt-4 border-t border-gray-light">
+                  {pub.isHappyHourNow && (
+                    <span className="inline-flex items-center gap-1.5 font-mono text-[0.6rem] font-bold uppercase tracking-wider text-red bg-red-pale px-2.5 py-1 rounded-full border border-red">
+                      HH{pub.happyHourMinutesRemaining ? ` · ${pub.happyHourMinutesRemaining < 1 ? 'ending soon' : pub.happyHourMinutesRemaining < 60 ? `${pub.happyHourMinutesRemaining}m left` : `${Math.floor(pub.happyHourMinutesRemaining / 60)}h ${pub.happyHourMinutesRemaining % 60 > 0 ? `${pub.happyHourMinutesRemaining % 60}m ` : ''}left`}` : ''}
+                    </span>
+                  )}
+                  {pub.priceVerified && pub.price !== null && (
+                    <span className="inline-flex items-center gap-1 font-mono text-[0.6rem] font-bold uppercase tracking-wider text-green bg-green-pale px-2.5 py-1 rounded-full border border-green">
+                      Verified
+                    </span>
+                  )}
+                  {pub.lastVerified && (
+                    <time
+                      dateTime={new Date(pub.lastVerified).toISOString()}
+                      className="text-[0.7rem] text-gray-mid"
+                    >
+                      Last verified {formatLastVerifiedDate(pub.lastVerified)}
+                    </time>
+                  )}
+                </div>
+              )}
+              {priceMissingCopy && (
+                <div className="mt-4 pt-4 border-t border-gray-light">
+                  {nearestVerifiedPub ? (
+                    <Link
+                      href={pubUrl({ suburb: nearestVerifiedPub.suburb, slug: nearestVerifiedPub.slug })}
+                      className="block text-[0.86rem] leading-relaxed text-ink hover:text-amber transition-colors no-underline"
+                    >
+                      {priceMissingCopy}
+                    </Link>
+                  ) : (
+                    <p className="text-[0.86rem] leading-relaxed text-ink">{priceMissingCopy}</p>
+                  )}
+                </div>
+              )}
 
               {/* Happy Hour — merged into price card */}
               {(pub.happyHour || pub.happyHourPrice) && (
@@ -203,10 +242,14 @@ export default function PubDetailClient({ pub, nearbyPubs, avgPrice }: PubDetail
             {/* Report a price — prominent CTA */}
             <button
               onClick={() => setShowSubmitForm(true)}
-              className="w-full flex items-center justify-center gap-2 font-mono text-[0.78rem] font-bold uppercase tracking-[0.05em] text-amber bg-amber-pale border-3 border-ink rounded-pill py-3 shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all"
+              className={`w-full flex items-center justify-center gap-2 font-mono font-bold uppercase tracking-[0.05em] border-3 border-ink rounded-pill shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all ${
+                isTierCPage
+                  ? 'text-white bg-amber py-4 text-[0.85rem]'
+                  : 'text-amber bg-amber-pale py-3 text-[0.78rem]'
+              }`}
             >
               <PenLine className="w-4 h-4" />
-              Know the price? Report it here
+              {reportCtaLabel}
             </button>
 
             {/* About */}
@@ -298,6 +341,7 @@ export default function PubDetailClient({ pub, nearbyPubs, avgPrice }: PubDetail
         isOpen={showSubmitForm}
         onClose={() => setShowSubmitForm(false)}
         initialPub={{ slug: pub.slug, name: pub.name, suburb: pub.suburb }}
+        submissionSource={isTierCPage ? 'tier-c-report-hero' : undefined}
       />
     </div>
   )

--- a/src/app/[suburb]/[pub]/page.tsx
+++ b/src/app/[suburb]/[pub]/page.tsx
@@ -1,10 +1,11 @@
 import { Metadata } from 'next'
 import { unstable_cache } from 'next/cache'
 import { notFound, permanentRedirect } from 'next/navigation'
-import { getPubBySlug, getAllPubSlugPairs, getNearbyPubs, getSiteStats, getSuburbAveragePrice } from '@/lib/supabase'
+import { getPubBySlug, getAllPubSlugPairs, getLatestAndrewCallAtByPubId, getNearestPubFromList, getNearbyPubs, getSiteStats, getSuburbAveragePrice, getVerifiedPricePubs } from '@/lib/supabase'
 import { getPubIndexability } from '@/lib/pubIndexability'
 import { buildPubJsonLd } from '@/lib/pubJsonLd'
 import { absolutePubUrl, toSuburbSlug } from '@/lib/urls'
+import type { Pub } from '@/types/pub'
 import PubDetailClient from './PubDetailClient'
 
 interface PageProps {
@@ -22,13 +23,26 @@ function getCachedPubBySlug(slug: string) {
   )()
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-  const pub = await getCachedPubBySlug(params.pub)
-  if (!pub) return { title: 'Pub Not Found' }
+const getCachedVerifiedPricePubs = unstable_cache(
+  () => getVerifiedPricePubs(),
+  ['verified-price-pubs'],
+  {
+    tags: ['verified-price-pubs'],
+    revalidate: 3600,
+  },
+)
 
-  const priceText = pub.price !== null ? `$${pub.price.toFixed(2)} pints` : 'Price TBC'
-  const title = `${pub.name}, ${pub.suburb}: ${priceText}`
-  const indexability = getPubIndexability({
+const getCachedLatestAndrewCallAtByPubId = unstable_cache(
+  () => getLatestAndrewCallAtByPubId(),
+  ['latest-andrew-call-at-by-pub-id'],
+  {
+    tags: ['latest-andrew-call-at-by-pub-id'],
+    revalidate: 3600,
+  },
+)
+
+function getPubPageIndexability(pub: Pub) {
+  return getPubIndexability({
     price: pub.regularPrice,
     priceVerified: pub.priceVerified,
     lastVerified: pub.lastVerified,
@@ -45,6 +59,15 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     sunsetSpot: pub.sunsetSpot,
     website: pub.website,
   })
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const pub = await getCachedPubBySlug(params.pub)
+  if (!pub) return { title: 'Pub Not Found' }
+
+  const priceText = pub.price !== null ? `$${pub.price.toFixed(2)} pints` : 'Price TBC'
+  const title = `${pub.name}, ${pub.suburb}: ${priceText}`
+  const indexability = getPubPageIndexability(pub)
 
   // Build description with progressive enrichment (target 70-160 chars)
   const descParts: string[] = []
@@ -109,8 +132,25 @@ export default async function PubPage({ params }: PageProps) {
     permanentRedirect(`/${suburbSlug}/${pub.slug}`)
   }
 
-  const [nearbyPubs, stats, suburbAvgPrice] = await Promise.all([
+  const indexability = getPubPageIndexability(pub)
+  const isTierCPage = indexability.tier === 'C'
+  const tierCDetails: Promise<[number, string | null, Pub | null]> = isTierCPage
+    ? Promise.all([getCachedVerifiedPricePubs(), getCachedLatestAndrewCallAtByPubId()]).then(([verifiedPricePubs, latestAndrewCallAtByPubId]) => {
+      const sameSuburbVerifiedPubs = verifiedPricePubs.filter(nearbyPub =>
+        nearbyPub.suburb === pub.suburb && nearbyPub.id !== pub.id
+      )
+
+      return [
+        sameSuburbVerifiedPubs.length,
+        latestAndrewCallAtByPubId[pub.id] ?? null,
+        getNearestPubFromList(sameSuburbVerifiedPubs, pub.lat, pub.lng),
+      ]
+    })
+    : Promise.resolve([0, null, null])
+
+  const [nearbyPubs, [nearbyVerifiedPriceCount, latestAndrewCallAt, nearestVerifiedPub], stats, suburbAvgPrice] = await Promise.all([
     getNearbyPubs(pub.suburb, pub.id, 8),
+    tierCDetails,
     getSiteStats(),
     getSuburbAveragePrice(pub.suburb),
   ])
@@ -134,7 +174,15 @@ export default async function PubPage({ params }: PageProps) {
         ))}
       </div>
 
-      <PubDetailClient pub={pub} nearbyPubs={nearbyPubs} avgPrice={Number(stats.avgPrice)} />
+      <PubDetailClient
+        pub={pub}
+        nearbyPubs={nearbyPubs}
+        avgPrice={Number(stats.avgPrice)}
+        isTierCPage={isTierCPage}
+        latestAndrewCallAt={latestAndrewCallAt}
+        nearestVerifiedPub={nearestVerifiedPub}
+        nearbyVerifiedPriceCount={nearbyVerifiedPriceCount}
+      />
     </>
   )
 }

--- a/src/components/SubmitPubForm.tsx
+++ b/src/components/SubmitPubForm.tsx
@@ -18,6 +18,7 @@ interface SubmitPubFormProps {
   onClose: () => void;
   userLocation?: { lat: number; lng: number } | null;
   initialPub?: { slug: string; name: string; suburb: string } | null;
+  submissionSource?: string;
 }
 
 type Mode = 'existing' | 'new' | 'report-outdated' | 'scan-menu';
@@ -28,7 +29,7 @@ interface ExtractedItem {
   price_type: 'regular' | 'happy_hour';
 }
 
-export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPub }: SubmitPubFormProps) {
+export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPub, submissionSource }: SubmitPubFormProps) {
   const [mode, setMode] = useState<Mode>('existing');
   const [pubs, setPubs] = useState<Pub[]>([]);
   const [pubsLoading, setPubsLoading] = useState(false);
@@ -429,6 +430,7 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
             reported_price: parseFloat(price),
             beer_type: beerType || undefined,
             price_type: priceType,
+            notes: submissionSource ? `[source:${submissionSource}]` : undefined,
           }),
         });
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 import { Pub } from '@/types/pub'
 import { getHappyHourStatus } from '@/lib/happyHourLive'
+import { haversineDistanceKm } from '@/lib/location'
 import { getPubIndexability, PubIndexabilityTier } from '@/lib/pubIndexability'
 import { toSuburbSlug } from './urls'
 
@@ -322,6 +323,54 @@ export async function getNearbyPubs(suburb: string, excludeId: number, limit: nu
   if (error || !data) return []
   
   return data.map(toPub)
+}
+
+export async function getVerifiedPricePubs(): Promise<Pub[]> {
+  const { data, error } = await supabase
+    .from('pubs')
+    .select('*')
+    .not('price', 'is', null)
+    .or('price_verified.is.null,price_verified.eq.true')
+    .order('price', { ascending: true, nullsFirst: false })
+
+  if (error || !data) return []
+
+  return data.map(toPub)
+}
+
+export function getNearestPubFromList(pubs: Pub[], lat: number, lng: number): Pub | null {
+  if (pubs.length === 0) return null
+
+  const byPrice = (a: Pub, b: Pub) => (a.price ?? Number.MAX_VALUE) - (b.price ?? Number.MAX_VALUE)
+  if (!Number.isFinite(lat) || !Number.isFinite(lng) || (lat === 0 && lng === 0)) {
+    return [...pubs].sort(byPrice)[0] ?? null
+  }
+
+  return pubs
+    .map(pub => ({
+      pub,
+      distance: haversineDistanceKm(lat, lng, pub.lat, pub.lng),
+    }))
+    .sort((a, b) => a.distance - b.distance || byPrice(a.pub, b.pub))[0]?.pub ?? null
+}
+
+export async function getLatestAndrewCallAtByPubId(): Promise<Record<number, string>> {
+  const { data, error } = await supabase
+    .from('phone_call_log')
+    .select('pub_id, created_at')
+    .not('pub_id', 'is', null)
+    .order('created_at', { ascending: false })
+
+  if (error || !data) return {}
+
+  const latestByPubId: Record<number, string> = {}
+  for (const row of data) {
+    const pubId = Number(row.pub_id)
+    if (!Number.isFinite(pubId) || !row.created_at || latestByPubId[pubId]) continue
+    latestByPubId[pubId] = row.created_at
+  }
+
+  return latestByPubId
 }
 
 // Fetch pubs in a similar price range from different suburbs (for cross-linking)


### PR DESCRIPTION
## Summary
- add a Tier-C absence stub on price-less pub pages with Andrew call timing, verified nearby-price count, and nearest checked pub link
- switch Tier-C pub-page CTA to a primary Report the price hero path and tag submissions with `source:tier-c-report-hero`
- keep Tier-C pages noindexed by sharing the existing indexability helper between metadata and rendering

Closes #74

## Verification
- `npx tsc --noEmit`
- `npm test` (199/199)
- `npm run lint` (existing warnings only)
- `npm run build` (success; existing lint warnings only; transient Supabase DNS warning during static generation)
- prior local desktop/mobile visual smoke for `/fremantle/federal-hotel` and non-Tier-C smoke for `/perth/18-knots-rooftop-bar`

## Review
- peer-reviewed clean by sub-agent Popper: no blocking findings; safe to merge