### PR TITLE
[codex] Implement price intake plumbing

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,11 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Price intake plumbing implemented (2026-06-01)
+- **Branch `codex/price-intake-plumbing-spec` / commit `e2de1c5`:** added structured `price_reports` provenance/evidence columns (`submission_source`, `source_url`, `evidence_text`, `observed_at`, `raw_extraction`, `extractor_version`) with a constrained source vocabulary and legacy backfill for menu scans, Tier-C report heroes, and stale flags.
+- **Intake + moderation safety:** public reports now store structured sources, menu-scan submissions no longer rely on note parsing, and admin approval maps provenance/confidence through one helper. Outdated flags are reviewed without touching live prices, happy-hour reports no longer write regular `price_history.price`, aggregator leads are blocked from direct approval, and admin stats count all pending reports.
+- **Verification:** verified `npm test` (**225/225 tests**), `npx tsc --noEmit`, `npm run lint` (existing warnings only), `npm run build`, and `git diff --check`. No Playwright screenshots were needed because the UI change was payload-only.
+
 ### Price provenance persisted (2026-06-01)
 - **Issue #76 / branch `codex/price-provenance-76` / commit `2c96ffc`:** added structured current-price provenance fields (`price_source`, `price_verified_at`, `price_confidence`) on `pubs`, with matching `verified_at` and `confidence` audit fields on `price_history`.
 - **Write paths + display:** Andrew mid-call writes, Andrew post-call fallback writes, admin-approved price reports, and approved pub submissions now persist source, verified time, and confidence. Pub pages can render compact copy such as `Checked by Andrew on 31 May 2026`, with low-confidence rows labelled.

--- a/docs/superpowers/plans/2026-06-01-price-intake-plumbing.md
+++ b/docs/superpowers/plans/2026-06-01-price-intake-plumbing.md
@@ -1,0 +1,85 @@
+# Price Intake Plumbing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add structured provenance/evidence to pending price reports and make admin approval safe for regular prices, happy-hour reports, stale flags, and future official menu leads.
+
+**Architecture:** Keep the current public-report -> admin-review -> canonical-pub update flow. Add report-level columns in one migration, centralize source/confidence mapping in `src/lib/priceProvenance.ts`, and keep non-Andrew sources pending until admin approval.
+
+**Tech Stack:** Next.js 14 App Router route handlers, TypeScript strict, Supabase Postgres/Supabase JS v2, Node test runner.
+
+---
+
+### Task 1: Add Report Provenance Columns
+
+**Files:**
+- Create: `supabase/migrations/20260601010000_price_report_intake_provenance.sql`
+
+- [ ] Add nullable `price_reports` columns: `submission_source`, `source_url`, `evidence_text`, `observed_at`, `raw_extraction`, `extractor_version`.
+- [ ] Backfill existing rows to `manual`, except note-marker menu scans to `menu_scan` and old Tier-C note markers to `tier_c_report_hero`.
+- [ ] Add a check constraint for the approved source labels.
+- [ ] Verify locally with `git diff --check`.
+
+### Task 2: Centralize Source And Confidence Mapping
+
+**Files:**
+- Modify: `src/lib/priceProvenance.ts`
+- Modify: `src/lib/priceProvenance.test.ts`
+
+- [ ] Add `ReportSubmissionSource` and helpers to normalize incoming source labels.
+- [ ] Map report source/confidence from structured `submission_source`, using notes only for legacy fallback rows.
+- [ ] Cover official menu evidence, community evidence, menu scan confidence, stale flags, and legacy note fallbacks in unit tests.
+- [ ] Run `npm test -- src/lib/priceProvenance.test.ts` if supported; otherwise run `npm test`.
+
+### Task 3: Store Structured Fields From Public Reports
+
+**Files:**
+- Modify: `src/app/api/price-report/route.ts`
+- Create: `src/app/api/price-report/route.test.ts`
+
+- [ ] Accept optional structured fields in `POST`.
+- [ ] Default omitted `submission_source` to `manual`; force stale reports to `stale_flag`.
+- [ ] Use `submission_source === "menu_scan"` for bulk rate limiting while still allowing old note-marker menu scan payloads.
+- [ ] Insert only validated provenance fields into `price_reports`.
+- [ ] Test default source and structured evidence inserts.
+
+### Task 4: Fix Menu Scan Caller And Rate Limit
+
+**Files:**
+- Modify: `src/app/api/menu-scan/route.ts`
+- Modify: `src/components/SubmitPubForm.tsx`
+
+- [ ] Count recent scans by `submission_source = "menu_scan"` plus legacy note-marker rows.
+- [ ] Submit menu scan extracted items with `submission_source: "menu_scan"`.
+- [ ] Submit Tier-C hero reports with `submission_source: "tier_c_report_hero"` instead of relying on note parsing.
+- [ ] Submit outdated flags with `submission_source: "stale_flag"`.
+
+### Task 5: Harden Admin Approval
+
+**Files:**
+- Modify: `src/app/api/admin/review/route.ts`
+- Create: `src/app/api/admin/review/route.test.ts`
+
+- [ ] Use structured report provenance for `pubs.price_source` and confidence.
+- [ ] Reject approval of `aggregator_lead` unless a later explicit design adds reviewer evidence.
+- [ ] Mark `outdated_flag` reports as reviewed without changing `pubs.price`.
+- [ ] For `happy_hour_report`, update only happy-hour fields and do not insert regular `price_history`.
+- [ ] Test regular approval provenance, happy-hour no-history behavior, outdated no-price-update behavior, and aggregator lead blocking.
+
+### Task 6: Count All Pending Reports In Admin Stats
+
+**Files:**
+- Modify: `src/app/api/admin/stats/route.ts`
+
+- [ ] Add a dedicated exact count query for `price_reports.status = "pending"`.
+- [ ] Keep the existing recent 10 rows for display only.
+- [ ] Use the dedicated count in the JSON payload.
+
+### Task 7: Verify
+
+- [ ] Run `npm test`.
+- [ ] Run `npx tsc --noEmit`.
+- [ ] Run `npm run lint`.
+- [ ] Run `npm run build`.
+- [ ] Run `git diff --check`.
+- [ ] No Playwright screenshots are required unless visible UI changes are introduced.

