### PR TITLE
feat: add geo-aware Cheaper Nearby module

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,11 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Geo-aware Cheaper Nearby module ready (2026-06-01)
+- **Issue #73 / branch `codex/cheaper-nearby-73` / commit `cae6329`:** replaced same-suburb-only pub recommendations with a geo-aware nearby helper. Pub pages now rank verified priced pubs inside a 2km radius, fall back to same-suburb links when sparse, and keep TBC pages useful with nearby verified prices.
+- **Cross-suburb internal links:** the module now renders correct cross-suburb pub URLs, distance text, suburb labels, and price-delta copy such as `$4.30 cheaper`, with crawler-visible links using the same canonical URL helper.
+- **Verification:** added pure ranking tests for cross-suburb cheaper pubs, sparse-radius fallback, and TBC/unknown-price pages. Verified `npm test` (**203/203 tests**), `npx tsc --noEmit`, `npm run lint` (existing warnings only), `npm run build`, and desktop/mobile screenshots for priced and TBC pub pages.
+
 ### Community + Reddit discovery loop documented (2026-06-01)
 - **Issue #115 / branch `codex/community-reddit-loop` / commit `3f4d135`:** added `docs/community-discovery-loop.md` with the first 10 Reddit/community targets, self-promo norms, and a transparent Pint Index community-post draft.
 - **Content + tracking:** added Reddit-sourced #27/#32 backlog questions and a referral plan that tracks `reddit.com`, `old.reddit.com`, `reddit`, and `old-reddit` alongside the existing SEO snapshot template.

--- a/src/app/[suburb]/[pub]/PubDetailClient.tsx
+++ b/src/app/[suburb]/[pub]/PubDetailClient.tsx
@@ -12,6 +12,7 @@ import { formatHappyHourDays } from '@/lib/happyHourLive'
 import Footer from '@/components/Footer'
 import { pubUrl, suburbUrl } from '@/lib/urls'
 import { verificationStub } from '@/lib/voiceCopy'
