### PR TITLE
[codex] Add official menu source discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ scripts/location-audit-results.json
 scripts/backfill-place-ids-results.json
 scripts/backfill-review.json
 scripts/discover-venues-results.json
+scripts/official-menu-source-candidates.json
 
 # Research agent data
 perth_pubs_pricing/

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,11 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Official menu source discovery ready (2026-06-01)
+- **Branch `codex/official-menu-source-discovery`:** added a read-only discovery CLI that scans missing-price pubs with websites, ranks likely menu/drinks/PDF links, and writes `scripts/official-menu-source-candidates.json` for review. The generated artifact is gitignored.
+- **Source scoring:** added pure link extraction/scoring helpers with tests for relative URL canonicalisation, menu/drinks/PDF ranking, low-intent filtering, and deduping.
+- **Verification:** verified `npm test` (**232/232 tests**), `npx tsc --noEmit`, `npm run lint` (existing warnings only), `npm run build`, `npm run discover:official-menu-sources -- --limit 5` (5 fetched, 2 candidates), and `git diff --check`.
+
 ### Official menu crawler MVP ready (2026-06-01)
 - **Branch `codex/official-menu-crawler-mvp`:** added a manual, dry-run-first official menu crawler for curated source URLs. It fetches reviewed venue/menu pages, extracts conservative pint-price candidates, and can insert pending `price_reports` with `submission_source = "official_menu"` only when run with `--write`.
 - **Guardrails:** extraction skips happy-hour/special/deal lines in v1, keeps reviewer evidence text, stores raw extraction metadata, and never updates canonical `pubs.price`. The committed seed file is an example only; real crawl lists stay explicit and reviewed.

--- a/docs/superpowers/plans/2026-06-01-official-menu-source-discovery.md
+++ b/docs/superpowers/plans/2026-06-01-official-menu-source-discovery.md
@@ -1,0 +1,44 @@
+# Official Menu Source Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Discover likely official menu/drinks/PDF source URLs for missing-price pubs so crawler inputs can be reviewed before extraction.
+
+**Architecture:** Keep discovery read-only. Pure link scoring lives in `src/lib/officialMenuSources.ts`; `scripts/discover-official-menu-sources.mjs` loads pubs with websites, fetches pages, ranks candidate links, and writes a local JSON review artifact.
+
+**Tech Stack:** Node.js fetch/URL/fs, Supabase JS v2 read queries, TypeScript node tests.
+
+---
+
+### Task 1: Pure Link Discovery
+
+**Files:**
+- Create: `src/lib/officialMenuSources.ts`
+- Create: `src/lib/officialMenuSources.test.ts`
+
+- [ ] Extract links from HTML relative to a base URL.
+- [ ] Score menu/drinks/PDF links higher than generic food/contact links.
+- [ ] Categorise candidates as `html`, `pdf`, `image`, or `other`.
+- [ ] Deduplicate by canonical URL.
+
+### Task 2: CLI Review Artifact
+
+**Files:**
+- Create: `scripts/discover-official-menu-sources.mjs`
+- Modify: `package.json`
+- Modify: `.gitignore`
+
+- [ ] Query pubs with non-empty websites, defaulting to missing regular prices.
+- [ ] Fetch each website with timeout and user agent.
+- [ ] Rank up to 5 candidate source URLs per pub.
+- [ ] Write `scripts/official-menu-source-candidates.json`.
+- [ ] Never insert reports or update pubs.
+
+### Task 3: Verify
+
+- [ ] Run `npm test`.
+- [ ] Run `npx tsc --noEmit`.
+- [ ] Run `npm run lint`.
+- [ ] Run `npm run build`.
+- [ ] Run `npm run discover:official-menu-sources -- --limit 5`.
+- [ ] Run `git diff --check`.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint --max-warnings 50",
     "test": "tsx --test \"src/**/*.test.ts\"",
     "crawl:official-menus": "tsx scripts/crawl-official-menus.mjs",
+    "discover:official-menu-sources": "tsx scripts/discover-official-menu-sources.mjs",
     "test:redirects": "node scripts/redirect-seo.test.mjs",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",