--- a/docs/superpowers/specs/2026-06-01-price-intake-plumbing-design.md
+++ b/docs/superpowers/specs/2026-06-01-price-intake-plumbing-design.md
@@ -1,0 +1,156 @@
+# Price Intake Plumbing Design
+
+Date: 2026-06-01
+
+## Context
+
+Andrew is paused for price collection until call quality is reliable. The next data push should come from official menus, menu photos, venue submissions, community reports, and manual sweeps. Those sources should not write directly to `pubs.price`.
+
+The existing path already has the right broad shape: public submissions create `price_reports`, admin approval promotes a report into `pubs` and `price_history`, and current-price provenance is stored on `pubs`. The weak point is that report-level provenance and evidence are implicit or missing, so more ingestion would make the moderation queue harder to trust.
+
+## Goal
+
+Build the smallest safe intake foundation before adding crawlers or new acquisition loops.
+
+Success means every incoming price candidate can say:
+
+- where it came from,
+- what evidence supports it,
+- when it was observed or captured,
+- how confident the system is,
+- and whether approving it should update regular price, happy-hour data, or only mark a venue as stale.
+
+## Non-Goals
+
+- Do not build the official menu crawler in this slice.
+- Do not run Andrew calls.
+- Do not auto-approve broad automated extracts.
+- Do not add a full user account, leaderboard, or rewards system.
+- Do not expand schema markup beyond what is required to keep existing writes safe.
+
+## Data Model
+
+Add report-level fields to `price_reports`:
+
+- `submission_source text`: first-class source label.
+- `source_url text`: official menu, QR menu, social post, or other evidence URL.
+- `evidence_text text`: short extracted snippet or reviewer-readable evidence.
+- `observed_at timestamptz`: when the reporter says the price was seen.
+- `raw_extraction jsonb`: optional machine output for OCR, menu crawler, or future extractors.
+- `extractor_version text`: optional parser/model version.
+
+Allowed initial `submission_source` values:
+
+- `manual`
+- `menu_scan`
+- `tier_c_report_hero`
+- `official_menu`
+- `venue_submission`
+- `community_bounty`
+- `aggregator_lead`
+- `stale_flag`
+
+Use a check constraint for these values. Future source labels should be added by migration, not silently accepted through free text.
+
+Keep current canonical fields on `pubs`:
+
+- `price_source`
+- `price_verified_at`
+- `price_confidence`
+
+Map accepted reports into those fields through the existing admin approval path.
+
+## Source And Confidence Rules
+
+Initial confidence mapping:
+
+- `official_menu`: high when `source_url` and clear `evidence_text` exist, otherwise medium.
+- `venue_submission`: medium by default.
+- `menu_scan`: low by default.
+- `community_bounty`: medium when evidence exists, low without evidence.
+- `manual`: medium.
+- `tier_c_report_hero`: medium.
+- `aggregator_lead`: low and not auto-approvable.
+- `stale_flag`: no price confidence; it marks review need only.
+
+`priceReportSource` should stop parsing free-form notes for menu scans once `submission_source` exists. Notes can remain as human context, not the routing mechanism.
+
+## API Changes
+
+Update `/api/price-report` to accept optional:
+
+- `submission_source`
+- `source_url`
+- `evidence_text`
+- `observed_at`
+- `raw_extraction`
+- `extractor_version`
+
+Default `submission_source` to `manual` when omitted. Keep the public form compatible.
+
+Menu-scan submissions should send `submission_source: "menu_scan"` instead of relying on `notes: "Submitted via menu scan"`.
+
+Tier-C report hero submissions should send `submission_source: "tier_c_report_hero"` instead of encoding that source only in notes.
+
+## Admin Review Semantics
+
+Approval rules:
+
+- `price_report`: may update `pubs.price`, `beer_type`, current-price provenance, and regular `price_history`.
+- `happy_hour_report`: may update happy-hour fields, but must not write a regular `price_history.price` row.
+- `outdated_flag`: must not approve as a `$0` price. It should mark the report reviewed and leave the current price untouched. A later implementation may add a dedicated stale queue or set `price_verified = false`, but this slice should avoid changing live price state without stronger product approval.
+- `aggregator_lead`: should remain pending/manual-review only. It cannot be accepted into `pubs.price` without independent source evidence added by the reviewer.
+
+Admin stats should count all pending `price_reports`, not just pending reports inside the latest 10 rows.
+
+## Menu Scan Rate Limiting
+
+Fix `/api/menu-scan` rate limiting to match actual stored reports.
+
+Current problem: the route checks for `report_type = "menu_scan"`, but submitted menu-scan rows are saved as normal `price_report` / `happy_hour_report` rows with a note marker.
+
+New rule: rate limits should look for `submission_source = "menu_scan"` once the migration exists. During rollout, also treat old note-marker rows as menu-scan rows for backwards compatibility.
+
+## Future Crawler Contract
+
+The future official-menu crawler should only insert pending `price_reports` with:
+
+- `submission_source = "official_menu"`
+- `source_url`
+- `evidence_text`
+- `observed_at` or `captured_at` encoded in `observed_at`
+- `raw_extraction`
+- `extractor_version`
+
+It should not update `pubs` directly. Any auto-approval rule must be a separate, explicit change with tests.
+
+## Testing
+
+Add or update tests for:
+
+- `/api/price-report` stores `submission_source` and evidence fields.
+- omitted `submission_source` defaults to `manual`.
+- menu-scan submissions are recognised through `submission_source`.
+- admin approval maps `submission_source` to `price_source` and confidence.
+- happy-hour approval does not write regular price history.
+- outdated flags cannot update `pubs.price`.
+- admin stats pending count is not capped by the latest 10 reports.
+
+Verification commands:
+
+- `npm test`
+- `npx tsc --noEmit`
+- `npm run lint`
+- `npm run build`
+- `git diff --check`
+
+No Playwright screenshots are required unless the implementation changes visible UI.
+
+## Rollout
+
+1. Add and apply the migration.
+2. Update server routes and helper functions.
+3. Update menu-scan and Tier-C submission callers.
+4. Add focused tests.
+5. Merge plumbing.
+6. Start the official-menu crawler design as the next slice.

