### PR TITLE
Track AI and community SEO referrals

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -1,6 +1,6 @@
 # Perth Pint Prices Project Status
 
-Last updated: 2026-05-31
+Last updated: 2026-06-01
 
 ## What this is
 
@@ -9,6 +9,11 @@ Perth Pint Prices (perthpintprices.com) tracks pint prices across **857 Perth pu
 Stack, database, routes, components, and lib files are documented in `CLAUDE.md` (auto-loaded every session). This file covers history, recent work, and the backlog.
 
 ## What's done recently
+
+### AI/community SEO snapshot tracking documented (2026-06-01)
+- **Issue #116 / branch `codex/ai-community-seo-snapshot`:** added `docs/seo-snapshots/TEMPLATE.md` as the #36 weekly SEO snapshot template, with required AI-referral and community-referral callouts for any source sending **>0 sessions**.
+- **GA4 + UTM process:** documented the GA4 exploration definitions for AI/search-assistant, community/social, DuckDuckGo, landing-page, and future key-event reporting. Added a lowercase UTM convention for community posts and PR outreach.
+- **Verification:** docs-only change; verified with `git diff --check`.
 
 ### Pint Index methodology + CSV citation asset shipped (2026-06-01)
 - **Issue #117 / branch `codex/pint-index-methodology`:** Pint Index now includes a visible methodology block covering what counts as a pint, which prices are included, how prices are checked, why TBC venues stay out of averages, and how weekly snapshots power the index.

--- a/docs/seo-action-plan.md
+++ b/docs/seo-action-plan.md
@@ -233,7 +233,12 @@ Pre-work: Pint Index page needs YoY chart, "share this stat" callouts, methodolo
 **Action**:
 - GSC → Settings → Email preferences → enable all alerts
 - Calendar block: 15 min every Monday for the GSC weekly Performance + Pages reports
-- Add a `npm run seo-snapshot` script that pulls GSC top-100 queries and pages each Monday into `docs/seo-snapshots/2026-MM-DD.md` for trend tracking
+- Use `docs/seo-snapshots/TEMPLATE.md` for each weekly snapshot in `docs/seo-snapshots/2026-MM-DD.md`
+- Include GA4 traffic acquisition using `Session source`, `Session medium`, `Session source / medium`, `Session default channel grouping`, landing pages, and key event metrics once #28 is configured
+- Call out every AI/search-assistant and community/social source with **>0 sessions**, including top landing pages and key events where available
+- Track DuckDuckGo separately from Google/Bing where GA4 exposes it
+- Tag community posts and PR outreach with the UTM convention in `docs/seo-snapshots/TEMPLATE.md`
+- Later, add a `npm run seo-snapshot` script that pulls GSC top-100 queries and pages each Monday into `docs/seo-snapshots/2026-MM-DD.md` for trend tracking
 - Quarterly: re-pull this exact data and check movement against the above 11 actions
 
 **Expected impact**: Compounds via faster spotting of regressions and opportunities.

