### PR TITLE
Add price recency tiers

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,11 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Price-recency tiers ready (2026-06-01)
+- **Issue #77 / branch `codex/price-recency-tiers-77` / commit `5134a24`:** added one `getPriceRecency` helper for `fresh` (<30 days), `aging` (30-90 days), `stale` (91+ days), and `unknown` price states derived from `last_verified`.
+- **Render + prerender:** pub pages now receive the recency tier from the server and stale prices show a visible `May be out of date` badge plus the checked-days count. The same tier feeds `dataScore` and Tier A/B/C selection, so stale verified prices fall to Tier B and only Tier A pub pages are pre-rendered.
+- **Verification:** added recency-boundary tests and indexability scoring tests. Verified `npm test` (**209/209 tests**), `npx tsc --noEmit`, `npm run lint` (existing warnings only), `npm run build`, and desktop/mobile screenshots for stale-price pub page `/northbridge/the-court-hotel`.
+
 ### Geo-aware Cheaper Nearby module ready (2026-06-01)
 - **Issue #73 / branch `codex/cheaper-nearby-73` / commit `cae6329`:** replaced same-suburb-only pub recommendations with a geo-aware nearby helper. Pub pages now rank verified priced pubs inside a 2km radius, fall back to same-suburb links when sparse, and keep TBC pages useful with nearby verified prices.
 - **Cross-suburb internal links:** the module now renders correct cross-suburb pub URLs, distance text, suburb labels, and price-delta copy such as `$4.30 cheaper`, with crawler-visible links using the same canonical URL helper.

--- a/src/app/[suburb]/[pub]/PubDetailClient.tsx
+++ b/src/app/[suburb]/[pub]/PubDetailClient.tsx
@@ -13,6 +13,7 @@ import Footer from '@/components/Footer'
 import { pubUrl, suburbUrl } from '@/lib/urls'
 import { verificationStub } from '@/lib/voiceCopy'
 import { formatDistance } from '@/lib/location'