--- a/src/app/api/admin/review/priceReportReview.ts
+++ b/src/app/api/admin/review/priceReportReview.ts
@@ -1,0 +1,123 @@
+import { priceReportConfidence, priceReportSource, reportSubmissionSource } from '@/lib/priceProvenance'
+
+interface ReviewPriceReportArgs {
+  id: string | number
+  action: string
+  target_slug?: string
+}
+
+export async function reviewPriceReport(
+  supabase: any,
+  { id, action, target_slug }: ReviewPriceReportArgs,
+  nowDate = new Date(),
+) {
+  const now = nowDate.toISOString()
+
+  if (action === 'reject') {
+    await supabase
+      .from('price_reports')
+      .update({ status: 'rejected', verified_at: now, verified_by: 'admin' })
+      .eq('id', id)
+
+    return { status: 200, body: { success: true, action: 'rejected' } }
+  }
+
+  if (action !== 'approve') {
+    return { status: 400, body: { error: 'Invalid action' } }
+  }
+
+  const { data: report, error: reportErr } = await supabase
+    .from('price_reports')
+    .select('*')
+    .eq('id', id)
+    .single()
+
+  if (reportErr || !report) {
+    return { status: 404, body: { error: 'Report not found' } }
+  }
+
+  const submissionSource = reportSubmissionSource(
+    report.submission_source,
+    report.notes,
+    report.report_type,
+  )
+
+  if (submissionSource === 'aggregator_lead') {
+    return {
+      status: 409,
+      body: { error: 'Aggregator leads need independent evidence before approval.' },
+    }
+  }
+
+  if (report.report_type === 'outdated_flag' || submissionSource === 'stale_flag') {
+    await supabase
+      .from('price_reports')
+      .update({ status: 'reviewed', verified_at: now, verified_by: 'admin' })
+      .eq('id', id)
+
+    return { status: 200, body: { success: true, action: 'reviewed', pubSlug: target_slug || report.pub_slug } }
+  }
+
+  const slug = target_slug || report.pub_slug
+  const priceSource = priceReportSource(report)
+  const priceConfidence = priceReportConfidence(report)
+  const isHappyHour = report.report_type === 'happy_hour_report'
+  const updatePayload: Record<string, unknown> = {
+    last_updated: now,
+  }
+
+  if (isHappyHour) {
+    updatePayload.happy_hour_price = report.reported_price
+  } else {
+    updatePayload.price = report.reported_price
+    updatePayload.price_verified = true
+    updatePayload.last_verified = now
+    updatePayload.price_verified_at = now
+    updatePayload.price_source = priceSource
+    updatePayload.price_confidence = priceConfidence
+    if (report.beer_type) {
+      updatePayload.beer_type = report.beer_type
+    }
+  }
+
+  const { data: updatedPubs, error: pubErr } = await supabase
+    .from('pubs')
+    .update(updatePayload)
+    .eq('slug', slug)
+    .select('slug')
+
+  if (pubErr) {
+    return { status: 500, body: { error: 'Failed to update pub: ' + pubErr.message } }
+  }
+
+  if (!updatedPubs || updatedPubs.length === 0) {
+    return { status: 404, body: { error: `No pub found with slug "${slug}"` } }
+  }
+
+  if (!isHappyHour) {
+    const { data: pub } = await supabase
+      .from('pubs')
+      .select('id')
+      .eq('slug', slug)
+      .single()
+
+    if (pub) {
+      await supabase.from('price_history').insert({
+        pub_id: pub.id,
+        price: report.reported_price,
+        change_type: 'update',
+        source: priceSource,
+        changed_at: now,
+        verified_at: now,
+        confidence: priceConfidence,
+      })
+    }
+  }
+
+  await supabase
+    .from('price_reports')
+    .update({ status: 'verified', verified_at: now, verified_by: 'admin' })
+    .eq('id', id)
+
+  return { status: 200, body: { success: true, action: 'approved', pubSlug: slug } }
+}