--- a/docs/seo-snapshots/TEMPLATE.md
+++ b/docs/seo-snapshots/TEMPLATE.md
@@ -1,0 +1,145 @@
+# Weekly SEO Snapshot - YYYY-MM-DD
+
+Use this template for issue #36's Monday SEO snapshot. Replace the placeholder values, keep zero-session rows out of the AI and community callouts, and link the saved GA4 explorations where possible.
+
+## Summary
+
+- Date range:
+- Snapshot owner:
+- GSC property: `sc-domain:perthpintprices.com`
+- GA4 property: `Perth Pint Prices` (`G-1WN68Q85SY`)
+- Headline movement:
+- Actions for next week:
+
+## Search Console
+
+### Performance
+
+| Metric | This period | Previous period | Change |
+|---|---:|---:|---:|
+| Clicks |  |  |  |
+| Impressions |  |  |  |
+| CTR |  |  |  |
+| Average position |  |  |  |
+
+### Top Queries
+
+| Query | Clicks | Impressions | CTR | Average position | Note |
+|---|---:|---:|---:|---:|---|
+|  |  |  |  |  |  |
+
+### Top Landing Pages
+
+| Page | Clicks | Impressions | CTR | Average position | Note |
+|---|---:|---:|---:|---:|---|
+|  |  |  |  |  |  |
+
+### Indexing Watch
+
+- New crawl/indexing errors:
+- Pages still "Discovered, currently not indexed":
+- Sitemap status:
+
+## GA4 Traffic Acquisition
+
+Traffic acquisition should use these dimensions:
+
+- `Session source`
+- `Session medium`
+- `Session source / medium`
+- `Session default channel grouping`
+- Landing page dimension: `Landing page + query string`
+- Key event metrics by channel once issue #28 is configured
+
+### Channel Mix
+
+| Channel | Sessions | Engaged sessions | Engagement rate | Average engagement time | Key events |
+|---|---:|---:|---:|---:|---:|
+| Organic Search |  |  |  |  |  |
+| Direct |  |  |  |  |  |
+| Referral |  |  |  |  |  |
+| Organic Social |  |  |  |  |  |
+| Unassigned |  |  |  |  |  |
+
+### Search Sources
+
+Use `Session source` or `Session source / medium` to split Google, Bing, and DuckDuckGo. DuckDuckGo should be called out separately from Google/Bing where GA4 exposes it.
+
+| Source / medium | Sessions | Engaged sessions | Engagement rate | Landing pages | Key events |
+|---|---:|---:|---:|---|---:|
+| google / organic |  |  |  |  |  |
+| bing / organic |  |  |  |  |  |
+| duckduckgo / organic |  |  |  |  |  |
+
+## AI-Referral Callouts
+
+Report every AI/search-assistant source with more than 0 sessions. If none are present, write `None observed this period`.
+
+Source matching:
+
+- `chatgpt.com`
+- `perplexity.ai`
+- `copilot.microsoft.com`
+- `bing.com` when the landing context indicates Copilot or AI search
+- Any other AI referrer GA4 exposes
+
+GA4 exploration definition:
+
+- Exploration type: Free form
+- Date range: same as the weekly snapshot
+- Rows: `Session source / medium`, then `Landing page + query string`
+- Values: `Sessions`, `Engaged sessions`, `Engagement rate`, `Average engagement time per session`, and key event metrics once #28 is configured
+- Filter: `Session source` exactly matches or contains the AI sources above
+
+| Source / medium | Sessions | Engaged sessions | Engagement rate | Top landing pages | Key events | Notes |
+|---|---:|---:|---:|---|---:|---|
+|  |  |  |  |  |  |  |
+
+## Community-Referral Callouts
+
+Report every community/social source with more than 0 sessions. If none are present, write `None observed this period`.
+
+Source matching:
+
+- `reddit.com`
+- `old.reddit.com`
+- `tiktok.com`
+- `instagram.com`
+- `x.com`
+- Other visible community sources that sent sessions
+
+GA4 exploration definition:
+
+- Exploration type: Free form
+- Date range: same as the weekly snapshot
+- Rows: `Session source / medium`, then `Landing page + query string`
+- Values: `Sessions`, `Engaged sessions`, `Engagement rate`, `Average engagement time per session`, and key event metrics once #28 is configured
+- Filter: `Session source` exactly matches or contains the community sources above
+
+| Source / medium | Sessions | Engaged sessions | Engagement rate | Top landing pages | Key events | Notes |
+|---|---:|---:|---:|---|---:|---|
+|  |  |  |  |  |  |  |
+
+## UTM Convention
+
+Use lowercase kebab-case values. Do not add UTMs to internal links.
+
+Required parameters:
+
+- `utm_source`: platform or outlet, for example `reddit`, `old-reddit`, `tiktok`, `instagram`, `x`, `perthnow`, `watoday`, `6pr`
+- `utm_medium`: channel type, for example `community`, `organic-social`, or `pr-outreach`
+- `utm_campaign`: campaign name in `yyyy-mm-topic` format, for example `2026-06-pint-index-pr`
+- `utm_content`: post, placement, or pitch variant, for example `r-perth-comment-1`, `journalist-email-a`, `bio-link`
+- `utm_term`: optional query, audience, or suburb tag; leave blank unless it adds analysis value
+
+Examples:
+
+- Reddit comment: `?utm_source=reddit&utm_medium=community&utm_campaign=2026-06-pint-index&utm_content=r-perth-comment-1`
+- Instagram bio/link sticker: `?utm_source=instagram&utm_medium=organic-social&utm_campaign=2026-06-pint-index&utm_content=story-link-1`
+- PR outreach link: `?utm_source=watoday&utm_medium=pr-outreach&utm_campaign=2026-06-pint-index-pr&utm_content=journalist-email-a`
+
+## Decisions
+
+- Keep doing:
+- Stop doing:
+- Test next:

--- a/docs/seo-snapshots/TEMPLATE.md
+++ b/docs/seo-snapshots/TEMPLATE.md
@@ -103,9 +103,14 @@ Source matching:
 
 - `reddit.com`
 - `old.reddit.com`
+- `reddit`
+- `old-reddit`
 - `tiktok.com`
+- `tiktok`
 - `instagram.com`
+- `instagram`
 - `x.com`
+- `x`
 - Other visible community sources that sent sessions
 
 GA4 exploration definition:
@@ -114,7 +119,7 @@ GA4 exploration definition:
 - Date range: same as the weekly snapshot
 - Rows: `Session source / medium`, then `Landing page + query string`
 - Values: `Sessions`, `Engaged sessions`, `Engagement rate`, `Average engagement time per session`, and key event metrics once #28 is configured
-- Filter: `Session source` exactly matches or contains the community sources above
+- Filter: `Session source` exactly matches or contains the community sources above, including both referrer domains and the matching UTM `utm_source` values
 
 | Source / medium | Sessions | Engaged sessions | Engagement rate | Top landing pages | Key events | Notes |
 |---|---:|---:|---:|---|---:|---|


### PR DESCRIPTION
## Summary
- Add `docs/seo-snapshots/TEMPLATE.md` for #36 weekly SEO snapshots, including AI-referral and community-referral sections.
- Document GA4 traffic acquisition/exploration definitions for AI, community, DuckDuckGo, landing pages, and future key events.
- Document UTM conventions for community posts and PR outreach, and record the 2026-06-01 project-status entry.

## Verification
- `git diff --check HEAD`
- Tests not run: docs-only change.

Closes #116