+import { formatDistance } from '@/lib/location'
 
 const PubDetailMap = dynamic(() => import('@/components/PubDetailMap'), {
   ssr: false,
@@ -87,6 +88,10 @@ export default function PubDetailClient({
   }
 
   const priceDiff = pub.effectivePrice && avgPrice ? pub.effectivePrice - avgPrice : 0
+  const currentPrice = pub.effectivePrice ?? pub.price
+  const hasCheaperNearby = currentPrice !== null && nearbyPubs.some(nearby =>
+    nearby.price !== null && nearby.price < currentPrice
+  )
   const hasStatusRow = pub.isHappyHourNow || (pub.priceVerified && pub.price !== null) || !!pub.lastVerified
   const priceMissingCopy = isTierCPage
     ? verificationStub({
@@ -298,40 +303,56 @@ export default function PubDetailClient({
           <div className="mt-8 border-3 border-ink rounded-card shadow-hard-sm overflow-hidden">
             <div className="px-4 py-3 border-b border-gray-light flex items-center justify-between">
               <h2 className="font-mono font-extrabold text-[0.85rem] text-ink uppercase tracking-[0.05em]">
-                More in {pub.suburb}
+                {hasCheaperNearby ? 'Cheaper nearby' : 'Nearby verified prices'}
               </h2>
               <Link
                 href={suburbUrl(pub.suburb)}
-                className="font-mono text-[0.7rem] font-bold text-amber hover:underline no-underline"
+                className="font-mono text-[0.7rem] font-bold text-amber hover:underline no-underline whitespace-nowrap"
               >
-                View all →
+                View suburb →
               </Link>
             </div>
-            {nearbyPubs.map((nearby, i) => (
-              <Link
-                key={nearby.id}
-                href={pubUrl({ suburb: pub.suburb, slug: nearby.slug })}
-                className={`flex items-center justify-between px-4 py-3 no-underline group hover:bg-off-white transition-colors ${
-                  i < nearbyPubs.length - 1 ? 'border-b border-gray-light' : ''
-                }`}
-              >
-                <div className="min-w-0 flex-1">
-                  <p className="font-mono text-[0.82rem] font-extrabold text-ink group-hover:text-amber transition-colors truncate">{nearby.name}</p>
-                  <div className="flex items-center gap-2 mt-0.5">
-                    <span className="text-[0.65rem] text-gray-mid">{nearby.beerType || 'House Pint'}</span>
-                    {nearby.isHappyHourNow && (
-                      <span className="inline-flex items-center gap-1 text-[0.6rem] font-bold text-red">
-                        <span className="w-1.5 h-1.5 rounded-full bg-red animate-pulse" />
-                        Happy Hour
-                      </span>
-                    )}
+            {nearbyPubs.map((nearby, i) => {
+              const distanceText = nearby.distanceKm !== null && nearby.distanceKm !== undefined
+                ? `${formatDistance(nearby.distanceKm)} away`
+                : null
+              const priceText = nearby.price !== null ? `$${nearby.price.toFixed(2)}` : 'TBC'
+              const priceDelta = currentPrice !== null && nearby.price !== null
+                ? currentPrice - nearby.price
+                : null
+
+              return (
+                <Link
+                  key={nearby.id}
+                  href={pubUrl({ suburb: nearby.suburb, slug: nearby.slug })}
+                  aria-label={`${nearby.name} in ${nearby.suburb}: ${priceText} pints${distanceText ? `, ${distanceText}` : ''}`}
+                  className={`flex items-center justify-between px-4 py-3 no-underline group hover:bg-off-white transition-colors ${
+                    i < nearbyPubs.length - 1 ? 'border-b border-gray-light' : ''
+                  }`}
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="font-mono text-[0.82rem] font-extrabold text-ink group-hover:text-amber transition-colors truncate">{nearby.name}</p>
+                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 mt-0.5">
+                      <span className="text-[0.65rem] text-gray-mid">{nearby.suburb}</span>
+                      {distanceText && <span className="text-[0.65rem] text-gray-mid">{distanceText}</span>}
+                      {nearby.beerType && <span className="text-[0.65rem] text-gray-mid">{nearby.beerType}</span>}
+                      {priceDelta !== null && priceDelta > 0 && (
+                        <span className="text-[0.65rem] font-bold text-green">${priceDelta.toFixed(2)} cheaper</span>
+                      )}
+                      {nearby.isHappyHourNow && (
+                        <span className="inline-flex items-center gap-1 text-[0.6rem] font-bold text-red">
+                          <span className="w-1.5 h-1.5 rounded-full bg-red animate-pulse" />
+                          Happy Hour
+                        </span>
+                      )}
+                    </div>
                   </div>
-                </div>
-                <span className="font-mono text-[1rem] font-extrabold text-ink ml-3 flex-shrink-0">
-                  {nearby.price !== null ? `$${nearby.price.toFixed(2)}` : 'TBC'}
-                </span>
-              </Link>
-            ))}
+                  <span className="font-mono text-[1rem] font-extrabold text-ink ml-3 flex-shrink-0">
+                    {priceText}
+                  </span>
+                </Link>
+              )
+            })}
           </div>
         )}
       </div>

--- a/src/app/[suburb]/[pub]/page.tsx
+++ b/src/app/[suburb]/[pub]/page.tsx
@@ -4,7 +4,7 @@ import { notFound, permanentRedirect } from 'next/navigation'
 import { getPubBySlug, getAllPubSlugPairs, getLatestAndrewCallAtByPubId, getNearestPubFromList, getNearbyPubs, getSiteStats, getSuburbAveragePrice, getVerifiedPricePubs } from '@/lib/supabase'
 import { getPubIndexability } from '@/lib/pubIndexability'
 import { buildPubJsonLd } from '@/lib/pubJsonLd'
-import { absolutePubUrl, toSuburbSlug } from '@/lib/urls'
+import { absolutePubUrl, pubUrl, toSuburbSlug } from '@/lib/urls'
 import type { Pub } from '@/types/pub'
 import PubDetailClient from './PubDetailClient'
 
@@ -149,7 +149,7 @@ export default async function PubPage({ params }: PageProps) {
     : Promise.resolve([0, null, null])
 
   const [nearbyPubs, [nearbyVerifiedPriceCount, latestAndrewCallAt, nearestVerifiedPub], stats, suburbAvgPrice] = await Promise.all([
-    getNearbyPubs(pub.suburb, pub.id, 8),
+    getNearbyPubs(pub, 4),
     tierCDetails,
     getSiteStats(),
     getSuburbAveragePrice(pub.suburb),
@@ -170,7 +170,7 @@ export default async function PubPage({ params }: PageProps) {
         <a href={`/${suburbSlug}`}>{pub.suburb}</a>
         <a href="/suburbs">All Suburbs</a>
         {nearbyPubs.map(np => (
-          <a key={np.slug} href={`/${suburbSlug}/${np.slug}`}>{np.name} - {np.suburb}</a>
+          <a key={np.slug} href={pubUrl({ suburb: np.suburb, slug: np.slug })}>{np.name} - {np.suburb}</a>
         ))}
       </div>
 

--- a/src/lib/nearbyPubs.test.ts
+++ b/src/lib/nearbyPubs.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { Pub } from '@/types/pub'
+import { rankNearbyPubs } from './nearbyPubs'
+
+function pub(overrides: Partial<Pub>): Pub {
+  return {
+    id: 1,
+    slug: 'current',
+    name: 'Current Pub',
+    address: '',
+    suburb: 'Perth',
+    lat: -31.9523,
+    lng: 115.8613,
+    price: 10,
+    regularPrice: 10,
+    effectivePrice: 10,
+    beerType: '',
+    happyHour: null,
+    website: null,
+    description: null,
+    priceVerified: true,
+    hasTab: false,
+    kidFriendly: false,
+    cozyPub: false,
+    happyHourPrice: null,
+    happyHourDays: null,
+    happyHourStart: null,
+    happyHourEnd: null,
+    lastVerified: null,
+    isHappyHourNow: false,
+    happyHourLabel: null,
+    happyHourMinutesRemaining: null,
+    imageUrl: null,
+    vibeTag: null,
+    ...overrides,
+  }
+}
+
+test('rankNearbyPubs prefers cheaper cross-suburb pubs inside the radius', () => {
+  const current = pub({})
+  const ranked = rankNearbyPubs(current, [
+    pub({ id: 2, name: 'Same Suburb Expensive', slug: 'same', suburb: 'Perth', lat: -31.953, lng: 115.862, price: 11, regularPrice: 11, effectivePrice: 11 }),
+    pub({ id: 3, name: 'Northbridge Cheap', slug: 'northbridge-cheap', suburb: 'Northbridge', lat: -31.946, lng: 115.858, price: 8, regularPrice: 8, effectivePrice: 8 }),
+    pub({ id: 4, name: 'East Perth Cheap', slug: 'east-perth-cheap', suburb: 'East Perth', lat: -31.955, lng: 115.872, price: 9, regularPrice: 9, effectivePrice: 9 }),
+  ])
+
+  assert.deepEqual(ranked.map(item => item.name), ['Northbridge Cheap', 'East Perth Cheap'])
+  assert.equal(typeof ranked[0].distanceKm, 'number')
+})
+
+test('rankNearbyPubs falls back to same suburb when radius results are sparse', () => {
+  const current = pub({})
+  const ranked = rankNearbyPubs(current, [
+    pub({ id: 2, name: 'Close Cheap', slug: 'close-cheap', lat: -31.953, lng: 115.862, price: 8, regularPrice: 8, effectivePrice: 8 }),
+    pub({ id: 3, name: 'Same Suburb Cheap', slug: 'same-suburb-cheap', suburb: 'Perth', lat: -32.1, lng: 116.1, price: 9, regularPrice: 9, effectivePrice: 9 }),
+  ])
+
+  assert.deepEqual(ranked.map(item => item.name), ['Close Cheap', 'Same Suburb Cheap'])
+})
+
+test('rankNearbyPubs shows nearest verified prices when the current pub has no price', () => {
+  const current = pub({ price: null, regularPrice: null, effectivePrice: null })
+  const ranked = rankNearbyPubs(current, [
+    pub({ id: 2, name: 'Unverified Pub', slug: 'unverified', priceVerified: false, price: 7, regularPrice: 7, effectivePrice: 7 }),
+    pub({ id: 3, name: 'Verified Pub', slug: 'verified', suburb: 'Northbridge', lat: -31.946, lng: 115.858, price: 9, regularPrice: 9, effectivePrice: 9 }),
+  ])
+
+  assert.deepEqual(ranked.map(item => item.name), ['Verified Pub'])
+})

--- a/src/lib/nearbyPubs.ts
+++ b/src/lib/nearbyPubs.ts
@@ -1,0 +1,74 @@
+import { haversineDistanceKm } from '@/lib/location'
+import type { Pub } from '@/types/pub'
+
+export const NEARBY_RADIUS_KM = 2
+export const NEARBY_FALLBACK_MIN_RESULTS = 3
+
+export function hasUsableCoordinates(pub: Pick<Pub, 'lat' | 'lng'>): boolean {
+  return Number.isFinite(pub.lat) && Number.isFinite(pub.lng) && !(pub.lat === 0 && pub.lng === 0)
+}
+
+function comparablePrice(pub: Pub): number | null {
+  return pub.effectivePrice ?? pub.price ?? pub.regularPrice
+}
+
+function withDistance(currentPub: Pub, pub: Pub): Pub {
+  return {
+    ...pub,
+    distanceKm: hasUsableCoordinates(currentPub) && hasUsableCoordinates(pub)
+      ? haversineDistanceKm(currentPub.lat, currentPub.lng, pub.lat, pub.lng)
+      : null,
+  }
+}
+
+function uniqueById(pubs: Pub[]): Pub[] {
+  const seen = new Set<number>()
+  return pubs.filter(pub => {
+    if (seen.has(pub.id)) return false
+    seen.add(pub.id)
+    return true
+  })
+}
+
+function sortNearby(a: Pub, b: Pub): number {
+  const aDistance = a.distanceKm ?? Number.MAX_VALUE
+  const bDistance = b.distanceKm ?? Number.MAX_VALUE
+  const aPrice = comparablePrice(a) ?? Number.MAX_VALUE
+  const bPrice = comparablePrice(b) ?? Number.MAX_VALUE
+
+  return aDistance - bDistance || aPrice - bPrice || a.name.localeCompare(b.name)
+}
+
+export function rankNearbyPubs(
+  currentPub: Pub,
+  candidates: Pub[],
+  limit = 4,
+  radiusKm = NEARBY_RADIUS_KM,
+): Pub[] {
+  const pricedCandidates = uniqueById(candidates)
+    .filter(pub => pub.id !== currentPub.id && pub.price !== null && pub.priceVerified)
+    .map(pub => withDistance(currentPub, pub))
+
+  const inRadius = hasUsableCoordinates(currentPub)
+    ? pricedCandidates.filter(pub => typeof pub.distanceKm === 'number' && pub.distanceKm <= radiusKm)
+    : []
+
+  const sameSuburb = pricedCandidates.filter(pub => pub.suburb === currentPub.suburb)
+  const candidatePool = uniqueById(
+    inRadius.length >= NEARBY_FALLBACK_MIN_RESULTS
+      ? inRadius
+      : [...inRadius, ...sameSuburb],
+  )
+
+  const currentPrice = comparablePrice(currentPub)
+  const cheaperPubs = currentPrice === null
+    ? []
+    : candidatePool.filter(pub => {
+      const price = comparablePrice(pub)
+      return price !== null && price < currentPrice
+    })
+
+  return (cheaperPubs.length > 0 ? cheaperPubs : candidatePool)
+    .sort(sortNearby)
+    .slice(0, limit)
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -2,6 +2,7 @@ import { createClient } from '@supabase/supabase-js'
 import { Pub } from '@/types/pub'
 import { getHappyHourStatus } from '@/lib/happyHourLive'
 import { haversineDistanceKm } from '@/lib/location'
+import { hasUsableCoordinates, NEARBY_RADIUS_KM, rankNearbyPubs } from '@/lib/nearbyPubs'
 import { getPubIndexability, PubIndexabilityTier } from '@/lib/pubIndexability'
 import { toSuburbSlug } from './urls'
 
@@ -310,19 +311,56 @@ export async function getIndexablePubSlugPairs(): Promise<IndexablePubSlugPair[]
     .map(({ isIndexable, ...row }) => row)
 }
 
-// Fetch nearby pubs (same suburb, excluding current)
-export async function getNearbyPubs(suburb: string, excludeId: number, limit: number = 4): Promise<Pub[]> {
+async function getSameSuburbPricedPubs(suburb: string, excludeId: number, limit: number): Promise<Pub[]> {
   const { data, error } = await supabase
     .from('pubs')
     .select('*')
     .eq('suburb', suburb)
     .neq('id', excludeId)
+    .not('price', 'is', null)
+    .or('price_verified.is.null,price_verified.eq.true')
     .order('price', { ascending: true, nullsFirst: false })
     .limit(limit)
-  
+
   if (error || !data) return []
-  
+
   return data.map(toPub)
+}
+
+async function getRadiusCandidatePubs(pub: Pub, radiusKm: number, limit: number): Promise<Pub[]> {
+  if (!hasUsableCoordinates(pub)) return []
+
+  const latDelta = radiusKm / 111
+  const lngScaleKm = 111 * Math.cos(pub.lat * Math.PI / 180)
+  if (!Number.isFinite(lngScaleKm) || lngScaleKm === 0) return []
+  const lngDelta = radiusKm / lngScaleKm
+
+  const { data, error } = await supabase
+    .from('pubs')
+    .select('*')
+    .neq('id', pub.id)
+    .not('price', 'is', null)
+    .or('price_verified.is.null,price_verified.eq.true')
+    .gte('lat', pub.lat - latDelta)
+    .lte('lat', pub.lat + latDelta)
+    .gte('lng', pub.lng - lngDelta)
+    .lte('lng', pub.lng + lngDelta)
+    .order('price', { ascending: true, nullsFirst: false })
+    .limit(Math.max(limit * 4, 12))
+
+  if (error || !data) return []
+
+  return data.map(toPub)
+}
+
+// Fetch geo-aware nearby pubs, falling back to same-suburb links when sparse.
+export async function getNearbyPubs(pub: Pub, limit: number = 4): Promise<Pub[]> {
+  const radiusCandidates = await getRadiusCandidatePubs(pub, NEARBY_RADIUS_KM, limit)
+  const sameSuburbCandidates = radiusCandidates.length < limit
+    ? await getSameSuburbPricedPubs(pub.suburb, pub.id, limit)
+    : []
+
+  return rankNearbyPubs(pub, [...radiusCandidates, ...sameSuburbCandidates], limit)
 }
 
 export async function getVerifiedPricePubs(): Promise<Pub[]> {

--- a/src/types/pub.ts
+++ b/src/types/pub.ts
@@ -32,4 +32,5 @@ export interface Pub {
   vibeTag: string | null
   cozyPub: boolean
   effectivePrice: number | null
+  distanceKm?: number | null
 }


### PR DESCRIPTION
## Summary
- Replaces same-suburb-only pub recommendations with a geo-aware nearby helper for pub pages.
- Ranks verified priced pubs inside a 2km radius, with same-suburb fallback when radius results are sparse.
- Updates the pub-page module to show `Cheaper nearby` or `Nearby verified prices`, distance, suburb, price deltas, and correct cross-suburb canonical links.
- Adds pure ranking tests and records the work in `docs/PROJECT-STATUS.md`.

Closes #73.

## Verification
- `npm test` — 203/203 passing
- `npx tsc --noEmit`
- `npm run lint` — existing warnings only in `SubmitPubForm` and `SunsetSippers`
- `npm run build`
- Local visual checks with Playwright screenshots:
  - `/perth/18-knots-rooftop-bar` mobile/TBC nearby verified prices
  - `/kalamunda/kalamunda-hotel` desktop/priced Cheaper nearby
