### PR TITLE
[codex] Add official menu crawler MVP

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,11 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Official menu crawler MVP ready (2026-06-01)
+- **Branch `codex/official-menu-crawler-mvp`:** added a manual, dry-run-first official menu crawler for curated source URLs. It fetches reviewed venue/menu pages, extracts conservative pint-price candidates, and can insert pending `price_reports` with `submission_source = "official_menu"` only when run with `--write`.
+- **Guardrails:** extraction skips happy-hour/special/deal lines in v1, keeps reviewer evidence text, stores raw extraction metadata, and never updates canonical `pubs.price`. The committed seed file is an example only; real crawl lists stay explicit and reviewed.
+- **Verification:** verified `npm test` (**229/229 tests**), `npx tsc --noEmit`, `npm run lint` (existing warnings only), `npm run build`, `git diff --check`, and a dry-run against `scripts/official-menu-seeds.example.json` with zero writes.
+
 ### Price intake plumbing implemented (2026-06-01)
 - **Branch `codex/price-intake-plumbing-spec` / commit `e2de1c5`:** added structured `price_reports` provenance/evidence columns (`submission_source`, `source_url`, `evidence_text`, `observed_at`, `raw_extraction`, `extractor_version`) with a constrained source vocabulary and legacy backfill for menu scans, Tier-C report heroes, and stale flags.
 - **Intake + moderation safety:** public reports now store structured sources, menu-scan submissions no longer rely on note parsing, and admin approval maps provenance/confidence through one helper. Outdated flags are reviewed without touching live prices, happy-hour reports no longer write regular `price_history.price`, aggregator leads are blocked from direct approval, and admin stats count all pending reports.

--- a/docs/superpowers/plans/2026-06-01-official-menu-crawler-mvp.md
+++ b/docs/superpowers/plans/2026-06-01-official-menu-crawler-mvp.md
@@ -1,0 +1,52 @@
+# Official Menu Crawler MVP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a small manual crawler that turns curated official menu URLs into pending `price_reports` rows without updating canonical pub prices.
+
+**Architecture:** The crawler is a CLI-only operational tool. Pure extraction lives in `src/lib/officialMenuExtract.ts` with tests; `scripts/crawl-official-menus.mjs` handles env loading, seed-file parsing, fetching, pub lookup, dry-run output, and optional insertion into `price_reports`.
+
+**Tech Stack:** Node.js fetch, Supabase JS v2 service-role script, TypeScript unit tests via `tsx --test`.
+
+---
+
+### Task 1: Seed Contract
+
+**Files:**
+- Create: `scripts/official-menu-seeds.example.json`
+
+- [ ] Define the curated seed format as `{ "sources": [{ "pub_slug": "...", "url": "...", "label": "..." }] }`.
+- [ ] Keep real production writes behind an explicit copied local seed file.
+
+### Task 2: Pure Extraction
+
+**Files:**
+- Create: `src/lib/officialMenuExtract.ts`
+- Create: `src/lib/officialMenuExtract.test.ts`
+
+- [ ] Convert HTML/text to readable menu lines.
+- [ ] Extract conservative pint-price candidates from beer/pint/tap/draught lines with `$3`-`$30` prices.
+- [ ] Skip happy-hour/special/deal lines in v1.
+- [ ] Preserve reviewer evidence text.
+
+### Task 3: Manual Crawler CLI
+
+**Files:**
+- Create: `scripts/crawl-official-menus.mjs`
+- Modify: `package.json`
+
+- [ ] Load `.env.local`.
+- [ ] Default to `--dry-run`.
+- [ ] Accept `--file`, `--limit`, and `--write`.
+- [ ] Fetch each URL with timeout and a normal user agent.
+- [ ] Look up seeded `pub_slug` values in `pubs`.
+- [ ] Insert pending `price_reports` with `submission_source = "official_menu"`, `source_url`, `evidence_text`, `observed_at`, `raw_extraction`, and `extractor_version`.
+- [ ] Never update `pubs`.
+
+### Task 4: Verify
+
+- [ ] Run `npm test`.
+- [ ] Run `npx tsc --noEmit`.
+- [ ] Run `npm run lint`.
+- [ ] Run `npm run build`.
+- [ ] Run `git diff --check`.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint --max-warnings 50",
     "test": "tsx --test \"src/**/*.test.ts\"",
