### PR TITLE
Humanise pub price recency chip

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,10 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Price recency chip humanised (2026-06-01)
+- **Branch `codex/humanize-recency-chip` / commit `b41ceaf`:** changed pub-page recency copy from warning-style labels plus a visible date to one plain chip such as `Checked 103d ago`. The exact date remains available as hover text, but the card now speaks in the dry, normal-person voice.
+- **Verification:** verified focused recency/indexability tests (**210/210 tests**), `npx tsc --noEmit`, `npm run lint` (existing warnings only), `npm run build`, and desktop/mobile Playwright proof for `/northbridge/the-court-hotel`.
+
 ### Stale-price warning trimmed (2026-06-01)
 - **Branch `codex/remove-stale-warning-blob` / commit `d39e819`:** removed the duplicated stale-price warning paragraph from pub price cards. The compact `May be out of date` pill and last-verified date remain, keeping the freshness signal without the bulky text block.
 - **Verification:** verified focused recency/indexability tests, `npx tsc --noEmit`, `npm run lint` (existing warnings only), `npm run build`, and desktop/mobile Playwright proof for `/northbridge/the-court-hotel`.

--- a/src/app/[suburb]/[pub]/PubDetailClient.tsx
+++ b/src/app/[suburb]/[pub]/PubDetailClient.tsx
@@ -198,17 +198,12 @@ export default function PubDetailClient({
                     </span>
                   )}
                   {pub.price !== null && (
-                    <span className={`inline-flex items-center gap-1 font-mono text-[0.6rem] font-bold uppercase tracking-wider px-2.5 py-1 rounded-full border ${recencyBadgeClass[priceRecency.tier]}`}>
+                    <span
+                      className={`inline-flex items-center gap-1 font-mono text-[0.65rem] font-bold px-2.5 py-1 rounded-full border ${recencyBadgeClass[priceRecency.tier]}`}
+                      title={pub.lastVerified ? `Last verified ${formatLastVerifiedDate(pub.lastVerified)}` : undefined}
+                    >
                       {priceRecency.label}
                     </span>
-                  )}
-                  {pub.lastVerified && (
-                    <time
-                      dateTime={new Date(pub.lastVerified).toISOString()}
-                      className="text-[0.7rem] text-gray-mid"
-                    >
-                      Last verified {formatLastVerifiedDate(pub.lastVerified)}
-                    </time>
                   )}
                 </div>
               )}

--- a/src/lib/freshness.test.ts
+++ b/src/lib/freshness.test.ts
@@ -10,7 +10,7 @@ describe('getPriceRecency', () => {
 
     assert.equal(result.tier, 'fresh')
     assert.equal(result.daysAgo, 29)
-    assert.equal(result.label, 'Verified')
+    assert.equal(result.label, 'Checked 29d ago')
   })
 
   it('marks prices from 30 to 90 days old as aging', () => {
@@ -23,11 +23,17 @@ describe('getPriceRecency', () => {
 
     assert.equal(result.tier, 'stale')
     assert.equal(result.daysAgo, 91)
-    assert.equal(result.label, 'May be out of date')
+    assert.equal(result.label, 'Checked 91d ago')
   })
 
   it('marks missing or invalid verification dates as unknown', () => {
     assert.equal(getPriceRecency(null, NOW).tier, 'unknown')
+    assert.equal(getPriceRecency(null, NOW).label, 'Not checked yet')
     assert.equal(getPriceRecency('not-a-date', NOW).tier, 'unknown')
+  })
+
+  it('uses everyday labels for same-day and yesterday checks', () => {
+    assert.equal(getPriceRecency('2026-06-01T00:00:00.000Z', NOW).label, 'Checked today')
+    assert.equal(getPriceRecency('2026-05-31T12:00:00.000Z', NOW).label, 'Checked yesterday')
   })
 })

--- a/src/lib/freshness.ts
+++ b/src/lib/freshness.ts
@@ -18,29 +18,36 @@ export interface PriceRecencyInfo {
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24
 
+function checkedLabel(daysAgo: number): string {
+  if (daysAgo === 0) return 'Checked today'
+  if (daysAgo === 1) return 'Checked yesterday'
+  return `Checked ${daysAgo}d ago`
+}
+
 export function getPriceRecency(lastVerified: string | null | undefined, now = new Date()): PriceRecencyInfo {
   if (!lastVerified) {
-    return { tier: 'unknown', daysAgo: null, label: 'Needs verification' }
+    return { tier: 'unknown', daysAgo: null, label: 'Not checked yet' }
   }
 
   const verified = new Date(lastVerified)
   const verifiedTime = verified.getTime()
 
   if (!Number.isFinite(verifiedTime)) {
-    return { tier: 'unknown', daysAgo: null, label: 'Needs verification' }
+    return { tier: 'unknown', daysAgo: null, label: 'Not checked yet' }
   }
 
   const daysAgo = Math.max(0, Math.floor((now.getTime() - verifiedTime) / MS_PER_DAY))
+  const label = checkedLabel(daysAgo)
 
   if (daysAgo < 30) {
-    return { tier: 'fresh', daysAgo, label: 'Verified' }
+    return { tier: 'fresh', daysAgo, label }
   }
 
   if (daysAgo <= 90) {
-    return { tier: 'aging', daysAgo, label: 'Recheck soon' }
+    return { tier: 'aging', daysAgo, label }
   }
 
-  return { tier: 'stale', daysAgo, label: 'May be out of date' }
+  return { tier: 'stale', daysAgo, label }
 }
 
 export function getFreshness(lastVerified: string | null): FreshnessInfo {

--- a/tests/e2e/pr-proof.spec.ts
+++ b/tests/e2e/pr-proof.spec.ts
@@ -24,7 +24,7 @@ test('pub page renders price, freshness, map, and nearby prices', async ({ page 
 
   await expect(page.getByRole('heading', { name: 'The Court Hotel' })).toBeVisible()
   await expect(page.getByText('Pint Price', { exact: true })).toBeVisible()
-  await expect(page.getByText(/Last verified/i)).toBeVisible()
+  await expect(page.getByText(/Checked \d+d ago/i)).toBeVisible()
   await expect(page.getByText(/Nearby verified prices/i)).toBeVisible()
   await expect(page.locator('.leaflet-container')).toBeVisible()
 


### PR DESCRIPTION
## Summary
- Replace warning-style recency labels with plain chips like `Checked 103d ago`.
- Remove the visible `Last verified...` date from the price card row; keep the exact date as hover text.
- Update the Playwright proof assertion to match the new human-facing copy.

## Verification
- `npm test -- --test-name-pattern='getPriceRecency|getPubIndexability'` (210/210)
- `npx tsc --noEmit`
- `npm run lint` (existing SubmitPubForm/SunsetSippers warnings only)
- `npm run build`
- `npm run test:e2e -- --project=desktop-chromium --project=mobile-chromium --grep 'pub page'`