--- a/src/app/api/admin/review/route.test.ts
+++ b/src/app/api/admin/review/route.test.ts
@@ -1,0 +1,183 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { reviewPriceReport } from './priceReportReview'
+
+describe('admin price report review', () => {
+  const now = new Date('2026-06-01T04:30:00.000Z')
+
+  it('maps structured report provenance onto approved regular prices', async () => {
+    const supabase = reviewSupabase({
+      id: 1,
+      pub_slug: 'test-pub',
+      reported_price: 10,
+      beer_type: 'Swan Draught',
+      report_type: 'price_report',
+      submission_source: 'official_menu',
+      source_url: 'https://example.com/menu',
+      evidence_text: 'Swan Draught pint $10',
+    })
+
+    const result = await reviewPriceReport(supabase, { id: 1, action: 'approve' }, now)
+
+    assert.equal(result.status, 200)
+    assert.deepEqual(supabase.calls.pubUpdate, {
+      last_updated: '2026-06-01T04:30:00.000Z',
+      price: 10,
+      price_verified: true,
+      last_verified: '2026-06-01T04:30:00.000Z',
+      price_verified_at: '2026-06-01T04:30:00.000Z',
+      price_source: 'official_menu',
+      price_confidence: 'high',
+      beer_type: 'Swan Draught',
+    })
+    assert.deepEqual(supabase.calls.historyInsert, {
+      pub_id: 42,
+      price: 10,
+      change_type: 'update',
+      source: 'official_menu',
+      changed_at: '2026-06-01T04:30:00.000Z',
+      verified_at: '2026-06-01T04:30:00.000Z',
+      confidence: 'high',
+    })
+  })
+
+  it('approves happy-hour reports without writing regular price history', async () => {
+    const supabase = reviewSupabase({
+      id: 2,
+      pub_slug: 'test-pub',
+      reported_price: 8,
+      beer_type: 'Swan Draught',
+      report_type: 'happy_hour_report',
+      submission_source: 'menu_scan',
+    })
+
+    const result = await reviewPriceReport(supabase, { id: 2, action: 'approve' }, now)
+
+    assert.equal(result.status, 200)
+    assert.deepEqual(supabase.calls.pubUpdate, {
+      last_updated: '2026-06-01T04:30:00.000Z',
+      happy_hour_price: 8,
+    })
+    assert.equal(supabase.calls.historyInsert, null)
+  })
+
+  it('reviews outdated flags without changing pub price state', async () => {
+    const supabase = reviewSupabase({
+      id: 3,
+      pub_slug: 'test-pub',
+      reported_price: 0,
+      report_type: 'outdated_flag',
+      submission_source: 'stale_flag',
+    })
+
+    const result = await reviewPriceReport(supabase, { id: 3, action: 'approve' }, now)
+
+    assert.equal(result.status, 200)
+    assert.deepEqual(result.body, { success: true, action: 'reviewed', pubSlug: 'test-pub' })
+    assert.equal(supabase.calls.pubUpdate, null)
+    assert.equal(supabase.calls.historyInsert, null)
+    assert.deepEqual(supabase.calls.reportUpdate, {
+      status: 'reviewed',
+      verified_at: '2026-06-01T04:30:00.000Z',
+      verified_by: 'admin',
+    })
+  })
+
+  it('blocks aggregator leads from direct approval', async () => {
+    const supabase = reviewSupabase({
+      id: 4,
+      pub_slug: 'test-pub',
+      reported_price: 9,
+      report_type: 'price_report',
+      submission_source: 'aggregator_lead',
+    })
+
+    const result = await reviewPriceReport(supabase, { id: 4, action: 'approve' }, now)
+
+    assert.equal(result.status, 409)
+    assert.match(String((result.body as { error: string }).error), /independent evidence/)
+    assert.equal(supabase.calls.pubUpdate, null)
+    assert.equal(supabase.calls.historyInsert, null)
+  })
+})
+
+function reviewSupabase(report: Record<string, unknown>) {
+  const calls: {
+    pubUpdate: Record<string, unknown> | null
+    reportUpdate: Record<string, unknown> | null
+    historyInsert: Record<string, unknown> | null
+  } = {
+    pubUpdate: null,
+    reportUpdate: null,
+    historyInsert: null,
+  }
+
+  return {
+    calls,
+    from(table: string) {
+      if (table === 'price_reports') {
+        return {
+          select() {
+            return {
+              eq() {
+                return {
+                  single() {
+                    return Promise.resolve({ data: report, error: null })
+                  },
+                }
+              },
+            }
+          },
+          update(updates: Record<string, unknown>) {
+            calls.reportUpdate = updates
+            return {
+              eq() {
+                return Promise.resolve({ error: null })
+              },
+            }
+          },
+        }
+      }
+
+      if (table === 'pubs') {
+        return {
+          update(updates: Record<string, unknown>) {
+            calls.pubUpdate = updates
+            return {
+              eq() {
+                return {
+                  select() {
+                    return Promise.resolve({ data: [{ slug: 'test-pub' }], error: null })
+                  },
+                }
+              },
+            }
+          },
+          select() {
+            return {
+              eq() {
+                return {
+                  single() {
+                    return Promise.resolve({ data: { id: 42 }, error: null })
+                  },
+                }
+              },
+            }
+          },
+        }
+      }
+
+      if (table === 'price_history') {
+        return {
+          insert(row: Record<string, unknown>) {
+            calls.historyInsert = row
+            return Promise.resolve({ error: null })
+          },
+        }
+      }
+
+      throw new Error(`Unexpected table ${table}`)
+    },
+  }
+}

--- a/src/app/api/admin/review/route.ts
+++ b/src/app/api/admin/review/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { serviceClient } from '@/lib/supabaseGateway'
 import { timingSafeEqual } from 'crypto'
-import { priceReportConfidence, priceReportSource } from '@/lib/priceProvenance'
+import { reviewPriceReport } from './priceReportReview'
 
 export const dynamic = 'force-dynamic'
 
