### PR TITLE
Add Playwright PR proof artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   verify:
     name: Typecheck, lint, build
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -54,3 +54,23 @@ jobs:
           # Stub vars so generateStaticParams() can hit Supabase during build
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Playwright PR proof
+        run: npm run test:e2e
+        env:
+          NEXT_TELEMETRY_DISABLED: "1"
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+
+      - name: Upload Playwright proof
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-proof
+          path: |
+            playwright-report
+            test-results/playwright
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ npm-debug.log*
 
 # Playwright MCP cache
 .playwright-mcp/
+playwright-report/
+test-results/
 
 # Development screenshots
 *.png

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,11 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Playwright PR proof gate ready (2026-06-01)
+- **Branch `codex/playwright-pr-proof` / commit `5da3158`:** installed Playwright Test and added desktop/mobile PR proof smoke coverage for the homepage and a pub detail page, with screenshots attached to the HTML report.
+- **CI artifacts:** the main CI workflow now installs Chromium, runs `npm run test:e2e` after the production build, and uploads a `playwright-proof` artifact containing the report and test output. Videos are retained for failures, and `npm run test:e2e:video` records intentional proof videos when motion or multi-step UI needs it.
+- **Verification:** verified `npm test` (**209/209 tests**), `npx tsc --noEmit`, `npm run lint` (existing warnings only), `npm run build`, `npm run test:e2e` (**4/4 Playwright tests**), a video-mode pub-page proof run, and the PR #124 GitHub artifact upload.
+
 ### Price-recency tiers ready (2026-06-01)
 - **Issue #77 / branch `codex/price-recency-tiers-77` / commit `a5183ea`:** added one `getPriceRecency` helper for `fresh` (<30 days), `aging` (30-90 days), `stale` (91+ days), and `unknown` price states derived from `last_verified`.
 - **Render + prerender:** pub pages now receive the recency tier from the server and stale prices show a visible `May be out of date` badge plus the checked-days count. The same tier feeds `dataScore` and Tier A/B/C selection, so stale verified prices fall to Tier B and only Tier A pub pages are pre-rendered.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "web-push": "^3.6.7"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@types/leaflet": "^1.9.8",
         "@types/leaflet.markercluster": "^1.5.4",
         "@types/node": "^20.12.7",
@@ -954,6 +955,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -7117,6 +7134,52 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "start": "next start",
     "lint": "next lint --max-warnings 50",
     "test": "tsx --test \"src/**/*.test.ts\"",
-    "test:redirects": "node scripts/redirect-seo.test.mjs"
+    "test:redirects": "node scripts/redirect-seo.test.mjs",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:video": "PLAYWRIGHT_VIDEO=on playwright test"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.106.2",
@@ -32,6 +35,7 @@
     "web-push": "^3.6.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/leaflet": "^1.9.8",
     "@types/leaflet.markercluster": "^1.5.4",
     "@types/node": "^20.12.7",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,64 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const port = process.env.PLAYWRIGHT_PORT || '3100'
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || `http://localhost:${port}`
+const webServerCommand = process.env.PLAYWRIGHT_WEB_SERVER_COMMAND
+  || (process.env.CI ? `npm run start -- -p ${port}` : `npm run dev -- -p ${port}`)
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  outputDir: 'test-results/playwright',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  timeout: 30_000,
+  expect: {
+    timeout: 8_000,
+  },
+  reporter: process.env.CI
+    ? [
+      ['github'],
+      ['list'],
+      ['html', { outputFolder: 'playwright-report', open: 'never' }],
+    ]
+    : [
+      ['list'],
+      ['html', { outputFolder: 'playwright-report', open: 'never' }],
+    ],
+  use: {
+    baseURL,
+    screenshot: 'only-on-failure',
+    trace: 'on-first-retry',
+    video: process.env.PLAYWRIGHT_VIDEO === 'on' ? 'on' : 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'desktop-chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 800 },
+      },
+    },
+    {
+      name: 'mobile-chromium',
+      use: {
+        ...devices['Pixel 5'],
+        viewport: { width: 375, height: 812 },
+      },
+    },
+  ],
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+      command: webServerCommand,
+      url: baseURL,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        NEXT_TELEMETRY_DISABLED: '1',
+        NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL || '',
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
+      },
+    },
+})

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,5 @@
+# Playwright PR Proof
+
+Every PR runs `npm run test:e2e` in CI and uploads the `playwright-proof` artifact. The HTML report includes attached desktop and mobile screenshots for the core smoke paths.
+
+Use `npm run test:e2e:video` when motion, forms, maps, or multi-step UI need a recording. Regular CI keeps videos for failures and traces for first retries.

--- a/tests/e2e/pr-proof.spec.ts
+++ b/tests/e2e/pr-proof.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test'
+
+async function attachProof(page: Page, testInfo: TestInfo, name: string) {
+  const screenshot = await page.screenshot({ fullPage: true })
+
+  await testInfo.attach(`${testInfo.project.name} ${name}`, {
+    body: screenshot,
+    contentType: 'image/png',
+  })
+}
+
+test('homepage renders the core discovery experience', async ({ page }, testInfo) => {
+  await page.goto('/')
+
+  await expect(page.getByRole('heading', { name: /perth's pints/i })).toBeVisible()
+  await expect(page.getByRole('link', { name: /discover/i }).first()).toBeVisible()
+  await expect(page.getByText(/real pint prices/i).first()).toBeVisible()
+
+  await attachProof(page, testInfo, 'homepage')
+})
+
+test('pub page renders price, freshness, map, and nearby prices', async ({ page }, testInfo) => {
+  await page.goto('/northbridge/the-court-hotel')
+
+  await expect(page.getByRole('heading', { name: 'The Court Hotel' })).toBeVisible()
+  await expect(page.getByText('Pint Price', { exact: true })).toBeVisible()
+  await expect(page.getByText(/Last verified/i)).toBeVisible()
+  await expect(page.getByText(/Nearby verified prices/i)).toBeVisible()
+  await expect(page.locator('.leaflet-container')).toBeVisible()
+
+  await attachProof(page, testInfo, 'pub-page')
+})


### PR DESCRIPTION
## Summary
- Install Playwright Test and add desktop/mobile PR proof smoke tests for homepage and pub-page flows.
- Add Playwright config with screenshots attached to the HTML report, traces/videos retained for debugging, and an explicit video-mode script.
- Run Playwright in CI after build and upload a `playwright-proof` artifact for every PR.

## Verification
- `npm test` (209/209)
- `npx tsc --noEmit`
- `npm run lint` (existing SubmitPubForm/SunsetSippers warnings only)
- `npm run build`
- `npm run test:e2e` (4/4)
- `PLAYWRIGHT_VIDEO=on npx playwright test tests/e2e/pr-proof.spec.ts --project=desktop-chromium --grep "pub page"`
