### PR TITLE
Remove bulky stale price warning block

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,10 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Stale-price warning trimmed (2026-06-01)
+- **Branch `codex/remove-stale-warning-blob` / commit `d39e819`:** removed the duplicated stale-price warning paragraph from pub price cards. The compact `May be out of date` pill and last-verified date remain, keeping the freshness signal without the bulky text block.
+- **Verification:** verified focused recency/indexability tests, `npx tsc --noEmit`, `npm run lint` (existing warnings only), `npm run build`, and desktop/mobile Playwright proof for `/northbridge/the-court-hotel`.
+
 ### Playwright PR proof gate ready (2026-06-01)
 - **Branch `codex/playwright-pr-proof` / commit `5da3158`:** installed Playwright Test and added desktop/mobile PR proof smoke coverage for the homepage and a pub detail page, with screenshots attached to the HTML report.
 - **CI artifacts:** the main CI workflow now installs Chromium, runs `npm run test:e2e` after the production build, and uploads a `playwright-proof` artifact containing the report and test output. Videos are retained for failures, and `npm run test:e2e:video` records intentional proof videos when motion or multi-step UI needs it.

--- a/src/app/[suburb]/[pub]/PubDetailClient.tsx
+++ b/src/app/[suburb]/[pub]/PubDetailClient.tsx
@@ -212,11 +212,6 @@ export default function PubDetailClient({
                   )}
                 </div>
               )}
-              {pub.price !== null && priceRecency.tier === 'stale' && (
-                <p className="mt-3 text-[0.76rem] leading-relaxed text-ink bg-amber-pale border border-amber rounded-card px-3 py-2">
-                  Price may be out of date. Last checked {priceRecency.daysAgo} days ago.
-                </p>
-              )}
               {priceMissingCopy && (
                 <div className="mt-4 pt-4 border-t border-gray-light">
                   {nearestVerifiedPub ? (


### PR DESCRIPTION
## Summary
- Remove the bulky stale-price warning paragraph from the pub price card.
- Keep the compact `May be out of date` pill and last-verified date as the freshness signal.

## Verification
- `npm test -- --test-name-pattern='getPriceRecency|getPubIndexability'`
- `npx tsc --noEmit`
- `npm run lint` (existing SubmitPubForm/SunsetSippers warnings only)
- `npm run build`
- `npm run test:e2e -- --project=desktop-chromium --project=mobile-chromium --grep 'pub page'`