--- a/scripts/discover-official-menu-sources.mjs
+++ b/scripts/discover-official-menu-sources.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * Discover likely official menu/drinks sources for pubs with websites.
+ *
+ * Read-only: this writes a local JSON review artifact and does not insert
+ * price_reports or update pubs.
+ *
+ * Usage:
+ *   npm run discover:official-menu-sources -- --limit 25
+ *   npm run discover:official-menu-sources -- --include-priced --output /tmp/sources.json
+ */
+import { createClient } from '@supabase/supabase-js'
+import { writeFileSync } from 'node:fs'
+import { config } from 'dotenv'
+
+import { discoverOfficialMenuSources } from '../src/lib/officialMenuSources.ts'
+
+config({ path: '.env.local' })
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co'
+const SUPABASE_ANON_KEY =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlmeGtvYmx2Z3R0ZWx6Ym9lbnBpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExODUwNjgsImV4cCI6MjA4Njc2MTA2OH0.qLy6B-VeVnMh0QSOxHK3uQEJ6iZr6xNHmfKov_7B-fY'
+
+const args = process.argv.slice(2)
+const limit = Number.parseInt(arg('--limit') || '50', 10)
+const includePriced = args.includes('--include-priced')
+const output = arg('--output') || 'scripts/official-menu-source-candidates.json'
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, { auth: { persistSession: false } })
+
+let query = supabase
+  .from('pubs')
+  .select('id, slug, name, suburb, price, website')
+  .not('website', 'is', null)
+  .neq('website', '')
+  .order('last_verified', { ascending: true, nullsFirst: true })
+  .limit(limit)
+
+if (!includePriced) {
+  query = query.or('price.is.null,price.eq.0')
+}
+
+const { data: pubs, error } = await query
+if (error) throw error
+
+console.log(`${pubs.length} pub website${pubs.length === 1 ? '' : 's'} to inspect`)
+console.log(includePriced ? 'Scope: all pubs with websites' : 'Scope: missing regular prices only')
+console.log(`Output: ${output}\n`)
+
+const results = []
+let fetched = 0
+let failed = 0
+let candidateCount = 0
+
+for (let i = 0; i < pubs.length; i++) {
+  const pub = pubs[i]
+  process.stdout.write(`[${i + 1}/${pubs.length}] ${pub.name} ... `)
+
+  try {
+    const html = await fetchText(pub.website)
+    const candidates = discoverOfficialMenuSources(html, pub.website, 5)
+    fetched++
+    candidateCount += candidates.length
+    results.push({
+      pub_slug: pub.slug,
+      pub_name: pub.name,
+      suburb: pub.suburb,
+      website: pub.website,
+      candidate_count: candidates.length,
+      candidates,
+    })
+    console.log(`${candidates.length} candidate${candidates.length === 1 ? '' : 's'}`)
+  } catch (err) {
+    failed++
+    results.push({
+      pub_slug: pub.slug,
+      pub_name: pub.name,
+      suburb: pub.suburb,
+      website: pub.website,
+      error: err instanceof Error ? err.message : String(err),
+      candidates: [],
+    })
+    console.log(`error: ${err instanceof Error ? err.message : String(err)}`)
+  }
+
+  await sleep(150)
+}
+
+const artifact = {
+  generated_at: new Date().toISOString(),
+  scope: includePriced ? 'all_with_websites' : 'missing_regular_prices_with_websites',
+  summary: {
+    inspected: pubs.length,
+    fetched,
+    failed,
+    candidate_count: candidateCount,
+  },
+  results,
+}
+
+writeFileSync(output, JSON.stringify(artifact, null, 2))
+
+console.log('\n=== Official menu source discovery ===')
+console.log(`Fetched: ${fetched}`)
+console.log(`Failed: ${failed}`)
+console.log(`Candidates: ${candidateCount}`)
+console.log(`Written: ${output}`)
+
+function arg(flag) {
+  const index = args.indexOf(flag)
+  return index >= 0 ? args[index + 1] : null
+}
+
+async function fetchText(url) {
+  const response = await fetch(url, {
+    headers: {
+      'user-agent': 'PerthPintPricesBot/1.0 (+https://perthpintprices.com)',
+      accept: 'text/html, text/plain;q=0.9, */*;q=0.5',
+    },
+    signal: AbortSignal.timeout(12000),
+  })
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`)
+  }
+
+  return response.text()
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/src/lib/officialMenuSources.test.ts
+++ b/src/lib/officialMenuSources.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { discoverOfficialMenuSources, extractLinks } from './officialMenuSources'
+
+describe('official menu source discovery', () => {
+  it('extracts and canonicalizes links against a base URL', () => {
+    const links = extractLinks(`
+      <a href="/drinks/">Drinks</a>
+      <a href="#top">Top</a>
+      <a href="mailto:test@example.com">Email</a>
+    `, 'https://example.com/pub/')
+
+    assert.deepEqual(links, [
+      { url: 'https://example.com/drinks/', label: 'Drinks' },
+    ])
+  })
+
+  it('ranks drinks and PDF menu links above generic pages', () => {
+    const candidates = discoverOfficialMenuSources(`
+      <a href="/contact/">Contact</a>
+      <a href="/food-menu/">Food Menu</a>
+      <a href="/drinks/">Drinks</a>
+      <a href="/files/tap-list.pdf">Tap list PDF</a>
+    `, 'https://example.com/')
+
+    assert.equal(candidates[0].url, 'https://example.com/files/tap-list.pdf')
+    assert.equal(candidates[0].type, 'pdf')
+    assert.deepEqual(candidates[0].reasons, ['drinks-or-beer', 'pdf'])
+    assert.equal(candidates[1].url, 'https://example.com/drinks/')
+    assert.equal(candidates[2].url, 'https://example.com/food-menu/')
+  })
+
+  it('deduplicates links by canonical URL and keeps the higher score', () => {
+    const candidates = discoverOfficialMenuSources(`
+      <a href="/menu#lunch">Menu</a>
+      <a href="/menu">Drinks menu</a>
+    `, 'https://example.com/')
+
+    assert.equal(candidates.length, 1)
+    assert.equal(candidates[0].url, 'https://example.com/menu')
+    assert.equal(candidates[0].score, 13)
+  })
+})

--- a/src/lib/officialMenuSources.ts
+++ b/src/lib/officialMenuSources.ts
@@ -1,0 +1,120 @@
+export type OfficialMenuSourceType = 'html' | 'pdf' | 'image' | 'other'
+
+export interface OfficialMenuSourceCandidate {
+  url: string
+  label: string
+  type: OfficialMenuSourceType
+  score: number
+  reasons: string[]
+}
+
+interface RawLink {
+  url: string
+  label: string
+}
+
+const HIGH_INTENT_RE = /\b(drinks?|beverages?|beer|tap[-\s]?list|wine-list|bar-menu)\b/i
+const MENU_RE = /\b(menu|menus|eat[-\s]?drink|food[-\s]?drink)\b/i
+const LOW_INTENT_RE = /\b(contact|booking|bookings|function|events?|privacy|terms|feed|wp-json|xmlrpc|login|cart|checkout)\b/i
+const ASSET_RE = /\.(pdf|png|jpe?g|webp)(?:[?#].*)?$/i
+
+export function discoverOfficialMenuSources(html: string, baseUrl: string, limit = 5): OfficialMenuSourceCandidate[] {
+  const byUrl = new Map<string, OfficialMenuSourceCandidate>()
+
+  for (const link of extractLinks(html, baseUrl)) {
+    const candidate = scoreLink(link)
+    if (candidate.score <= 0) continue
+
+    const existing = byUrl.get(candidate.url)
+    if (!existing || candidate.score > existing.score) {
+      byUrl.set(candidate.url, candidate)
+    }
+  }
+
+  return Array.from(byUrl.values())
+    .sort((a, b) => b.score - a.score || a.url.localeCompare(b.url))
+    .slice(0, limit)
+}
+
+export function extractLinks(html: string, baseUrl: string): RawLink[] {
+  const links: RawLink[] = []
+  const base = new URL(baseUrl)
+  const linkRe = /<a\b[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi
+
+  let match: RegExpExecArray | null
+  while ((match = linkRe.exec(html)) !== null) {
+    const href = match[1]?.trim()
+    if (!href || href.startsWith('#') || href.startsWith('mailto:') || href.startsWith('tel:')) continue
+
+    try {
+      const url = new URL(href, base)
+      url.hash = ''
+      if (!url.protocol.startsWith('http')) continue
+
+      links.push({
+        url: url.toString(),
+        label: cleanLabel(match[2] || ''),
+      })
+    } catch {
+      // Ignore malformed links from third-party pages.
+    }
+  }
+
+  return links
+}
+
+function scoreLink(link: RawLink): OfficialMenuSourceCandidate {
+  const haystack = `${link.url} ${link.label}`
+  const reasons: string[] = []
+  let score = 0
+
+  if (HIGH_INTENT_RE.test(haystack)) {
+    score += 8
+    reasons.push('drinks-or-beer')
+  }
+
+  if (MENU_RE.test(haystack)) {
+    score += 5
+    reasons.push('menu')
+  }
+
+  if (/\.pdf(?:[?#].*)?$/i.test(link.url)) {
+    score += 4
+    reasons.push('pdf')
+  }
+
+  if (ASSET_RE.test(link.url) && !/\.pdf/i.test(link.url)) {
+    score += 1
+    reasons.push('image-asset')
+  }
+
+  if (LOW_INTENT_RE.test(haystack)) {
+    score -= 6
+    reasons.push('low-intent')
+  }
+
+  return {
+    url: link.url,
+    label: link.label,
+    type: sourceType(link.url),
+    score,
+    reasons,
+  }
+}
+
+function sourceType(url: string): OfficialMenuSourceType {
+  if (/\.pdf(?:[?#].*)?$/i.test(url)) return 'pdf'
+  if (/\.(png|jpe?g|webp)(?:[?#].*)?$/i.test(url)) return 'image'
+  if (/^https?:\/\//i.test(url)) return 'html'
+  return 'other'
+}
+
+function cleanLabel(value: string): string {
+  return value
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 120)
+}


### PR DESCRIPTION
## Summary
- Adds a read-only official menu source discovery CLI for pubs with websites, defaulting to missing regular prices.
- Adds pure link extraction/scoring helpers for menu/drinks/PDF candidates, with tests for canonicalization, ranking, and deduping.
- Gitignores the generated review artifact so batches can be inspected locally without committing crawl output.

## Safety
- No database writes.
- No `price_reports` inserts.
- No `pubs` updates.
- Output is a local review JSON: `scripts/official-menu-source-candidates.json`.

## Test Plan
- [x] npm test
- [x] npx tsc --noEmit
- [x] npm run lint
- [x] npm run build
- [x] npm run discover:official-menu-sources -- --limit 5
- [x] git diff --check

## Calibration
A 5-pub missing-price sample fetched 5 websites, failed 0, and found 2 likely menu source candidates.