+    "crawl:official-menus": "tsx scripts/crawl-official-menus.mjs",
     "test:redirects": "node scripts/redirect-seo.test.mjs",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",

--- a/scripts/crawl-official-menus.mjs
+++ b/scripts/crawl-official-menus.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Crawl a curated list of official menu URLs and create pending price reports.
+ *
+ * Default mode is dry-run. Copy scripts/official-menu-seeds.example.json to a
+ * local seed file, add reviewed official URLs, then run:
+ *
+ *   npm run crawl:official-menus -- --file scripts/official-menu-seeds.json
+ *   npm run crawl:official-menus -- --file scripts/official-menu-seeds.json --write
+ */
+import { createClient } from '@supabase/supabase-js'
+import { existsSync, readFileSync } from 'node:fs'
+import { config } from 'dotenv'
+
+import { extractOfficialMenuCandidates } from '../src/lib/officialMenuExtract.ts'
+
+config({ path: '.env.local' })
+
+const EXTRACTOR_VERSION = 'official-menu-crawler-v1'
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co'
+const SUPABASE_ANON_KEY =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlmeGtvYmx2Z3R0ZWx6Ym9lbnBpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExODUwNjgsImV4cCI6MjA4Njc2MTA2OH0.qLy6B-VeVnMh0QSOxHK3uQEJ6iZr6xNHmfKov_7B-fY'
+const args = process.argv.slice(2)
+const shouldWrite = args.includes('--write')
+const dryRun = !shouldWrite
+const seedFile = arg('--file') || 'scripts/official-menu-seeds.json'
+const limit = Number.parseInt(arg('--limit') || '0', 10) || null
+
+if (!existsSync(seedFile)) {
+  console.error(`Seed file not found: ${seedFile}`)
+  console.error('Copy scripts/official-menu-seeds.example.json and add reviewed official menu URLs.')
+  process.exit(1)
+}
+
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+if (shouldWrite && !serviceKey) {
+  console.error('SUPABASE_SERVICE_ROLE_KEY is required when using --write')
+  process.exit(1)
+}
+
+const supabase = createClient(
+  SUPABASE_URL,
+  serviceKey || SUPABASE_ANON_KEY,
+  { auth: { persistSession: false } },
+)
+
+const sources = loadSources(seedFile)
+const selectedSources = limit ? sources.slice(0, limit) : sources
+console.log(`${selectedSources.length} official menu source${selectedSources.length === 1 ? '' : 's'}`)
+console.log(dryRun ? 'Mode: dry run (no writes)\n' : 'Mode: write pending price_reports\n')
+
+let fetched = 0
+let inserted = 0
+let found = 0
+let failed = 0
+
+for (const source of selectedSources) {
+  process.stdout.write(`${source.pub_slug} ${source.url} ... `)
+
+  try {
+    const { data: pub, error: pubErr } = await supabase
+      .from('pubs')
+      .select('id, slug, name')
+      .eq('slug', source.pub_slug)
+      .single()
+
+    if (pubErr || !pub) {
+      failed++
+      console.log(`no pub found`)
+      continue
+    }
+
+    const html = await fetchText(source.url)
+    fetched++
+    const candidates = extractOfficialMenuCandidates(html, source.max_candidates || 5)
+    found += candidates.length
+    console.log(`${candidates.length} candidate${candidates.length === 1 ? '' : 's'}`)
+
+    for (const candidate of candidates) {
+      console.log(`  - $${candidate.price.toFixed(2)} ${candidate.beerType || 'pint'} (${candidate.evidenceText})`)
+    }
+
+    if (!dryRun && candidates.length > 0) {
+      const observedAt = new Date().toISOString()
+      const rows = candidates.map((candidate) => ({
+        pub_slug: pub.slug,
+        reported_price: candidate.price,
+        beer_type: candidate.beerType,
+        reporter_name: 'Official menu crawler',
+        report_type: 'price_report',
+        notes: source.label ? `Official menu crawl: ${source.label}` : 'Official menu crawl',
+        submission_source: 'official_menu',
+        source_url: source.url,
+        evidence_text: candidate.evidenceText,
+        observed_at: observedAt,
+        raw_extraction: {
+          source,
+          candidate,
+        },
+        extractor_version: EXTRACTOR_VERSION,
+      }))
+
+      const { error: insertErr } = await supabase.from('price_reports').insert(rows)
+      if (insertErr) {
+        failed++
+        console.log(`  ! insert failed: ${insertErr.message}`)
+      } else {
+        inserted += rows.length
+      }
+    }
+  } catch (err) {
+    failed++
+    console.log(`error: ${err instanceof Error ? err.message : String(err)}`)
+  }
+
+  await sleep(150)
+}
+
+console.log('\n=== Official menu crawl summary ===')
+console.log(`Fetched: ${fetched}`)
+console.log(`Candidates found: ${found}`)
+console.log(`Inserted pending reports: ${inserted}`)
+console.log(`Failed sources: ${failed}`)
+console.log(dryRun ? '(dry run - no writes)' : 'Write complete')
+
+function arg(flag) {
+  const index = args.indexOf(flag)
+  return index >= 0 ? args[index + 1] : null
+}
+
+function loadSources(path) {
+  const parsed = JSON.parse(readFileSync(path, 'utf8'))
+  if (!Array.isArray(parsed.sources)) {
+    throw new Error(`${path} must contain a "sources" array`)
+  }
+
+  return parsed.sources.map((source, index) => {
+    if (!source.pub_slug || !source.url) {
+      throw new Error(`sources[${index}] must include pub_slug and url`)
+    }
+    new URL(source.url)
+    return source
+  })
+}
+
+async function fetchText(url) {
+  const response = await fetch(url, {
+    headers: {
+      'user-agent': 'PerthPintPricesBot/1.0 (+https://perthpintprices.com)',
+      accept: 'text/html, text/plain;q=0.9, */*;q=0.5',
+    },
+    signal: AbortSignal.timeout(12000),
+  })
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`)
+  }
+
+  return response.text()
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/scripts/official-menu-seeds.example.json
+++ b/scripts/official-menu-seeds.example.json
@@ -1,0 +1,9 @@
+{
+  "sources": [
+    {
+      "pub_slug": "399-bar",
+      "url": "https://399bar.com/",
+      "label": "official website"
+    }
+  ]
+}

--- a/src/lib/officialMenuExtract.test.ts
+++ b/src/lib/officialMenuExtract.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { extractOfficialMenuCandidates, menuLines } from './officialMenuExtract'
+
+describe('official menu extraction', () => {
+  it('extracts conservative pint candidates from menu text', () => {
+    const candidates = extractOfficialMenuCandidates(`
+      Swan Draught pint $10
+      Single Fin draught pint $12.50
+      Fish and chips $28
+    `)
+
+    assert.deepEqual(candidates, [
+      { beerType: 'Swan', price: 10, evidenceText: 'Swan Draught pint $10' },
+      { beerType: 'Single Fin', price: 12.5, evidenceText: 'Single Fin draught pint $12.50' },
+    ])
+  })
+
+  it('skips happy-hour and non-drink menu prices', () => {
+    const candidates = extractOfficialMenuCandidates(`
+      Happy hour pints $8
+      Beef burger $24
+      House wine $11
+      Tap lager $9
+    `)
+
+    assert.deepEqual(candidates, [
+      { beerType: 'lager', price: 9, evidenceText: 'Tap lager $9' },
+    ])
+  })
+
+  it('normalizes basic html into readable lines', () => {
+    assert.deepEqual(menuLines('<ul><li>Swan Draught pint&nbsp;$10</li><li>Fish &amp; chips $28</li></ul>'), [
+      'Swan Draught pint $10',
+      'Fish & chips $28',
+    ])
+  })
+
+  it('rejects prices outside the expected pint range', () => {
+    assert.deepEqual(extractOfficialMenuCandidates('Tap beer $2\nFancy beer pint $42'), [])
+  })
+})

--- a/src/lib/officialMenuExtract.ts
+++ b/src/lib/officialMenuExtract.ts
@@ -1,0 +1,77 @@
+export interface OfficialMenuCandidate {
+  beerType: string | null
+  price: number
+  evidenceText: string
+}
+
+const PRICE_RE = /(?:\$|aud\s*)\s*(\d{1,2}(?:\.\d{1,2})?)/i
+const DRINK_RE = /\b(pint|pints|draught|draft|tap|lager|ale|beer|cider)\b/i
+const SKIP_RE = /\b(happy\s*hour|special|deal|promo|members?|jug|bottle|can|cocktail|wine|spirit|food)\b/i
+
+export function extractOfficialMenuCandidates(input: string, limit = 10): OfficialMenuCandidate[] {
+  const seen = new Set<string>()
+  const candidates: OfficialMenuCandidate[] = []
+
+  for (const line of menuLines(input)) {
+    if (!DRINK_RE.test(line) || SKIP_RE.test(line)) continue
+
+    const priceMatch = line.match(PRICE_RE)
+    if (!priceMatch) continue
+
+    const price = Number.parseFloat(priceMatch[1])
+    if (!Number.isFinite(price) || price < 3 || price > 30) continue
+
+    const beerType = inferBeerType(line, priceMatch[0])
+    const key = `${beerType || 'pint'}:${price}:${line.toLowerCase()}`
+    if (seen.has(key)) continue
+    seen.add(key)
+
+    candidates.push({
+      beerType,
+      price,
+      evidenceText: line,
+    })
+
+    if (candidates.length >= limit) break
+  }
+
+  return candidates
+}
+
+export function menuLines(input: string): string[] {
+  return htmlToText(input)
+    .split('\n')
+    .map((line) => line.replace(/\s+/g, ' ').trim())
+    .filter((line) => line.length >= 8 && line.length <= 180)
+}
+
+function htmlToText(input: string): string {
+  return decodeEntities(input)
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '\n')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, '\n')
+    .replace(/<(br|p|li|tr|td|th|div|section|article|h[1-6])\b[^>]*>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[ \t\r\f\v]+/g, ' ')
+    .replace(/\n\s+/g, '\n')
+}
+
+function decodeEntities(input: string): string {
+  return input
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&dollar;/gi, '$')
+    .replace(/&#36;/g, '$')
+    .replace(/&ndash;|&mdash;/gi, '-')
+}
+
+function inferBeerType(line: string, priceText: string): string | null {
+  const beforePrice = line.split(priceText)[0] || line
+  const cleaned = beforePrice
+    .replace(/\b(pints?|draught|draft|tap|beer|cider|from|only|glass|middy|schooner)\b/gi, ' ')
+    .replace(/[|:,-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (!cleaned || cleaned.length < 3) return null
+  return cleaned.slice(0, 80)
+}


### PR DESCRIPTION
## Summary
- Adds a manual official-menu crawler CLI with dry-run by default and explicit `--write` for pending report inserts.
- Adds conservative menu-price extraction helpers and tests for pint/tap/draught lines, price range guards, HTML cleanup, and happy-hour/special skipping.
- Adds an example seed-file contract and project-status handoff notes.

## Safety
- Inserts only pending `price_reports` with `submission_source = "official_menu"`.
- Never writes to `pubs` or canonical price history.
- Real source lists must be curated through a local seed file; the committed seed is an example.

## Test Plan
- [x] npm test
- [x] npx tsc --noEmit
- [x] npm run lint
- [x] npm run build
- [x] git diff --check
- [x] npm run crawl:official-menus -- --file scripts/official-menu-seeds.example.json --limit 1