+import type { PriceRecencyInfo, PriceRecencyTier } from '@/lib/freshness'
 
 const PubDetailMap = dynamic(() => import('@/components/PubDetailMap'), {
   ssr: false,
@@ -40,6 +41,7 @@ function formatHappyHourTime(start: string | null, end: string | null): string {
 
 interface PubDetailClientProps {
   pub: Pub
+  priceRecency: PriceRecencyInfo
   nearbyPubs: Pub[]
   avgPrice: number
   isTierCPage: boolean
@@ -50,6 +52,7 @@ interface PubDetailClientProps {
 
 export default function PubDetailClient({
   pub,
+  priceRecency,
   nearbyPubs,
   avgPrice,
   isTierCPage,
@@ -92,7 +95,13 @@ export default function PubDetailClient({
   const hasCheaperNearby = currentPrice !== null && nearbyPubs.some(nearby =>
     nearby.price !== null && nearby.price < currentPrice
   )
-  const hasStatusRow = pub.isHappyHourNow || (pub.priceVerified && pub.price !== null) || !!pub.lastVerified
+  const hasStatusRow = pub.isHappyHourNow || pub.price !== null || !!pub.lastVerified
+  const recencyBadgeClass: Record<PriceRecencyTier, string> = {
+    fresh: 'text-green bg-green-pale border-green',
+    aging: 'text-amber bg-amber-pale border-amber',
+    stale: 'text-amber bg-amber-pale border-amber',
+    unknown: 'text-gray-mid bg-off-white border-gray-light',
+  }
   const priceMissingCopy = isTierCPage
     ? verificationStub({
       lastAndrewCall: latestAndrewCallAt ? formatLastVerifiedDate(latestAndrewCallAt) : null,
@@ -188,9 +197,9 @@ export default function PubDetailClient({
                       HH{pub.happyHourMinutesRemaining ? ` · ${pub.happyHourMinutesRemaining < 1 ? 'ending soon' : pub.happyHourMinutesRemaining < 60 ? `${pub.happyHourMinutesRemaining}m left` : `${Math.floor(pub.happyHourMinutesRemaining / 60)}h ${pub.happyHourMinutesRemaining % 60 > 0 ? `${pub.happyHourMinutesRemaining % 60}m ` : ''}left`}` : ''}
                     </span>
                   )}
-                  {pub.priceVerified && pub.price !== null && (
-                    <span className="inline-flex items-center gap-1 font-mono text-[0.6rem] font-bold uppercase tracking-wider text-green bg-green-pale px-2.5 py-1 rounded-full border border-green">
-                      Verified
+                  {pub.price !== null && (
+                    <span className={`inline-flex items-center gap-1 font-mono text-[0.6rem] font-bold uppercase tracking-wider px-2.5 py-1 rounded-full border ${recencyBadgeClass[priceRecency.tier]}`}>
+                      {priceRecency.label}
                     </span>
                   )}
                   {pub.lastVerified && (
@@ -202,6 +211,11 @@ export default function PubDetailClient({
                     </time>
                   )}
                 </div>
+              )}
+              {pub.price !== null && priceRecency.tier === 'stale' && (
+                <p className="mt-3 text-[0.76rem] leading-relaxed text-ink bg-amber-pale border border-amber rounded-card px-3 py-2">
+                  Price may be out of date. Last checked {priceRecency.daysAgo} days ago.
+                </p>
               )}
               {priceMissingCopy && (
                 <div className="mt-4 pt-4 border-t border-gray-light">

--- a/src/app/[suburb]/[pub]/page.tsx
+++ b/src/app/[suburb]/[pub]/page.tsx
@@ -1,8 +1,9 @@
 import { Metadata } from 'next'
 import { unstable_cache } from 'next/cache'
 import { notFound, permanentRedirect } from 'next/navigation'
-import { getPubBySlug, getAllPubSlugPairs, getLatestAndrewCallAtByPubId, getNearestPubFromList, getNearbyPubs, getSiteStats, getSuburbAveragePrice, getVerifiedPricePubs } from '@/lib/supabase'
+import { getPubBySlug, getIndexablePubSlugPairs, getLatestAndrewCallAtByPubId, getNearestPubFromList, getNearbyPubs, getSiteStats, getSuburbAveragePrice, getVerifiedPricePubs } from '@/lib/supabase'
 import { getPubIndexability } from '@/lib/pubIndexability'
+import { getPriceRecency } from '@/lib/freshness'
 import { buildPubJsonLd } from '@/lib/pubJsonLd'
 import { absolutePubUrl, pubUrl, toSuburbSlug } from '@/lib/urls'
 import type { Pub } from '@/types/pub'
@@ -115,8 +116,10 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 export async function generateStaticParams() {
-  const pairs = await getAllPubSlugPairs()
-  return pairs.map(pair => ({ suburb: toSuburbSlug(pair.suburb), pub: pair.slug }))
+  const pairs = await getIndexablePubSlugPairs()
+  return pairs
+    .filter(pair => pair.indexabilityTier === 'A')
+    .map(pair => ({ suburb: toSuburbSlug(pair.suburb), pub: pair.slug }))
 }
 
 export const dynamicParams = true
@@ -133,6 +136,7 @@ export default async function PubPage({ params }: PageProps) {
   }
 
   const indexability = getPubPageIndexability(pub)
+  const priceRecency = getPriceRecency(pub.lastVerified)
   const isTierCPage = indexability.tier === 'C'
   const tierCDetails: Promise<[number, string | null, Pub | null]> = isTierCPage
     ? Promise.all([getCachedVerifiedPricePubs(), getCachedLatestAndrewCallAtByPubId()]).then(([verifiedPricePubs, latestAndrewCallAtByPubId]) => {
@@ -176,6 +180,7 @@ export default async function PubPage({ params }: PageProps) {
 
       <PubDetailClient
         pub={pub}
+        priceRecency={priceRecency}
         nearbyPubs={nearbyPubs}
         avgPrice={Number(stats.avgPrice)}
         isTierCPage={isTierCPage}

--- a/src/lib/freshness.test.ts
+++ b/src/lib/freshness.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { getPriceRecency } from './freshness'
+
+const NOW = new Date('2026-06-01T12:00:00.000Z')
+
+describe('getPriceRecency', () => {
+  it('marks prices checked within 30 days as fresh', () => {
+    const result = getPriceRecency('2026-05-03T12:00:00.000Z', NOW)
+
+    assert.equal(result.tier, 'fresh')
+    assert.equal(result.daysAgo, 29)
+    assert.equal(result.label, 'Verified')
+  })
+
+  it('marks prices from 30 to 90 days old as aging', () => {
+    assert.equal(getPriceRecency('2026-05-02T12:00:00.000Z', NOW).tier, 'aging')
+    assert.equal(getPriceRecency('2026-03-03T12:00:00.000Z', NOW).tier, 'aging')
+  })
+
+  it('marks prices older than 90 days as stale', () => {
+    const result = getPriceRecency('2026-03-02T12:00:00.000Z', NOW)
+
+    assert.equal(result.tier, 'stale')
+    assert.equal(result.daysAgo, 91)
+    assert.equal(result.label, 'May be out of date')
+  })
+
+  it('marks missing or invalid verification dates as unknown', () => {
+    assert.equal(getPriceRecency(null, NOW).tier, 'unknown')
+    assert.equal(getPriceRecency('not-a-date', NOW).tier, 'unknown')
+  })
+})

--- a/src/lib/freshness.ts
+++ b/src/lib/freshness.ts
@@ -1,4 +1,5 @@
 export type FreshnessLevel = 'verified' | 'unknown'
+export type PriceRecencyTier = 'fresh' | 'aging' | 'stale' | 'unknown'
 
 export interface FreshnessInfo {
   level: FreshnessLevel
@@ -7,6 +8,39 @@ export interface FreshnessInfo {
   color: string
   bgColor: string
   borderColor: string
+}
+
+export interface PriceRecencyInfo {
+  tier: PriceRecencyTier
+  daysAgo: number | null
+  label: string
+}
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24
+
+export function getPriceRecency(lastVerified: string | null | undefined, now = new Date()): PriceRecencyInfo {
+  if (!lastVerified) {
+    return { tier: 'unknown', daysAgo: null, label: 'Needs verification' }
+  }
+
+  const verified = new Date(lastVerified)
+  const verifiedTime = verified.getTime()
+
+  if (!Number.isFinite(verifiedTime)) {
+    return { tier: 'unknown', daysAgo: null, label: 'Needs verification' }
+  }
+
+  const daysAgo = Math.max(0, Math.floor((now.getTime() - verifiedTime) / MS_PER_DAY))
+
+  if (daysAgo < 30) {
+    return { tier: 'fresh', daysAgo, label: 'Verified' }
+  }
+
+  if (daysAgo <= 90) {
+    return { tier: 'aging', daysAgo, label: 'Recheck soon' }
+  }
+
+  return { tier: 'stale', daysAgo, label: 'May be out of date' }
 }
 
 export function getFreshness(lastVerified: string | null): FreshnessInfo {
@@ -24,7 +58,7 @@ export function getFreshness(lastVerified: string | null): FreshnessInfo {
   const now = new Date()
   const verified = new Date(lastVerified)
   const diffMs = now.getTime() - verified.getTime()
-  const daysAgo = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+  const daysAgo = Math.floor(diffMs / MS_PER_DAY)
 
   return {
     level: 'verified',
@@ -41,7 +75,7 @@ export function formatVerifiedDate(lastVerified: string | null): string {
   const date = new Date(lastVerified)
   const now = new Date()
   const diffMs = now.getTime() - date.getTime()
-  const daysAgo = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+  const daysAgo = Math.floor(diffMs / MS_PER_DAY)
 
   if (daysAgo === 0) return 'Verified today'
   if (daysAgo === 1) return 'Verified yesterday'

--- a/src/lib/pubIndexability.test.ts
+++ b/src/lib/pubIndexability.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { getPubIndexability } from './pubIndexability'
 
+const NOW = new Date('2026-06-01T12:00:00.000Z')
+
 describe('getPubIndexability', () => {
   it('noindexes NAP-only pub pages', () => {
     const result = getPubIndexability({
@@ -30,10 +32,41 @@ describe('getPubIndexability', () => {
       price: 11.5,
       priceVerified: true,
       lastVerified: '2026-05-31T00:00:00.000Z',
+      now: NOW,
     })
 
     assert.equal(result.tier, 'A')
     assert.equal(result.isIndexable, true)
+  })
+
+  it('demotes stale verified prices to Tier B', () => {
+    const result = getPubIndexability({
+      price: 11.5,
+      priceVerified: true,
+      lastVerified: '2026-03-02T00:00:00.000Z',
+      now: NOW,
+    })
+
+    assert.equal(result.tier, 'B')
+    assert.equal(result.isIndexable, true)
+  })
+
+  it('scores fresh prices above stale prices', () => {
+    const fresh = getPubIndexability({
+      price: 11.5,
+      priceVerified: true,
+      lastVerified: '2026-05-31T00:00:00.000Z',
+      now: NOW,
+    })
+    const stale = getPubIndexability({
+      price: 11.5,
+      priceVerified: true,
+      lastVerified: '2026-03-02T00:00:00.000Z',
+      now: NOW,
+    })
+
+    assert.equal(fresh.dataScore, 4)
+    assert.equal(stale.dataScore, 2)
   })
 
   it('indexes happy-hour pubs without a regular price', () => {

--- a/src/lib/pubIndexability.ts
+++ b/src/lib/pubIndexability.ts
@@ -1,3 +1,5 @@
+import { getPriceRecency } from '@/lib/freshness'
+
 export type PubIndexabilityTier = 'A' | 'B' | 'C'
 
 export interface PubIndexabilityInput {
@@ -16,6 +18,7 @@ export interface PubIndexabilityInput {
   cozyPub?: boolean | null
   sunsetSpot?: boolean | null
   website?: string | null
+  now?: Date
 }
 
 export interface PubIndexability {
@@ -34,7 +37,9 @@ function hasText(value: string | null | undefined): boolean {
 
 export function getPubIndexability(pub: PubIndexabilityInput): PubIndexability {
   const hasPrice = hasPositiveNumber(pub.price)
-  const hasVerifiedPrice = hasPrice && pub.priceVerified !== false && hasText(pub.lastVerified)
+  const priceRecency = getPriceRecency(pub.lastVerified, pub.now)
+  const hasCurrentRecency = priceRecency.tier === 'fresh' || priceRecency.tier === 'aging'
+  const hasVerifiedPrice = hasPrice && pub.priceVerified !== false && hasCurrentRecency
   const hasHappyHour = hasText(pub.happyHour)
     || hasPositiveNumber(pub.happyHourPrice)
     || (hasText(pub.happyHourDays) && hasText(pub.happyHourStart) && hasText(pub.happyHourEnd))
@@ -50,9 +55,13 @@ export function getPubIndexability(pub: PubIndexabilityInput): PubIndexability {
     pub.sunsetSpot,
   ].filter(Boolean).length
 
+  const recencyScore = hasPrice && pub.priceVerified !== false
+    ? { fresh: 2, aging: 1, stale: 0, unknown: 0 }[priceRecency.tier]
+    : 0
+
   const dataScore = [
     hasPrice ? 2 : 0,
-    hasVerifiedPrice ? 1 : 0,
+    recencyScore,
     hasHappyHour ? 2 : 0,
     Math.min(attributeCount, 2),
   ].reduce((sum, score) => sum + score, 0)


### PR DESCRIPTION
## Summary
- Add a shared price-recency helper for fresh, aging, stale, and unknown `last_verified` states.
- Feed recency into pub indexability dataScore and Tier A/B/C selection; stale verified prices now fall to Tier B.
- Render stale pub prices with a visible may-be-out-of-date state, and pre-render only Tier A pub pages while leaving dynamic fallback enabled.

Closes #77

## Verification
- `npm test` (209/209)
- `npx tsc --noEmit`
- `npm run lint` (existing SubmitPubForm/SunsetSippers warnings only)
- `npm run build`
- Playwright screenshots: desktop 1280x800 and mobile 375x812 for `/northbridge/the-court-hotel`