@@ -39,91 +39,8 @@ export async function POST(request: NextRequest) {
 
   try {
     if (type === 'price_report') {
-      if (action === 'approve') {
-        const { data: report, error: reportErr } = await supabase
-          .from('price_reports')
-          .select('*')
-          .eq('id', id)
-          .single()
-
-        if (reportErr || !report) {
-          return NextResponse.json({ error: 'Report not found' }, { status: 404 })
-        }
-
-        const now = new Date().toISOString()
-        const slug = target_slug || report.pub_slug
-        const priceSource = priceReportSource(report.notes)
-        const priceConfidence = priceReportConfidence(report.notes)
-
-        // Build update payload — route to correct price column based on report type
-        const isHappyHour = report.report_type === 'happy_hour_report'
-        const updatePayload: Record<string, unknown> = {
-          last_updated: now,
-        }
-        if (isHappyHour) {
-          updatePayload.happy_hour_price = report.reported_price
-        } else {
-          updatePayload.price = report.reported_price
-          updatePayload.price_verified = true
-          updatePayload.last_verified = now
-          updatePayload.price_verified_at = now
-          updatePayload.price_source = priceSource
-          updatePayload.price_confidence = priceConfidence
-        }
-        if (report.beer_type) {
-          updatePayload.beer_type = report.beer_type
-        }
-
-        // Update pub price
-        const { data: updatedPubs, error: pubErr } = await supabase
-          .from('pubs')
-          .update(updatePayload)
-          .eq('slug', slug)
-          .select('slug')
-
-        if (pubErr) {
-          return NextResponse.json({ error: 'Failed to update pub: ' + pubErr.message }, { status: 500 })
-        }
-
-        if (!updatedPubs || updatedPubs.length === 0) {
-          return NextResponse.json({ error: `No pub found with slug "${slug}"` }, { status: 404 })
-        }
-
-        // Get pub_id for price_history
-        const { data: pub } = await supabase
-          .from('pubs')
-          .select('id')
-          .eq('slug', slug)
-          .single()
-
-        if (pub) {
-          await supabase.from('price_history').insert({
-            pub_id: pub.id,
-            price: report.reported_price,
-            change_type: 'update',
-            source: priceSource,
-            changed_at: now,
-            verified_at: now,
-            confidence: priceConfidence,
-          })
-        }
-
-        // Mark report as verified
-        await supabase
-          .from('price_reports')
-          .update({ status: 'verified', verified_at: now, verified_by: 'admin' })
-          .eq('id', id)
-
-        return NextResponse.json({ success: true, action: 'approved', pubSlug: slug })
-
-      } else if (action === 'reject') {
-        await supabase
-          .from('price_reports')
-          .update({ status: 'rejected', verified_at: new Date().toISOString(), verified_by: 'admin' })
-          .eq('id', id)
-
-        return NextResponse.json({ success: true, action: 'rejected' })
-      }
+      const result = await reviewPriceReport(supabase, { id, action, target_slug })
+      return NextResponse.json(result.body, { status: result.status })
 
     } else if (type === 'pub_submission') {
       if (action === 'approve') {

--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -163,6 +163,7 @@ export async function GET(request: NextRequest) {
       snapshotResult,
       priceHistoryResult,
       priceReportsResult,
+      pendingPriceReportsResult,
       pushSubsResult,
       activityResult,
       recentPubsResult,
@@ -181,6 +182,8 @@ export async function GET(request: NextRequest) {
       supabase.from('price_history').select('*', { count: 'exact' }).order('changed_at', { ascending: false }).limit(10),
       // Price reports (crowdsourced)
       supabase.from('price_reports').select('*', { count: 'exact' }).order('created_at', { ascending: false }).limit(10),
+      // All pending price reports, not just the latest display slice
+      supabase.from('price_reports').select('id', { count: 'exact', head: true }).eq('status', 'pending'),
       // Push subscriptions
       supabase.from('push_subscriptions').select('*', { count: 'exact' }),
       // Agent activity (now readable by anon with RLS policy)
@@ -241,7 +244,7 @@ export async function GET(request: NextRequest) {
       },
       priceReports: {
         total: priceReportsResult.count || 0,
-        pending: (priceReportsResult.data || []).filter((r: any) => r.status === 'pending').length,
+        pending: pendingPriceReportsResult.count || 0,
         recent: (priceReportsResult.data || []).map((r: any) => ({
           id: r.id,
           pubSlug: r.pub_slug,

--- a/src/app/api/menu-scan/rateLimit.ts
+++ b/src/app/api/menu-scan/rateLimit.ts
@@ -1,0 +1,11 @@
+interface RecentReport {
+  submission_source?: unknown
+  notes?: unknown
+}
+
+export function countMenuScanReports(reports: RecentReport[] | null | undefined): number {
+  return (reports || []).filter((report) =>
+    report.submission_source === 'menu_scan' ||
+    (typeof report.notes === 'string' && report.notes.toLowerCase().includes('menu scan'))
+  ).length
+}

--- a/src/app/api/menu-scan/route.test.ts
+++ b/src/app/api/menu-scan/route.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { countMenuScanReports } from './rateLimit'
+
+describe('menu-scan rate limit helpers', () => {
+  it('counts structured menu scan reports and legacy note-marker rows', () => {
+    assert.equal(countMenuScanReports([
+      { submission_source: 'menu_scan', notes: null },
+      { submission_source: 'manual', notes: 'Submitted via menu scan' },
+      { submission_source: 'manual', notes: 'Regular report' },
+      { submission_source: null, notes: null },
+    ]), 2)
+  })
+})

--- a/src/app/api/menu-scan/route.ts
+++ b/src/app/api/menu-scan/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { anonClient } from '@/lib/supabaseGateway'
 import OpenAI from 'openai'
+import { countMenuScanReports } from './rateLimit'
 
 export const maxDuration = 30
 
@@ -56,12 +57,11 @@ export async function POST(req: NextRequest) {
 
     const { data: recentScans } = await supabase
       .from('price_reports')
-      .select('id')
+      .select('id, submission_source, notes')
       .eq('ip_hash', ipHash)
-      .eq('report_type', 'menu_scan')
       .gte('created_at', new Date(Date.now() - 86400000).toISOString())
 
-    if (recentScans && recentScans.length >= 3) {
+    if (countMenuScanReports(recentScans) >= 3) {
       return NextResponse.json({ error: 'Scan limit reached. Try again tomorrow.' }, { status: 429 })
     }
 

--- a/src/app/api/price-report/intake.ts
+++ b/src/app/api/price-report/intake.ts
@@ -1,0 +1,95 @@
+import { normalizeReportSubmissionSource } from '@/lib/priceProvenance'
+
+export interface PreparedPriceReport {
+  pubSlug: string
+  isMenuScan: boolean
+  insertData: Record<string, unknown>
+}
+
+export type PriceReportPreparation =
+  | { ok: true; value: PreparedPriceReport }
+  | { ok: false; error: string; status: number }
+
+export function preparePriceReport(body: any, ipHash: string): PriceReportPreparation {
+  const {
+    pub_slug,
+    reported_price,
+    beer_type,
+    reporter_name,
+    outdated,
+    notes,
+    price_type,
+    submission_source,
+    source_url,
+    evidence_text,
+    observed_at,
+    raw_extraction,
+    extractor_version,
+  } = body
+
+  const isOutdatedReport = outdated === true
+  const normalizedSubmissionSource = normalizeReportSubmissionSource(submission_source)
+
+  if (!pub_slug) {
+    return { ok: false, error: 'pub_slug is required', status: 400 }
+  }
+  if (submission_source !== undefined && !normalizedSubmissionSource) {
+    return { ok: false, error: 'submission_source is invalid', status: 400 }
+  }
+  if (!isOutdatedReport && !reported_price) {
+    return { ok: false, error: 'reported_price is required', status: 400 }
+  }
+
+  let price = 0
+  if (reported_price) {
+    price = parseFloat(reported_price)
+    if (isNaN(price) || price < 3 || price > 30) {
+      return { ok: false, error: 'Price must be between $3 and $30', status: 400 }
+    }
+  }
+
+  const observedAt = parseOptionalDate(observed_at)
+  if (observed_at !== undefined && !observedAt) {
+    return { ok: false, error: 'observed_at is invalid', status: 400 }
+  }
+
+  const storedSubmissionSource = isOutdatedReport
+    ? 'stale_flag'
+    : normalizedSubmissionSource || 'manual'
+  const legacyMenuScan = typeof notes === 'string' && notes.toLowerCase().includes('menu scan')
+  const isMenuScan = storedSubmissionSource === 'menu_scan' || legacyMenuScan
+
+  return {
+    ok: true,
+    value: {
+      pubSlug: pub_slug,
+      isMenuScan,
+      insertData: {
+        pub_slug,
+        reported_price: isOutdatedReport ? 0 : price,
+        beer_type: beer_type || null,
+        reporter_name: reporter_name || 'Anonymous',
+        ip_hash: ipHash,
+        report_type: isOutdatedReport ? 'outdated_flag' : (price_type === 'happy_hour' ? 'happy_hour_report' : 'price_report'),
+        notes: notes || null,
+        submission_source: storedSubmissionSource,
+        source_url: optionalString(source_url),
+        evidence_text: optionalString(evidence_text),
+        observed_at: observedAt,
+        raw_extraction: raw_extraction ?? null,
+        extractor_version: optionalString(extractor_version),
+      },
+    },
+  }
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function parseOptionalDate(value: unknown): string | null {
+  if (value === undefined || value === null || value === '') return null
+  if (typeof value !== 'string') return null
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date.toISOString()
+}

--- a/src/app/api/price-report/route.test.ts
+++ b/src/app/api/price-report/route.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { preparePriceReport } from './intake'
+
+describe('price-report intake preparation', () => {
+  it('defaults omitted submission_source to manual', () => {
+    const result = preparePriceReport({
+      pub_slug: 'test-pub',
+      reported_price: '10',
+      beer_type: 'Swan Draught',
+    }, 'ip-hash')
+
+    assert.equal(result.ok, true)
+    if (!result.ok) return
+    assert.equal(result.value.insertData.submission_source, 'manual')
+    assert.equal(result.value.insertData.reported_price, 10)
+    assert.equal(result.value.insertData.report_type, 'price_report')
+    assert.equal(result.value.isMenuScan, false)
+  })
+
+  it('stores structured evidence fields for menu scan submissions', () => {
+    const result = preparePriceReport({
+      pub_slug: 'test-pub',
+      reported_price: 9,
+      beer_type: 'Single Fin',
+      price_type: 'happy_hour',
+      submission_source: 'menu_scan',
+      source_url: ' https://example.com/menu ',
+      evidence_text: 'Single Fin pint $9',
+      observed_at: '2026-06-01T04:30:00.000Z',
+      raw_extraction: { model: 'test', text: 'Single Fin $9' },
+      extractor_version: 'menu-scan-test',
+    }, 'ip-hash')
+
+    assert.equal(result.ok, true)
+    if (!result.ok) return
+    assert.equal(result.value.isMenuScan, true)
+    assert.deepEqual(result.value.insertData, {
+      pub_slug: 'test-pub',
+      reported_price: 9,
+      beer_type: 'Single Fin',
+      reporter_name: 'Anonymous',
+      ip_hash: 'ip-hash',
+      report_type: 'happy_hour_report',
+      notes: null,
+      submission_source: 'menu_scan',
+      source_url: 'https://example.com/menu',
+      evidence_text: 'Single Fin pint $9',
+      observed_at: '2026-06-01T04:30:00.000Z',
+      raw_extraction: { model: 'test', text: 'Single Fin $9' },
+      extractor_version: 'menu-scan-test',
+    })
+  })
+
+  it('forces outdated flags to stale_flag without requiring a price', () => {
+    const result = preparePriceReport({
+      pub_slug: 'test-pub',
+      outdated: true,
+      submission_source: 'manual',
+      notes: '[closed] Price looks old',
+    }, 'ip-hash')
+
+    assert.equal(result.ok, true)
+    if (!result.ok) return
+    assert.equal(result.value.insertData.submission_source, 'stale_flag')
+    assert.equal(result.value.insertData.reported_price, 0)
+    assert.equal(result.value.insertData.report_type, 'outdated_flag')
+  })
+
+  it('rejects unsupported submission_source values', () => {
+    const result = preparePriceReport({
+      pub_slug: 'test-pub',
+      reported_price: 10,
+      submission_source: 'crawler_guess',
+    }, 'ip-hash')
+
+    assert.equal(result.ok, false)
+    if (result.ok) return
+    assert.equal(result.status, 400)
+    assert.equal(result.error, 'submission_source is invalid')
+  })
+})

--- a/src/app/api/price-report/route.ts
+++ b/src/app/api/price-report/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { revalidatePath, revalidateTag } from 'next/cache'
 import { anonClient } from '@/lib/supabaseGateway'
 import { toSuburbSlug } from '@/lib/urls'
+import { preparePriceReport } from './intake'
 
 const supabase = anonClient()
 
@@ -22,41 +23,22 @@ async function revalidateReportedPub(pubSlug: string) {
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json()
-    const { pub_slug, reported_price, beer_type, reporter_name, outdated, notes, price_type } = body
-
-    const isOutdatedReport = outdated === true
-
-    if (!pub_slug) {
-      return NextResponse.json({ error: 'pub_slug is required' }, { status: 400 })
-    }
-
-    // For price reports, price is required. For outdated flags, it's optional.
-    if (!isOutdatedReport && !reported_price) {
-      return NextResponse.json({ error: 'reported_price is required' }, { status: 400 })
-    }
-
-    let price = 0
-    if (reported_price) {
-      price = parseFloat(reported_price)
-      if (isNaN(price) || price < 3 || price > 30) {
-        return NextResponse.json({ error: 'Price must be between $3 and $30' }, { status: 400 })
-      }
-    }
 
     // Simple IP-based rate limiting
     const forwarded = req.headers.get('x-forwarded-for')
     const ip = forwarded?.split(',')[0]?.trim() || 'unknown'
     const ipHash = await hashString(ip)
+    const prepared = preparePriceReport(body, ipHash)
+    if (!prepared.ok) {
+      return NextResponse.json({ error: prepared.error }, { status: prepared.status })
+    }
 
-    // Check if same IP reported same pub in last hour
-    // Allow more reports for menu scans (bulk submission)
-    const isMenuScan = notes && typeof notes === 'string' && notes.includes('menu scan')
-    const rateLimit = isMenuScan ? 15 : 1
+    const rateLimit = prepared.value.isMenuScan ? 15 : 1
 
     const { data: recentReport } = await supabase
       .from('price_reports')
       .select('id')
-      .eq('pub_slug', pub_slug)
+      .eq('pub_slug', prepared.value.pubSlug)
       .eq('ip_hash', ipHash)
       .gte('created_at', new Date(Date.now() - 3600000).toISOString())
 
@@ -64,28 +46,18 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'You already reported for this pub recently. Try again in an hour.' }, { status: 429 })
     }
 
-    const insertData: Record<string, unknown> = {
-      pub_slug,
-      reported_price: isOutdatedReport ? 0 : price,
-      beer_type: beer_type || null,
-      reporter_name: reporter_name || 'Anonymous',
-      ip_hash: ipHash,
-      report_type: isOutdatedReport ? 'outdated_flag' : (price_type === 'happy_hour' ? 'happy_hour_report' : 'price_report'),
-      notes: notes || null,
-    }
-
     const { error } = await supabase
       .from('price_reports')
-      .insert(insertData)
+      .insert(prepared.value.insertData)
 
     if (error) {
       console.error('Error inserting price report:', error)
       return NextResponse.json({ error: 'Failed to submit report' }, { status: 500 })
     }
 
-    await revalidateReportedPub(pub_slug)
+    await revalidateReportedPub(prepared.value.pubSlug)
 
-    const message = isOutdatedReport
+    const message = body.outdated === true
       ? 'Thanks for flagging — we\'ll check this price.'
       : 'Price reported. Thanks for contributing.'
 

--- a/src/components/SubmitPubForm.tsx
+++ b/src/components/SubmitPubForm.tsx
@@ -366,6 +366,7 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
             reported_price: item.price,
             beer_type: item.beer_type,
             price_type: item.price_type,
+            submission_source: 'menu_scan',
             notes: 'Submitted via menu scan',
           }),
         });
@@ -430,6 +431,7 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
             reported_price: parseFloat(price),
             beer_type: beerType || undefined,
             price_type: priceType,
+            submission_source: submissionSource ? normalizeSubmissionSourceForPayload(submissionSource) : undefined,
             notes: submissionSource ? `[source:${submissionSource}]` : undefined,
           }),
         });
@@ -453,6 +455,7 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
           body: JSON.stringify({
             pub_slug: selectedPub.slug,
             outdated: true,
+            submission_source: 'stale_flag',
             notes: outdatedNote.trim()
               ? `[${issueReason}] ${outdatedNote.trim()}`
               : `[${issueReason}]`,
@@ -498,7 +501,6 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
           return;
         }
       }
-
       setSubmitted(true);
     } catch {
       setError('Network error. Please try again.');
@@ -1199,4 +1201,8 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
       </div>
     </div>
   );
+}
+
+function normalizeSubmissionSourceForPayload(source: string): string {
+  return source.replace(/-/g, '_');
 }

--- a/src/lib/priceProvenance.test.ts
+++ b/src/lib/priceProvenance.test.ts
@@ -3,9 +3,11 @@ import { describe, it } from 'node:test'
 
 import {
   describePriceSource,
+  normalizeReportSubmissionSource,
   normalizePriceConfidence,
   priceReportConfidence,
   priceReportSource,
+  reportSubmissionSource,
 } from './priceProvenance'
 
 describe('price provenance helpers', () => {
@@ -23,11 +25,38 @@ describe('price provenance helpers', () => {
     assert.equal(priceReportConfidence('[source:tier-c-report-hero]'), 'medium')
   })
 
+  it('normalizes only supported structured submission sources', () => {
+    assert.equal(normalizeReportSubmissionSource('menu_scan'), 'menu_scan')
+    assert.equal(normalizeReportSubmissionSource('tier-c-report-hero'), 'tier_c_report_hero')
+    assert.equal(normalizeReportSubmissionSource('scraped_menu'), null)
+    assert.equal(reportSubmissionSource(undefined, undefined, 'outdated_flag'), 'stale_flag')
+  })
+
+  it('prefers structured submission source over legacy notes', () => {
+    assert.equal(
+      priceReportSource({ submission_source: 'official_menu', notes: 'Submitted via menu scan' }),
+      'official_menu',
+    )
+    assert.equal(
+      priceReportConfidence({
+        submission_source: 'official_menu',
+        source_url: 'https://example.com/menu',
+        evidence_text: 'Swan Draught pint $10',
+      }),
+      'high',
+    )
+    assert.equal(priceReportConfidence({ submission_source: 'official_menu' }), 'medium')
+    assert.equal(priceReportConfidence({ submission_source: 'community_bounty' }), 'low')
+    assert.equal(priceReportConfidence({ submission_source: 'community_bounty', evidence_text: 'Photo shows $9' }), 'medium')
+  })
+
   it('renders short source phrases for the pub page', () => {
     assert.equal(describePriceSource('andrew'), 'by Andrew')
     assert.equal(describePriceSource('ElevenLabs conv_123'), 'by Andrew')
     assert.equal(describePriceSource('crowdsourced'), 'by a local')
     assert.equal(describePriceSource('menu_scan'), 'from a menu scan')
+    assert.equal(describePriceSource('official_menu'), 'from an official menu')
+    assert.equal(describePriceSource('venue_submission'), 'from the venue')
     assert.equal(describePriceSource(null), null)
   })
 })

--- a/src/lib/priceProvenance.ts
+++ b/src/lib/priceProvenance.ts
@@ -1,5 +1,41 @@
 export type PriceConfidence = 'high' | 'medium' | 'low'
-export type PriceSource = 'andrew' | 'crowdsourced' | 'menu_scan'
+export type ReportSubmissionSource =
+  | 'manual'
+  | 'menu_scan'
+  | 'tier_c_report_hero'
+  | 'official_menu'
+  | 'venue_submission'
+  | 'community_bounty'
+  | 'aggregator_lead'
+  | 'stale_flag'
+
+export type PriceSource =
+  | 'andrew'
+  | 'crowdsourced'
+  | 'menu_scan'
+  | 'official_menu'
+  | 'venue_submission'
+  | 'aggregator_lead'
+  | 'stale_flag'
+
+export const REPORT_SUBMISSION_SOURCES: readonly ReportSubmissionSource[] = [
+  'manual',
+  'menu_scan',
+  'tier_c_report_hero',
+  'official_menu',
+  'venue_submission',
+  'community_bounty',
+  'aggregator_lead',
+  'stale_flag',
+]
+
+interface ReportProvenanceInput {
+  submission_source?: unknown
+  source_url?: unknown
+  evidence_text?: unknown
+  notes?: unknown
+  report_type?: unknown
+}
 
 export function normalizePriceConfidence(value: unknown): PriceConfidence | null {
   if (typeof value !== 'string') return null
@@ -9,14 +45,67 @@ export function normalizePriceConfidence(value: unknown): PriceConfidence | null
     : null
 }
 
-export function priceReportSource(notes: unknown): PriceSource {
-  return typeof notes === 'string' && notes.toLowerCase().includes('menu scan')
-    ? 'menu_scan'
-    : 'crowdsourced'
+export function normalizeReportSubmissionSource(value: unknown): ReportSubmissionSource | null {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim().toLowerCase().replace(/-/g, '_')
+  return REPORT_SUBMISSION_SOURCES.includes(normalized as ReportSubmissionSource)
+    ? normalized as ReportSubmissionSource
+    : null
 }
 
-export function priceReportConfidence(notes: unknown): PriceConfidence {
-  return priceReportSource(notes) === 'menu_scan' ? 'low' : 'medium'
+export function reportSubmissionSource(
+  submissionSource: unknown,
+  notes?: unknown,
+  reportType?: unknown,
+): ReportSubmissionSource {
+  const normalized = normalizeReportSubmissionSource(submissionSource)
+  if (normalized) return normalized
+
+  if (reportType === 'outdated_flag') return 'stale_flag'
+  if (typeof notes === 'string') {
+    const normalizedNotes = notes.toLowerCase()
+    if (normalizedNotes.includes('menu scan')) return 'menu_scan'
+    if (
+      normalizedNotes.includes('[source:tier-c-report-hero]') ||
+      normalizedNotes.includes('[source:tier_c_report_hero]')
+    ) {
+      return 'tier_c_report_hero'
+    }
+  }
+
+  return 'manual'
+}
+
+export function priceReportSource(input: ReportProvenanceInput | unknown, notes?: unknown): PriceSource {
+  const submissionSource = isReportProvenanceInput(input)
+    ? reportSubmissionSource(input.submission_source, input.notes, input.report_type)
+    : reportSubmissionSource(input, notes ?? input)
+
+  if (
+    submissionSource === 'manual' ||
+    submissionSource === 'tier_c_report_hero' ||
+    submissionSource === 'community_bounty'
+  ) {
+    return 'crowdsourced'
+  }
+
+  return submissionSource
+}
+
+export function priceReportConfidence(input: ReportProvenanceInput | unknown, notes?: unknown): PriceConfidence {
+  const submissionSource = isReportProvenanceInput(input)
+    ? reportSubmissionSource(input.submission_source, input.notes, input.report_type)
+    : reportSubmissionSource(input, notes ?? input)
+
+  if (submissionSource === 'official_menu') {
+    return hasEvidence(input) && hasSourceUrl(input) ? 'high' : 'medium'
+  }
+  if (submissionSource === 'venue_submission') return 'medium'
+  if (submissionSource === 'menu_scan') return 'low'
+  if (submissionSource === 'community_bounty') return hasEvidence(input) ? 'medium' : 'low'
+  if (submissionSource === 'aggregator_lead') return 'low'
+  if (submissionSource === 'stale_flag') return 'low'
+  return 'medium'
 }
 
 export function describePriceSource(source: string | null | undefined): string | null {
@@ -29,9 +118,37 @@ export function describePriceSource(source: string | null | undefined): string |
   if (normalized === 'menu_scan') {
     return 'from a menu scan'
   }
-  if (normalized === 'crowdsourced') {
+  if (normalized === 'official_menu') {
+    return 'from an official menu'
+  }
+  if (normalized === 'venue_submission') {
+    return 'from the venue'
+  }
+  if (normalized === 'aggregator_lead') {
+    return 'from an aggregator lead'
+  }
+  if (normalized === 'crowdsourced' || normalized === 'manual' || normalized === 'community_bounty') {
+    return 'by a local'
+  }
+  if (normalized === 'tier_c_report_hero') {
     return 'by a local'
   }
 
   return `by ${source}`
+}
+
+function isReportProvenanceInput(value: unknown): value is ReportProvenanceInput {
+  return typeof value === 'object' && value !== null
+}
+
+function hasEvidence(value: unknown): boolean {
+  return isReportProvenanceInput(value) &&
+    typeof value.evidence_text === 'string' &&
+    value.evidence_text.trim().length > 0
+}
+
+function hasSourceUrl(value: unknown): boolean {
+  return isReportProvenanceInput(value) &&
+    typeof value.source_url === 'string' &&
+    value.source_url.trim().length > 0
 }

--- a/supabase/migrations/20260601010000_price_report_intake_provenance.sql
+++ b/supabase/migrations/20260601010000_price_report_intake_provenance.sql
@@ -1,0 +1,47 @@
+-- Add structured report-level provenance for every pending price candidate.
+-- Canonical pub price provenance still lives on public.pubs and is populated
+-- only when an admin approves a report.
+
+alter table public.price_reports
+  add column if not exists submission_source text default 'manual',
+  add column if not exists source_url text,
+  add column if not exists evidence_text text,
+  add column if not exists observed_at timestamptz,
+  add column if not exists raw_extraction jsonb,
+  add column if not exists extractor_version text;
+
+update public.price_reports
+set submission_source = case
+  when report_type = 'outdated_flag' then 'stale_flag'
+  when lower(coalesce(notes, '')) like '%menu scan%' then 'menu_scan'
+  when lower(coalesce(notes, '')) like '%[source:tier-c-report-hero]%' then 'tier_c_report_hero'
+  when lower(coalesce(notes, '')) like '%[source:tier_c_report_hero]%' then 'tier_c_report_hero'
+  else 'manual'
+end
+where submission_source is null
+   or submission_source = 'manual';
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'price_reports_submission_source_check'
+      and conrelid = 'public.price_reports'::regclass
+  ) then
+    alter table public.price_reports
+      add constraint price_reports_submission_source_check
+      check (
+        submission_source in (
+          'manual',
+          'menu_scan',
+          'tier_c_report_hero',
+          'official_menu',
+          'venue_submission',
+          'community_bounty',
+          'aggregator_lead',
+          'stale_flag'
+        )
+      );
+  end if;
+end $$;


### PR DESCRIPTION
## Summary
- Adds structured `price_reports` provenance/evidence columns with source constraints and legacy backfill.
- Stores `submission_source`/evidence from public reports, menu scans, Tier-C hero reports, and stale flags.
- Hardens admin approval so stale flags cannot update prices, happy-hour reports avoid regular price history, aggregator leads are blocked, and pending report stats count all pending rows.

## Test Plan
- [x] npm test
- [x] npx tsc --noEmit
- [x] npm run lint
- [x] npm run build
- [x] git diff --check

## Notes
- Andrew calls remain untouched and paused.
- UI change is payload-only; no visible layout changes were made, so no Playwright screenshots were needed.
