### PR TITLE
[codex] Finish official menu crawler workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ npm-debug.log*
 .vscode/
 
 # Playwright MCP cache
+.cache/
 .playwright-mcp/
 playwright-report/
 test-results/
@@ -46,7 +47,15 @@ scripts/location-audit-results.json
 scripts/backfill-place-ids-results.json
 scripts/backfill-review.json
 scripts/discover-venues-results.json
-scripts/official-menu-source-candidates.json
+scripts/official-menu-crawl-results*.json
+scripts/official-menu-import-plan*.json
+scripts/official-menu-review*.csv
+scripts/official-menu-review*.json
+scripts/official-menu-seeds.json
+scripts/official-menu-seeds.generated*.json
+scripts/official-menu-seeds.large*.json
+scripts/official-menu-source-candidates*.json
+scripts/official-menu-seeds-discovered*.json
 
 # Research agent data
 perth_pubs_pricing/

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -15,9 +15,10 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 - **Crawler improvements:** added rendered HTML fallback, PDF text/table extraction, image OCR, scanned-PDF OCR fallback, JSON-LD `MenuItem` extraction, adjacent price-line handling, source/provider discovery, and stricter filtering for ecommerce/product pages, generic image assets, unsupported AVIF OCR, cocktails/wine/spirits, food combos, non-alcoholic beers, stale CMS templates, and other false positives found during live dry runs.
 - **Review workflow:** added `scripts/build-official-menu-seeds.mjs`, `scripts/build-official-menu-review.mjs`, and `scripts/import-official-menu-review.mjs`. Review exports include source URL, evidence text, extraction mode, confidence, decision, and notes; suggested decisions separate explicit pint/draught/tap evidence from rows needing manual review.
 - **Admin review:** the admin stats payload now returns pending price reports as the review queue instead of only the latest 10 reports, and the Reports tab surfaces official-menu source/evidence fields so the 26 imported rows can be actioned through the normal approval path.
+- **Follow-up provenance fix:** linked-source crawl candidates now carry the actual linked menu/PDF/image URL and extraction mode into review exports instead of falling back to the parent page URL.
 - **Latest batch:** a 140-source dry run fetched 129 sources, found 26 review candidates, and inserted 0 rows during crawl. After owner approval, the importer inserted 26 **pending** `price_reports` with `submission_source = "official_menu"`. Admin review is complete: 5 clear official-menu rows were approved into canonical pub prices, and 21 ambiguous/duplicate rows were rejected.
 - **Verification:** verified `node --check` for the new workflow scripts, a dry-run import plan, `npm test`, `npx tsc --noEmit`, `npm run lint` (existing warnings only), `npm run build` (existing warnings only), and desktop/mobile admin screenshots.
-- **Commit:** `d8e976d`
+- **Commits:** `d8e976d`, `99b8200`
 
 ### Official menu source discovery ready (2026-06-01)
 - **PR #130 / merge commit `92f2c8d`:** added a read-only discovery CLI that scans missing-price pubs with websites, ranks likely menu/drinks/PDF links, and writes `scripts/official-menu-source-candidates.json` for review. The generated artifact is gitignored.

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -17,7 +17,7 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 - **Admin review:** the admin stats payload now returns pending price reports as the review queue instead of only the latest 10 reports, and the Reports tab surfaces official-menu source/evidence fields so the 26 imported rows can be actioned through the normal approval path.
 - **Latest batch:** a 140-source dry run fetched 129 sources, found 26 review candidates, and inserted 0 rows during crawl. After owner approval, the importer inserted 26 **pending** `price_reports` with `submission_source = "official_menu"`. Admin review is complete: 5 clear official-menu rows were approved into canonical pub prices, and 21 ambiguous/duplicate rows were rejected.
 - **Verification:** verified `node --check` for the new workflow scripts, a dry-run import plan, `npm test`, `npx tsc --noEmit`, `npm run lint` (existing warnings only), `npm run build` (existing warnings only), and desktop/mobile admin screenshots.
-- **Commit:** `fb547b5`
+- **Commit:** `d8e976d`
 
 ### Official menu source discovery ready (2026-06-01)
 - **PR #130 / merge commit `92f2c8d`:** added a read-only discovery CLI that scans missing-price pubs with websites, ranks likely menu/drinks/PDF links, and writes `scripts/official-menu-source-candidates.json` for review. The generated artifact is gitignored.

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -1,6 +1,6 @@
 # Perth Pint Prices Project Status
 
-Last updated: 2026-06-01
+Last updated: 2026-06-02
 
 ## What this is
 
@@ -9,6 +9,15 @@ Perth Pint Prices (perthpintprices.com) tracks pint prices across **857 Perth pu
 Stack, database, routes, components, and lib files are documented in `CLAUDE.md` (auto-loaded every session). This file covers history, recent work, and the backlog.
 
 ## What's done recently
+
+### Official menu crawler scaled to review + pending reports (2026-06-02)
+- **Local uncommitted work:** expanded the official-menu workflow from MVP into a dry-run-first discovery, seed, crawl, review, suggested-decision, and guarded import pipeline. The approval pack lives at `docs/official-menu-crawler-approval.html`; generated crawl/review/import artifacts are gitignored.
+- **Crawler improvements:** added rendered HTML fallback, PDF text/table extraction, image OCR, scanned-PDF OCR fallback, JSON-LD `MenuItem` extraction, adjacent price-line handling, source/provider discovery, and stricter filtering for ecommerce/product pages, generic image assets, unsupported AVIF OCR, cocktails/wine/spirits, food combos, non-alcoholic beers, stale CMS templates, and other false positives found during live dry runs.
+- **Review workflow:** added `scripts/build-official-menu-seeds.mjs`, `scripts/build-official-menu-review.mjs`, and `scripts/import-official-menu-review.mjs`. Review exports include source URL, evidence text, extraction mode, confidence, decision, and notes; suggested decisions separate explicit pint/draught/tap evidence from rows needing manual review.
+- **Admin review:** the admin stats payload now returns pending price reports as the review queue instead of only the latest 10 reports, and the Reports tab surfaces official-menu source/evidence fields so the 26 imported rows can be actioned through the normal approval path.
+- **Latest batch:** a 140-source dry run fetched 129 sources, found 26 review candidates, and inserted 0 rows during crawl. After owner approval, the importer inserted 26 **pending** `price_reports` with `submission_source = "official_menu"`. Admin review is complete: 5 clear official-menu rows were approved into canonical pub prices, and 21 ambiguous/duplicate rows were rejected.
+- **Verification:** verified `node --check` for the new workflow scripts, a dry-run import plan, `npm test`, `npx tsc --noEmit`, `npm run lint` (existing warnings only), `npm run build` (existing warnings only), and desktop/mobile admin screenshots.
+- **Commit:** `fb547b5`
 
 ### Official menu source discovery ready (2026-06-01)
 - **PR #130 / merge commit `92f2c8d`:** added a read-only discovery CLI that scans missing-price pubs with websites, ranks likely menu/drinks/PDF links, and writes `scripts/official-menu-source-candidates.json` for review. The generated artifact is gitignored.

--- a/docs/official-menu-crawler-approval.html
+++ b/docs/official-menu-crawler-approval.html
@@ -1,0 +1,544 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Official Menu Crawler Approval Pack</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #171717;
+      --muted: #666;
+      --line: #d9d9d4;
+      --paper: #fdf8f0;
+      --panel: #fffdfa;
+      --accent: #d4740a;
+      --ok: #147a3d;
+      --warn: #a15c00;
+      --bad: #9b1c1c;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      background: var(--paper);
+      color: var(--ink);
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.55;
+    }
+
+    main {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 48px 24px 72px;
+    }
+
+    header {
+      border-bottom: 3px solid var(--ink);
+      padding-bottom: 24px;
+      margin-bottom: 28px;
+    }
+
+    h1, h2, h3 {
+      line-height: 1.1;
+      margin: 0;
+    }
+
+    h1 {
+      font-size: clamp(2rem, 5vw, 4rem);
+      max-width: 860px;
+      letter-spacing: 0;
+    }
+
+    h2 {
+      font-size: 1.45rem;
+      margin: 36px 0 14px;
+      border-bottom: 2px solid var(--line);
+      padding-bottom: 8px;
+    }
+
+    h3 {
+      font-size: 1rem;
+      margin: 24px 0 8px;
+    }
+
+    p { margin: 10px 0; }
+
+    code {
+      background: #fff3e0;
+      border: 1px solid #ecd1ad;
+      border-radius: 4px;
+      padding: 1px 5px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.92em;
+    }
+
+    pre {
+      overflow-x: auto;
+      background: var(--ink);
+      color: #fff;
+      border-radius: 8px;
+      padding: 14px 16px;
+      font-size: 0.9rem;
+    }
+
+    pre code {
+      background: transparent;
+      border: 0;
+      color: inherit;
+      padding: 0;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--panel);
+      border: 2px solid var(--ink);
+      margin: 12px 0 20px;
+    }
+
+    th, td {
+      border: 1px solid var(--line);
+      padding: 10px 12px;
+      text-align: left;
+      vertical-align: top;
+    }
+
+    th {
+      background: #fff3e0;
+      font-weight: 800;
+    }
+
+    ul {
+      margin: 10px 0 20px;
+      padding-left: 22px;
+    }
+
+    li { margin: 6px 0; }
+
+    .lede {
+      font-size: 1.12rem;
+      max-width: 820px;
+      color: #333;
+      margin-top: 16px;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin: 20px 0 28px;
+    }
+
+    .metric {
+      background: var(--panel);
+      border: 2px solid var(--ink);
+      border-radius: 8px;
+      padding: 14px;
+      min-height: 112px;
+    }
+
+    .metric strong {
+      display: block;
+      font-size: 1.9rem;
+      line-height: 1;
+      margin-bottom: 8px;
+    }
+
+    .metric span {
+      color: var(--muted);
+      font-size: 0.92rem;
+    }
+
+    .callout {
+      border: 2px solid var(--ink);
+      border-radius: 8px;
+      background: var(--panel);
+      padding: 16px;
+      margin: 18px 0;
+    }
+
+    .callout.ok { border-color: var(--ok); }
+    .callout.warn { border-color: var(--warn); }
+
+    .pill {
+      display: inline-block;
+      border: 1px solid currentColor;
+      border-radius: 999px;
+      padding: 2px 8px;
+      font-size: 0.8rem;
+      font-weight: 800;
+      white-space: nowrap;
+    }
+
+    .pill.ok { color: var(--ok); }
+    .pill.warn { color: var(--warn); }
+    .pill.bad { color: var(--bad); }
+
+    .small { color: var(--muted); font-size: 0.92rem; }
+
+    @media (max-width: 760px) {
+      main { padding: 28px 16px 48px; }
+      .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      table { font-size: 0.9rem; }
+      th, td { padding: 8px; }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <p class="small">Perth Pint Prices / Production Approval Pack</p>
+    <h1>Official Menu Crawler And Review Workflow</h1>
+    <p class="lede">
+      This document summarizes the production-ready local workflow for discovering official venue menu sources,
+      extracting candidate pint prices, reviewing them, and preparing pending <code>price_reports</code> rows.
+      The validated path is dry-run by default and does not write to Supabase unless an explicit <code>--write</code>
+      command is approved.
+    </p>
+  </header>
+
+  <section>
+    <h2>Approval Summary</h2>
+    <div class="grid">
+      <div class="metric">
+        <strong>140</strong>
+        <span>large-batch official menu source URLs seeded for crawl</span>
+      </div>
+      <div class="metric">
+        <strong>129</strong>
+        <span>sources fetched successfully in the latest dry run</span>
+      </div>
+      <div class="metric">
+        <strong>26</strong>
+        <span>candidate price rows exported for review</span>
+      </div>
+      <div class="metric">
+        <strong>5</strong>
+        <span>canonical pub prices approved from official-menu evidence</span>
+      </div>
+    </div>
+
+    <div class="callout ok">
+      <strong>Current recommendation:</strong>
+      approve the code/workflow changes for merge and keep production data writes disabled by default. The first
+      official-menu admin batch has been reviewed: 5 clear rows were approved and 21 ambiguous or duplicate rows were rejected.
+    </div>
+  </section>
+
+  <section>
+    <h2>What You Are Approving</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Area</th>
+          <th>Production-ready change</th>
+          <th>Default safety state</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Source discovery</td>
+          <td>Discovers official menu sources from homepages, resource tags, JSON-LD, PDF/image assets, and menu providers.</td>
+          <td><span class="pill ok">local artifact only</span></td>
+        </tr>
+        <tr>
+          <td>Crawl/extraction</td>
+          <td>Fetches public menu URLs and extracts conservative pint candidates from HTML, rendered HTML, PDFs, tables, and OCR.</td>
+          <td><span class="pill ok">dry-run by default</span></td>
+        </tr>
+        <tr>
+          <td>Noise filters</td>
+          <td>Blocks happy-hour specials, product/shop pages, generic venue images, food combos, cocktails, wine, non-alcoholic beer, unsupported AVIF OCR, and messy false positives found in the live batch.</td>
+          <td><span class="pill ok">tested</span></td>
+        </tr>
+        <tr>
+          <td>Review queue</td>
+          <td>Exports crawl candidates to CSV/JSON with confidence, decision, notes, evidence text, and source URL fields.</td>
+          <td><span class="pill ok">manual review first</span></td>
+        </tr>
+        <tr>
+          <td>Suggested decisions</td>
+          <td>Optional triage mode marks explicit pint/draught/tap evidence as <code>approve_suggested</code> and ambiguous beer-menu rows as <code>needs_manual_review</code>.</td>
+          <td><span class="pill warn">suggestions only</span></td>
+        </tr>
+        <tr>
+          <td>Importer</td>
+          <td>Builds an import plan for approved review rows and can insert pending <code>price_reports</code> only with <code>--write</code> and a service role key.</td>
+          <td><span class="pill ok">dry-run by default</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Latest Dry-run Results</h2>
+    <table>
+      <tbody>
+        <tr>
+          <th>Source crawl</th>
+          <td>140 sources, 129 fetched, 11 failed, 26 candidates, 0 inserts</td>
+        </tr>
+        <tr>
+          <th>Extraction modes used</th>
+          <td>PDF text, PDF OCR, PDF table extraction, raw HTML, rendered HTML, image OCR</td>
+        </tr>
+        <tr>
+          <th>Review triage</th>
+          <td>26 total review rows, 9 <code>approve_suggested</code>, 17 <code>needs_manual_review</code></td>
+        </tr>
+        <tr>
+          <th>Import plan</th>
+          <td>26 reviewed rows were imported as pending reports after explicit approval; admin review approved 5 canonical prices and rejected 21 rows</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>Approved-by-suggestion import plan</h3>
+    <table>
+      <thead>
+        <tr>
+          <th>Venue</th>
+          <th>Price</th>
+          <th>Beer type</th>
+          <th>Evidence</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Otherside Brew Lounge</td>
+          <td>$13</td>
+          <td>GUINNESS</td>
+          <td>GUINNESS Draught $13</td>
+        </tr>
+        <tr>
+          <td>Noble Falls Tavern</td>
+          <td>$13</td>
+          <td>Unknown pint</td>
+          <td>$13 Pint</td>
+        </tr>
+        <tr>
+          <td>Noble Falls Tavern</td>
+          <td>$14</td>
+          <td>Unknown pint</td>
+          <td>$14 Pint</td>
+        </tr>
+        <tr>
+          <td>Noble Falls Tavern</td>
+          <td>$12</td>
+          <td>Unknown pint</td>
+          <td>$12 Pint</td>
+        </tr>
+        <tr>
+          <td>Noble Falls Tavern</td>
+          <td>$15</td>
+          <td>Unknown pint</td>
+          <td>$15 Pint</td>
+        </tr>
+        <tr>
+          <td>Frisk. Small Bar</td>
+          <td>$10</td>
+          <td>Unknown tap beer</td>
+          <td>tap beer 10</td>
+        </tr>
+        <tr>
+          <td>Argyle Social</td>
+          <td>$14</td>
+          <td>GUINNESS</td>
+          <td>GUINNESS DRAUGHT 14</td>
+        </tr>
+        <tr>
+          <td>Argyle Social</td>
+          <td>$10</td>
+          <td>CARLTON</td>
+          <td>CARLTON DRAUGHT 10</td>
+        </tr>
+        <tr>
+          <td>18 Knots Rooftop Bar</td>
+          <td>$10</td>
+          <td>Unknown draught beer</td>
+          <td>DRAUGHT BEER 10</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Workflow Commands</h2>
+    <h3>1. Discover candidate official menu sources</h3>
+    <pre><code>npm run discover:official-menu-sources -- --limit 200 --output scripts/official-menu-source-candidates-large.json</code></pre>
+
+    <h3>2. Build a reviewed seed file</h3>
+    <pre><code>npm run build:official-menu-seeds -- --input scripts/official-menu-source-candidates-large.json --output scripts/official-menu-seeds.large.json --min-score 8 --per-pub 2</code></pre>
+
+    <h3>3. Crawl sources in dry-run mode</h3>
+    <pre><code>npm run crawl:official-menus -- --file scripts/official-menu-seeds.large.json --output scripts/official-menu-crawl-results-large.json</code></pre>
+
+    <h3>4. Export review queue</h3>
+    <pre><code>npm run build:official-menu-review</code></pre>
+
+    <h3>5. Export suggested decisions</h3>
+    <pre><code>npm run build:official-menu-review -- --suggest-decisions --csv-output scripts/official-menu-review.suggested.csv --json-output scripts/official-menu-review.suggested.json</code></pre>
+
+    <h3>6. Build dry-run import plan</h3>
+    <pre><code>npm run import:official-menu-review</code></pre>
+
+    <h3>7. Optional write command after explicit approval</h3>
+    <pre><code>npm run import:official-menu-review -- --write</code></pre>
+    <p class="small">The write path uses <code>SUPABASE_SERVICE_ROLE_KEY</code> by default, checks existing <code>official_menu</code> reports before inserting, and only uses the anon public-insert path when <code>--allow-anon-write</code> is explicitly supplied.</p>
+  </section>
+
+  <section>
+    <h2>Files Added Or Changed</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>File</th>
+          <th>Purpose</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>src/lib/officialMenuExtract.ts</code></td>
+          <td>Candidate extraction, JSON-LD menu items, adjacent price-line handling, and false-positive filters.</td>
+        </tr>
+        <tr>
+          <td><code>src/lib/officialMenuSources.ts</code></td>
+          <td>Official source discovery, scoring, provider/resource extraction, URL dedupe, static/generic/image/product filtering.</td>
+        </tr>
+        <tr>
+          <td><code>scripts/crawl-official-menus.mjs</code></td>
+          <td>Dry-run crawler with PDF extraction, rendered HTML fallback, image/PDF OCR, local artifacts, and guarded write mode.</td>
+        </tr>
+        <tr>
+          <td><code>scripts/discover-official-menu-sources.mjs</code></td>
+          <td>Large-batch source discovery with rendered homepage fallback and local discovery artifact output.</td>
+        </tr>
+        <tr>
+          <td><code>scripts/build-official-menu-seeds.mjs</code></td>
+          <td>Builds high-intent crawler seed files from discovery artifacts.</td>
+        </tr>
+        <tr>
+          <td><code>scripts/build-official-menu-review.mjs</code></td>
+          <td>Exports review CSV/JSON and optional suggested decisions.</td>
+        </tr>
+        <tr>
+          <td><code>scripts/import-official-menu-review.mjs</code></td>
+          <td>Builds dry-run import plans and supports guarded pending-report insertion only with <code>--write</code>.</td>
+        </tr>
+        <tr>
+          <td><code>src/app/api/admin/stats/route.ts</code></td>
+          <td>Returns pending price reports as the admin review queue instead of only the latest 10 reports.</td>
+        </tr>
+        <tr>
+          <td><code>src/app/admin/page.tsx</code></td>
+          <td>Shows official-menu source and evidence fields in the Reports tab for approval review.</td>
+        </tr>
+        <tr>
+          <td><code>src/lib/officialMenuExtract.test.ts</code></td>
+          <td>Regression tests for price extraction, JSON-LD, adjacent prices, mixed beverages, food combos, non-alcoholic beer, and false positives.</td>
+        </tr>
+        <tr>
+          <td><code>src/lib/officialMenuSources.test.ts</code></td>
+          <td>Regression tests for source discovery, dedupe, templates, providers, static assets, AVIF/generic images, bookings, and ecommerce URLs.</td>
+        </tr>
+        <tr>
+          <td><code>package.json</code> and <code>package-lock.json</code></td>
+          <td>Add script commands plus <code>pdf-parse</code> and <code>tesseract.js</code> dev dependencies.</td>
+        </tr>
+        <tr>
+          <td><code>.gitignore</code></td>
+          <td>Ignores generated crawl, review, import, seed, discovery, and OCR cache artifacts.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Production Guardrails</h2>
+    <ul>
+      <li>All crawler, review, and importer scripts default to local/dry-run behavior.</li>
+      <li>No crawler/importer script updates canonical <code>pubs.price</code>; importer creates pending <code>price_reports</code> only after <code>--write</code>, and canonical price updates still go through the admin review path.</li>
+      <li>Official-menu provenance is preserved with <code>submission_source</code>, <code>source_url</code>, <code>evidence_text</code>, <code>observed_at</code>, <code>raw_extraction</code>, and <code>extractor_version</code>.</li>
+      <li>The importer prefers <code>SUPABASE_SERVICE_ROLE_KEY</code> for writes, requires an explicit <code>--allow-anon-write</code> flag for the public insert policy, and checks existing official-menu reports to avoid duplicates.</li>
+      <li>Generated artifacts are ignored by git so crawl output and OCR artifacts do not become source-controlled noise.</li>
+      <li>Internet usage is limited to fetching public venue/menu URLs; parsing, OCR, review, and import planning run locally.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Open-source Research Applied</h2>
+    <p>
+      Research did not find a complete open-source solution for reliable "restaurant URL to normalized pint price"
+      extraction. The implemented workflow follows the recommended layered approach instead:
+    </p>
+    <ul>
+      <li>Use browser rendering for dynamic pages rather than relying only on raw HTML.</li>
+      <li>Use deterministic PDF text/table extraction before OCR.</li>
+      <li>Use OCR as a fallback for image and scanned PDF sources.</li>
+      <li>Keep LLM/service-based tools as later fallbacks, not the default production path.</li>
+      <li>Keep human review between extraction and any database write.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Known Limits</h2>
+    <ul>
+      <li>Many venues publish beer prices without explicitly saying "pint"; these remain <code>needs_manual_review</code>.</li>
+      <li>Some venue URLs 403, 404, timeout, or fail fetch; those are captured in artifacts but not retried automatically yet.</li>
+      <li>OCR can produce messy text; suspicious OCR rows are kept out of auto-approval suggestions.</li>
+      <li>The workflow currently imports pending reports, not direct canonical pub price updates.</li>
+      <li>Crawlee, Docling, OCRmyPDF, PaddleOCR, Firecrawl, and LLM-based extractors are not integrated yet.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Verification</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Check</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>node --check scripts/build-official-menu-review.mjs</code></td>
+          <td><span class="pill ok">passed</span></td>
+        </tr>
+        <tr>
+          <td><code>node --check scripts/import-official-menu-review.mjs</code></td>
+          <td><span class="pill ok">passed</span></td>
+        </tr>
+        <tr>
+          <td><code>npm test</code></td>
+          <td><span class="pill ok">246/246 passed</span></td>
+        </tr>
+        <tr>
+          <td><code>npx tsc --noEmit</code></td>
+          <td><span class="pill ok">passed</span></td>
+        </tr>
+        <tr>
+          <td>Large crawl dry run</td>
+          <td><span class="pill ok">140 sources, 26 candidates, 0 inserts</span></td>
+        </tr>
+        <tr>
+          <td>Review/import dry run</td>
+          <td><span class="pill ok">26 pending reports reviewed: 5 approved, 21 rejected</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Approval Gates</h2>
+    <div class="callout warn">
+      <p><strong>Gate 1: merge approval.</strong> Approve the code and local workflow changes.</p>
+      <p><strong>Gate 2: admin report approval.</strong> Complete — 5 <code>official_menu</code> reports approved and 21 rejected through the normal review path.</p>
+      <p><strong>Gate 3: scale approval.</strong> Approve running discovery/crawl over the full missing-price venue set after reviewing this first batch.</p>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,8 +39,10 @@
         "dotenv": "^17.4.2",
         "eslint": "^8.57.1",
         "eslint-config-next": "^14.2.35",
+        "pdf-parse": "^2.4.5",
         "postcss": "^8.5.15",
         "tailwindcss": "^3.4.3",
+        "tesseract.js": "^7.0.0",
         "tsx": "^4.22.4",
         "typescript": "^5.4.5"
       }
@@ -726,6 +728,216 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+      "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-x64": "0.1.80",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.80",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+      "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+      "integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+      "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+      "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+      "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+      "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+      "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+      "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+      "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+      "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3845,6 +4057,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/bn.js": {
       "version": "4.12.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
@@ -5702,6 +5921,13 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.4.tgz",
+      "integrity": "sha512-D/NzHWUmYJGXi++z67aMSrnisb9A3621CyRK5G89JyTlN13C8xf0g04DLxUKMufPem3e3L2JAXR6Z00OWy183Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6155,6 +6381,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
@@ -6786,6 +7019,27 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.46",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
@@ -6966,6 +7220,16 @@
         }
       }
     },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7098,6 +7362,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pdf-parse": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+      "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@napi-rs/canvas": "0.1.80",
+        "pdfjs-dist": "5.4.296"
+      },
+      "bin": {
+        "pdf-parse": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0 <21 || >=22.3.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
       }
     },
     "node_modules/picocolors": {
@@ -7692,6 +7990,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -8489,6 +8794,32 @@
         "tailwindcss": ">=3.0.0 || insiders"
       }
     },
+    "node_modules/tesseract.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
+      "integrity": "sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^7.0.0",
+        "wasm-feature-detect": "^1.8.0",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz",
+      "integrity": "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -8573,6 +8904,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -8965,6 +9303,13 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/web-push": {
       "version": "3.6.7",
       "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
@@ -8982,6 +9327,24 @@
       },
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -9227,6 +9590,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "test": "tsx --test \"src/**/*.test.ts\"",
     "crawl:official-menus": "tsx scripts/crawl-official-menus.mjs",
     "discover:official-menu-sources": "tsx scripts/discover-official-menu-sources.mjs",
+    "build:official-menu-seeds": "tsx scripts/build-official-menu-seeds.mjs",
+    "build:official-menu-review": "tsx scripts/build-official-menu-review.mjs",
+    "import:official-menu-review": "tsx scripts/import-official-menu-review.mjs",
     "test:redirects": "node scripts/redirect-seo.test.mjs",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
@@ -47,8 +50,10 @@
     "dotenv": "^17.4.2",
     "eslint": "^8.57.1",
     "eslint-config-next": "^14.2.35",
+    "pdf-parse": "^2.4.5",
     "postcss": "^8.5.15",
     "tailwindcss": "^3.4.3",
+    "tesseract.js": "^7.0.0",
     "tsx": "^4.22.4",
     "typescript": "^5.4.5"
   }

--- a/scripts/build-official-menu-review.mjs
+++ b/scripts/build-official-menu-review.mjs
@@ -38,9 +38,11 @@ for (const result of artifact.results) {
       price: candidate.price,
       beer_type: beerType,
       evidence_text: candidate.evidenceText,
-      source_url: result.url,
-      source_kind: result.source_kind || '',
-      extraction_modes: (result.extraction_modes || []).join('|'),
+      source_url: candidate.source_url || result.url,
+      source_kind: candidate.source_kind || result.source_kind || '',
+      extraction_modes: candidate.extraction_modes
+        ? candidate.extraction_modes.join('|')
+        : (result.extraction_modes || []).join('|'),
       confidence,
       decision: suggestion.decision,
       notes: suggestion.notes,

--- a/scripts/build-official-menu-review.mjs
+++ b/scripts/build-official-menu-review.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Build a local review queue from an official menu crawl artifact.
+ *
+ * This helper only reads and writes local files. It does not fetch sources,
+ * insert price_reports, or update pubs.
+ *
+ * Usage:
+ *   npm run build:official-menu-review
+ *   npm run build:official-menu-review -- --input scripts/official-menu-crawl-results-large.json
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const args = process.argv.slice(2)
+const input = arg('--input') || 'scripts/official-menu-crawl-results-large.json'
+const csvOutput = arg('--csv-output') || 'scripts/official-menu-review.csv'
+const jsonOutput = arg('--json-output') || 'scripts/official-menu-review.json'
+const suggestDecisions = args.includes('--suggest-decisions')
+
+const artifact = JSON.parse(readFileSync(input, 'utf8'))
+if (!Array.isArray(artifact.results)) {
+  throw new Error(`${input} must contain a crawl "results" array`)
+}
+
+const rows = []
+
+for (const result of artifact.results) {
+  for (const candidate of result.candidates || []) {
+    const beerType = cleanBeerType(candidate.beerType, candidate.price)
+    const confidence = confidenceFor(candidate.evidenceText)
+    const suggestion = suggestDecisions
+      ? decisionSuggestion(candidate.evidenceText, confidence, beerType)
+      : { decision: '', notes: '' }
+
+    rows.push({
+      pub_slug: result.pub_slug,
+      pub_name: result.pub_name || '',
+      price: candidate.price,
+      beer_type: beerType,
+      evidence_text: candidate.evidenceText,
+      source_url: result.url,
+      source_kind: result.source_kind || '',
+      extraction_modes: (result.extraction_modes || []).join('|'),
+      confidence,
+      decision: suggestion.decision,
+      notes: suggestion.notes,
+    })
+  }
+}
+
+writeFileSync(jsonOutput, JSON.stringify({ generated_at: new Date().toISOString(), input, rows }, null, 2))
+writeFileSync(csvOutput, toCsv(rows))
+
+console.log(`Input: ${input}`)
+console.log(`CSV output: ${csvOutput}`)
+console.log(`JSON output: ${jsonOutput}`)
+console.log(`Review rows: ${rows.length}`)
+console.log(`Suggested decisions: ${suggestDecisions ? 'enabled' : 'disabled'}`)
+
+function confidenceFor(evidenceText) {
+  if (/\bpints?\b/i.test(evidenceText)) return 'strong'
+  if (/\b(draught|draft|tap\s*beer)\b/i.test(evidenceText)) return 'strong'
+  return 'review'
+}
+
+function cleanBeerType(beerType, price) {
+  const text = typeof beerType === 'string' ? beerType.trim() : ''
+  if (!text) return ''
+  if (text === String(price) || text === `$${price}`) return ''
+  if (/^\$?\d{1,2}(?:\.\d{1,2})?$/.test(text)) return ''
+  return text
+}
+
+function decisionSuggestion(evidenceText, confidence, beerType) {
+  if (/[\\()]{2,}/.test(evidenceText)) {
+    return {
+      decision: 'needs_manual_review',
+      notes: 'OCR/text extraction is messy; verify source menu before using.',
+    }
+  }
+
+  if (confidence === 'strong') {
+    return {
+      decision: 'approve_suggested',
+      notes: beerType ? 'Explicit pint/draught/tap evidence.' : 'Explicit pint/draught/tap evidence; beer type unknown.',
+    }
+  }
+
+  return {
+    decision: 'needs_manual_review',
+    notes: 'Beer/cider price found on official menu source, but size is not explicit in the evidence line.',
+  }
+}
+
+function toCsv(rows) {
+  const headers = [
+    'pub_slug',
+    'pub_name',
+    'price',
+    'beer_type',
+    'evidence_text',
+    'source_url',
+    'source_kind',
+    'extraction_modes',
+    'confidence',
+    'decision',
+    'notes',
+  ]
+
+  return [
+    headers.join(','),
+    ...rows.map((row) => headers.map((header) => csvValue(row[header])).join(',')),
+  ].join('\n') + '\n'
+}
+
+function csvValue(value) {
+  const text = value === null || value === undefined ? '' : String(value)
+  return `"${text.replace(/"/g, '""')}"`
+}
+
+function arg(flag) {
+  const index = args.indexOf(flag)
+  return index >= 0 ? args[index + 1] : null
+}

--- a/scripts/build-official-menu-seeds.mjs
+++ b/scripts/build-official-menu-seeds.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Build a crawler seed file from a reviewed discovery artifact.
+ *
+ * This is a local review helper only: it reads JSON and writes JSON. It does
+ * not fetch sources, insert price_reports, or update pubs.
+ *
+ * Usage:
+ *   npm run build:official-menu-seeds -- --input scripts/official-menu-source-candidates.json --output scripts/official-menu-seeds.large.json
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const args = process.argv.slice(2)
+const input = arg('--input') || 'scripts/official-menu-source-candidates.json'
+const output = arg('--output') || 'scripts/official-menu-seeds.generated.json'
+const minScore = Number.parseInt(arg('--min-score') || '5', 10)
+const perPub = Number.parseInt(arg('--per-pub') || '2', 10)
+const includeImages = !args.includes('--no-images')
+const IMAGE_SOURCE_RE = /\b(tap[-\s]?list|wine-list|bar-menu|drink[-\s]?menu|drinks[-\s]?menu|menu|menus)\b/i
+const IMAGE_ASSET_RE = /\.(png|jpe?g|webp|avif)(?:[?#].*)?$/i
+const UNSUPPORTED_IMAGE_RE = /\.avif(?:[?#].*)?$/i
+const LOW_INTENT_URL_RE = /\b(shop|products?|product-category|cart|checkout|giftcards?|gift[-\s]?cards?)\b/i
+
+const artifact = JSON.parse(readFileSync(input, 'utf8'))
+if (!Array.isArray(artifact.results)) {
+  throw new Error(`${input} must contain a discovery "results" array`)
+}
+
+const sources = []
+
+for (const result of artifact.results) {
+  const candidates = (result.candidates || [])
+    .filter((candidate) => isSeedCandidate(candidate))
+    .sort((a, b) => b.score - a.score || a.url.localeCompare(b.url))
+    .slice(0, perPub)
+
+  for (const candidate of candidates) {
+    sources.push({
+      pub_slug: result.pub_slug,
+      url: candidate.url,
+      label: `discovered ${candidate.type} source: ${(candidate.reasons || []).join(', ')}`,
+    })
+  }
+}
+
+writeFileSync(output, JSON.stringify({ sources }, null, 2))
+
+console.log(`Input: ${input}`)
+console.log(`Output: ${output}`)
+console.log(`Sources: ${sources.length}`)
+console.log(`Filters: min score ${minScore}, max ${perPub} per pub, images ${includeImages ? 'included' : 'excluded'}`)
+
+function isSeedCandidate(candidate) {
+  if (!candidate || !candidate.url) return false
+  if ((candidate.score || 0) < minScore) return false
+  if ((candidate.reasons || []).includes('low-intent')) return false
+  if (LOW_INTENT_URL_RE.test(candidate.url)) return false
+  if (UNSUPPORTED_IMAGE_RE.test(candidate.url)) return false
+  if (IMAGE_ASSET_RE.test(candidate.url) && !IMAGE_SOURCE_RE.test(candidate.url)) return false
+  if (candidate.type === 'image' && (!includeImages || !IMAGE_SOURCE_RE.test(candidate.url))) return false
+  return candidate.type === 'html' || candidate.type === 'pdf' || candidate.type === 'image'
+}
+
+function arg(flag) {
+  const index = args.indexOf(flag)
+  return index >= 0 ? args[index + 1] : null
+}

--- a/scripts/crawl-official-menus.mjs
+++ b/scripts/crawl-official-menus.mjs
@@ -108,7 +108,12 @@ for (const source of selectedSources) {
     result.extraction_modes = extraction.extractionModes
     if (extraction.renderError) result.render_error = extraction.renderError
 
-    let candidates = extraction.candidates
+    let candidates = withCandidateSource(
+      extraction.candidates,
+      source.url,
+      extraction.sourceText.kind,
+      extraction.extractionModes,
+    )
 
     if (followLinks && extraction.sourceText.kind === 'html') {
       const linkedSources = discoverLinkedSources(extraction, source.url, linkedSourceLimit)
@@ -131,8 +136,14 @@ for (const source of selectedSources) {
           linkedResult.source_kind = linkedExtraction.sourceText.kind
           linkedResult.extraction_modes = linkedExtraction.extractionModes
           if (linkedExtraction.renderError) linkedResult.render_error = linkedExtraction.renderError
-          linkedResult.candidates = linkedExtraction.candidates
-          candidates = mergeCandidates(candidates, linkedExtraction.candidates, maxCandidates)
+          const linkedCandidates = withCandidateSource(
+            linkedExtraction.candidates,
+            linkedSource.url,
+            linkedExtraction.sourceText.kind,
+            linkedExtraction.extractionModes,
+          )
+          linkedResult.candidates = linkedCandidates
+          candidates = mergeCandidates(candidates, linkedCandidates, maxCandidates)
         } catch (linkedErr) {
           linkedFailed++
           linkedResult.error = linkedErr instanceof Error ? linkedErr.message : String(linkedErr)
@@ -469,6 +480,15 @@ function mergeCandidates(existing, next, limit) {
   }
 
   return Array.from(byKey.values()).slice(0, limit)
+}
+
+function withCandidateSource(candidates, sourceUrl, sourceKind, extractionModes) {
+  return candidates.map((candidate) => ({
+    ...candidate,
+    source_url: sourceUrl,
+    source_kind: sourceKind,
+    extraction_modes: extractionModes,
+  }))
 }
 
 function canonicalSourceKey(url) {

--- a/scripts/crawl-official-menus.mjs
+++ b/scripts/crawl-official-menus.mjs
@@ -6,13 +6,17 @@
  * local seed file, add reviewed official URLs, then run:
  *
  *   npm run crawl:official-menus -- --file scripts/official-menu-seeds.json
+ *   npm run crawl:official-menus -- --file scripts/official-menu-seeds.json --output /tmp/menu-crawl.json
+ *   npm run crawl:official-menus -- --file scripts/official-menu-seeds.json --render-all
+ *   npm run crawl:official-menus -- --file scripts/official-menu-seeds.json --follow-links
  *   npm run crawl:official-menus -- --file scripts/official-menu-seeds.json --write
  */
 import { createClient } from '@supabase/supabase-js'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { config } from 'dotenv'
 
 import { extractOfficialMenuCandidates } from '../src/lib/officialMenuExtract.ts'
+import { discoverOfficialMenuSources } from '../src/lib/officialMenuSources.ts'
 
 config({ path: '.env.local' })
 
@@ -24,8 +28,17 @@ const SUPABASE_ANON_KEY =
 const args = process.argv.slice(2)
 const shouldWrite = args.includes('--write')
 const dryRun = !shouldWrite
+const renderEnabled = !args.includes('--no-render')
+const renderAll = args.includes('--render-all')
+const ocrEnabled = !args.includes('--no-ocr')
+const pdfOcrEnabled = ocrEnabled && !args.includes('--no-pdf-ocr')
+const followLinks = args.includes('--follow-links')
+const linkedSourceLimit = Number.parseInt(arg('--linked-source-limit') || '3', 10)
 const seedFile = arg('--file') || 'scripts/official-menu-seeds.json'
+const output = arg('--output') || 'scripts/official-menu-crawl-results.json'
 const limit = Number.parseInt(arg('--limit') || '0', 10) || null
+let ocrWorker = null
+let renderBrowser = null
 
 if (!existsSync(seedFile)) {
   console.error(`Seed file not found: ${seedFile}`)
@@ -49,14 +62,28 @@ const sources = loadSources(seedFile)
 const selectedSources = limit ? sources.slice(0, limit) : sources
 console.log(`${selectedSources.length} official menu source${selectedSources.length === 1 ? '' : 's'}`)
 console.log(dryRun ? 'Mode: dry run (no writes)\n' : 'Mode: write pending price_reports\n')
+console.log(`Rendered HTML fallback: ${renderEnabled ? (renderAll ? 'all HTML sources' : 'zero-candidate HTML only') : 'disabled'}`)
+console.log(`Image OCR: ${ocrEnabled ? 'enabled' : 'disabled'}`)
+console.log(`Scanned PDF OCR fallback: ${pdfOcrEnabled ? 'enabled' : 'disabled'}`)
+console.log(`Linked source crawl: ${followLinks ? `enabled (${linkedSourceLimit} per HTML source)` : 'disabled'}`)
+console.log(`Output: ${output}\n`)
 
 let fetched = 0
+let linkedFetched = 0
+let linkedFailed = 0
 let inserted = 0
 let found = 0
 let failed = 0
+const results = []
 
 for (const source of selectedSources) {
   process.stdout.write(`${source.pub_slug} ${source.url} ... `)
+  const result = {
+    pub_slug: source.pub_slug,
+    url: source.url,
+    label: source.label || null,
+    candidates: [],
+  }
 
   try {
     const { data: pub, error: pubErr } = await supabase
@@ -67,13 +94,57 @@ for (const source of selectedSources) {
 
     if (pubErr || !pub) {
       failed++
+      result.error = 'no pub found'
       console.log(`no pub found`)
+      results.push(result)
       continue
     }
 
-    const html = await fetchText(source.url)
+    const maxCandidates = source.max_candidates || 5
+    const extraction = await extractFromSource(source.url, maxCandidates)
     fetched++
-    const candidates = extractOfficialMenuCandidates(html, source.max_candidates || 5)
+    result.content_type = extraction.sourceText.contentType || null
+    result.source_kind = extraction.sourceText.kind
+    result.extraction_modes = extraction.extractionModes
+    if (extraction.renderError) result.render_error = extraction.renderError
+
+    let candidates = extraction.candidates
+
+    if (followLinks && extraction.sourceText.kind === 'html') {
+      const linkedSources = discoverLinkedSources(extraction, source.url, linkedSourceLimit)
+      result.linked_sources = []
+
+      for (const linkedSource of linkedSources) {
+        const linkedResult = {
+          url: linkedSource.url,
+          label: linkedSource.label,
+          type: linkedSource.type,
+          score: linkedSource.score,
+          reasons: linkedSource.reasons,
+          candidates: [],
+        }
+
+        try {
+          const linkedExtraction = await extractFromSource(linkedSource.url, maxCandidates)
+          linkedFetched++
+          linkedResult.content_type = linkedExtraction.sourceText.contentType || null
+          linkedResult.source_kind = linkedExtraction.sourceText.kind
+          linkedResult.extraction_modes = linkedExtraction.extractionModes
+          if (linkedExtraction.renderError) linkedResult.render_error = linkedExtraction.renderError
+          linkedResult.candidates = linkedExtraction.candidates
+          candidates = mergeCandidates(candidates, linkedExtraction.candidates, maxCandidates)
+        } catch (linkedErr) {
+          linkedFailed++
+          linkedResult.error = linkedErr instanceof Error ? linkedErr.message : String(linkedErr)
+        }
+
+        result.linked_sources.push(linkedResult)
+        await sleep(100)
+      }
+    }
+
+    result.pub_name = pub.name
+    result.candidates = candidates
     found += candidates.length
     console.log(`${candidates.length} candidate${candidates.length === 1 ? '' : 's'}`)
 
@@ -104,24 +175,52 @@ for (const source of selectedSources) {
       const { error: insertErr } = await supabase.from('price_reports').insert(rows)
       if (insertErr) {
         failed++
+        result.error = `insert failed: ${insertErr.message}`
         console.log(`  ! insert failed: ${insertErr.message}`)
       } else {
         inserted += rows.length
+        result.inserted = rows.length
       }
     }
   } catch (err) {
     failed++
+    result.error = err instanceof Error ? err.message : String(err)
     console.log(`error: ${err instanceof Error ? err.message : String(err)}`)
   }
 
+  results.push(result)
   await sleep(150)
 }
 
+const artifact = {
+  generated_at: new Date().toISOString(),
+  mode: dryRun ? 'dry_run' : 'write',
+  seed_file: seedFile,
+  summary: {
+    sources: selectedSources.length,
+    fetched,
+    linked_fetched: linkedFetched,
+    linked_failed: linkedFailed,
+    candidate_count: found,
+    inserted,
+    failed,
+  },
+  results,
+}
+
+writeFileSync(output, JSON.stringify(artifact, null, 2))
+
+await closeRenderBrowser()
+await closeOcrWorker()
+
 console.log('\n=== Official menu crawl summary ===')
 console.log(`Fetched: ${fetched}`)
+console.log(`Linked fetched: ${linkedFetched}`)
+console.log(`Linked failed: ${linkedFailed}`)
 console.log(`Candidates found: ${found}`)
 console.log(`Inserted pending reports: ${inserted}`)
 console.log(`Failed sources: ${failed}`)
+console.log(`Written: ${output}`)
 console.log(dryRun ? '(dry run - no writes)' : 'Write complete')
 
 function arg(flag) {
@@ -144,20 +243,240 @@ function loadSources(path) {
   })
 }
 
-async function fetchText(url) {
+async function fetchSourceText(url) {
   const response = await fetch(url, {
     headers: {
       'user-agent': 'PerthPintPricesBot/1.0 (+https://perthpintprices.com)',
-      accept: 'text/html, text/plain;q=0.9, */*;q=0.5',
+      accept: 'text/html, application/pdf, image/*, text/plain;q=0.9, */*;q=0.5',
     },
-    signal: AbortSignal.timeout(12000),
+    signal: AbortSignal.timeout(30000),
   })
 
   if (!response.ok) {
     throw new Error(`HTTP ${response.status}`)
   }
 
-  return response.text()
+  const contentType = response.headers.get('content-type') || ''
+
+  if (isPdfSource(url, contentType)) {
+    const pdf = await pdfToText(Buffer.from(await response.arrayBuffer()))
+    return {
+      text: pdf.text,
+      kind: 'pdf',
+      contentType,
+      modes: pdf.modes,
+    }
+  }
+
+  if (isImageSource(url, contentType)) {
+    if (!ocrEnabled) {
+      return { text: '', kind: 'image', contentType, modes: ['image-ocr-disabled'] }
+    }
+
+    if (!isSupportedOcrImageSource(url, contentType)) {
+      return { text: '', kind: 'image', contentType, modes: ['image-ocr-unsupported'] }
+    }
+
+    try {
+      return {
+        text: await imageToText(Buffer.from(await response.arrayBuffer())),
+        kind: 'image',
+        contentType,
+        modes: ['image-ocr'],
+      }
+    } catch {
+      return { text: '', kind: 'image', contentType, modes: ['image-ocr-error'] }
+    }
+  }
+
+  const html = await response.text()
+  return {
+    text: html,
+    html,
+    kind: 'html',
+    contentType,
+    modes: ['raw-html'],
+  }
+}
+
+function isPdfSource(url, contentType) {
+  return /\.pdf(?:[?#].*)?$/i.test(url) || /application\/pdf/i.test(contentType || '')
+}
+
+function isImageSource(url, contentType) {
+  return /\.(png|jpe?g|webp|avif)(?:[?#].*)?$/i.test(url) || /^image\//i.test(contentType || '')
+}
+
+function isSupportedOcrImageSource(url, contentType) {
+  return /\.(png|jpe?g|webp)(?:[?#].*)?$/i.test(url) || /^image\/(?:png|jpe?g|webp)\b/i.test(contentType || '')
+}
+
+async function extractFromSource(url, maxCandidates) {
+  const sourceText = await fetchSourceText(url)
+  const extractionModes = [...sourceText.modes]
+  let candidates = extractOfficialMenuCandidates(sourceText.text, maxCandidates)
+  let renderedHtml = ''
+  let renderError = null
+
+  if (renderEnabled && sourceText.kind === 'html' && (renderAll || candidates.length === 0)) {
+    const renderResult = await renderPageText(url)
+    if (renderResult.error) {
+      renderError = renderResult.error
+    }
+
+    if (renderResult.text || renderResult.html) {
+      renderedHtml = renderResult.html
+      extractionModes.push('rendered-html')
+      candidates = mergeCandidates(
+        candidates,
+        extractOfficialMenuCandidates(`${renderResult.html}\n${renderResult.text}`, maxCandidates),
+        maxCandidates,
+      )
+    }
+  }
+
+  return {
+    sourceText,
+    extractionModes,
+    candidates,
+    renderedHtml,
+    renderError,
+  }
+}
+
+function discoverLinkedSources(extraction, baseUrl, limit) {
+  const html = [extraction.sourceText.html, extraction.renderedHtml].filter(Boolean).join('\n')
+  if (!html) return []
+
+  const sourceKey = canonicalSourceKey(baseUrl)
+  return discoverOfficialMenuSources(html, baseUrl, limit)
+    .filter((source) => canonicalSourceKey(source.url) !== sourceKey)
+}
+
+async function pdfToText(buffer) {
+  const { PDFParse } = await import('pdf-parse')
+  const parser = new PDFParse({ data: buffer })
+  const modes = ['pdf-text']
+
+  try {
+    const textResult = await parser.getText({
+      cellSeparator: ' ',
+      pageJoiner: '\n',
+    })
+    const parts = [textResult.text]
+
+    const tableText = await pdfTablesToText(parser)
+    if (tableText) {
+      modes.push('pdf-table')
+      parts.push(tableText)
+    }
+
+    if (pdfOcrEnabled && extractOfficialMenuCandidates(parts.join('\n'), 1).length === 0) {
+      const ocrText = await pdfScreenshotOcr(parser)
+      if (ocrText) {
+        modes.push('pdf-ocr')
+        parts.push(ocrText)
+      }
+    }
+
+    return { text: parts.filter(Boolean).join('\n'), modes }
+  } finally {
+    await parser.destroy()
+  }
+}
+async function pdfTablesToText(parser) {
+  try {
+    const tableResult = await parser.getTable()
+    return tableResult.pages
+      .flatMap((page) => page.tables)
+      .flatMap((table) => table)
+      .map((row) => row.map((cell) => cell.replace(/\s+/g, ' ').trim()).filter(Boolean).join(' '))
+      .filter(Boolean)
+      .join('\n')
+  } catch {
+    return ''
+  }
+}
+
+async function pdfScreenshotOcr(parser) {
+  try {
+    const screenshotResult = await parser.getScreenshot({
+      first: 2,
+      desiredWidth: 1600,
+      imageDataUrl: false,
+      imageBuffer: true,
+    })
+
+    const pages = []
+    for (const page of screenshotResult.pages) {
+      pages.push(await imageToText(Buffer.from(page.data)))
+    }
+
+    return pages.join('\n')
+  } catch {
+    return ''
+  }
+}
+
+async function imageToText(buffer) {
+  const { createWorker } = await import('tesseract.js')
+  mkdirSync('.cache/tesseract', { recursive: true })
+  ocrWorker ||= await createWorker('eng', 1, { cachePath: '.cache/tesseract' })
+  const result = await ocrWorker.recognize(buffer)
+  return result.data.text
+}
+
+async function closeOcrWorker() {
+  if (!ocrWorker) return
+  await ocrWorker.terminate()
+  ocrWorker = null
+}
+
+async function renderPageText(url) {
+  let page = null
+
+  try {
+    const { chromium } = await import('playwright')
+    renderBrowser ||= await chromium.launch({ headless: true })
+    page = await renderBrowser.newPage({
+      userAgent: 'PerthPintPricesBot/1.0 (+https://perthpintprices.com)',
+    })
+
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 })
+    await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {})
+    const text = await page.locator('body').innerText({ timeout: 5000 })
+    const html = await page.content()
+    return { text, html, error: null }
+  } catch (err) {
+    return { text: '', html: '', error: err instanceof Error ? err.message : String(err) }
+  } finally {
+    if (page && !page.isClosed()) await page.close().catch(() => {})
+  }
+}
+
+async function closeRenderBrowser() {
+  if (!renderBrowser) return
+  await renderBrowser.close()
+  renderBrowser = null
+}
+
+function mergeCandidates(existing, next, limit) {
+  const byKey = new Map()
+
+  for (const candidate of [...existing, ...next]) {
+    const key = `${candidate.beerType || 'pint'}:${candidate.price}:${candidate.evidenceText.toLowerCase()}`
+    if (!byKey.has(key)) byKey.set(key, candidate)
+  }
+
+  return Array.from(byKey.values()).slice(0, limit)
+}
+
+function canonicalSourceKey(url) {
+  const parsed = new URL(url)
+  if (parsed.pathname.length > 1) {
+    parsed.pathname = parsed.pathname.replace(/\/+$/, '')
+  }
+  return parsed.toString()
 }
 
 function sleep(ms) {

--- a/scripts/discover-official-menu-sources.mjs
+++ b/scripts/discover-official-menu-sources.mjs
@@ -8,6 +8,8 @@
  * Usage:
  *   npm run discover:official-menu-sources -- --limit 25
  *   npm run discover:official-menu-sources -- --include-priced --output /tmp/sources.json
+ *   npm run discover:official-menu-sources -- --limit 100 --render-all
+ *   npm run discover:official-menu-sources -- --limit 200 --seed-output /tmp/seeds.json
  */
 import { createClient } from '@supabase/supabase-js'
 import { writeFileSync } from 'node:fs'
@@ -24,8 +26,13 @@ const SUPABASE_ANON_KEY =
 
 const args = process.argv.slice(2)
 const limit = Number.parseInt(arg('--limit') || '50', 10)
+const perPubLimit = Number.parseInt(arg('--per-pub-limit') || '5', 10)
 const includePriced = args.includes('--include-priced')
+const renderEnabled = !args.includes('--no-render')
+const renderAll = args.includes('--render-all')
 const output = arg('--output') || 'scripts/official-menu-source-candidates.json'
+const seedOutput = arg('--seed-output')
+let renderBrowser = null
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, { auth: { persistSession: false } })
 
@@ -46,7 +53,9 @@ if (error) throw error
 
 console.log(`${pubs.length} pub website${pubs.length === 1 ? '' : 's'} to inspect`)
 console.log(includePriced ? 'Scope: all pubs with websites' : 'Scope: missing regular prices only')
+console.log(`Rendered homepage fallback: ${renderEnabled ? (renderAll ? 'all fetched sites' : 'zero-candidate sites only') : 'disabled'}`)
 console.log(`Output: ${output}\n`)
+if (seedOutput) console.log(`Seed output: ${seedOutput}\n`)
 
 const results = []
 let fetched = 0
@@ -59,7 +68,25 @@ for (let i = 0; i < pubs.length; i++) {
 
   try {
     const html = await fetchText(pub.website)
-    const candidates = discoverOfficialMenuSources(html, pub.website, 5)
+    let candidates = discoverOfficialMenuSources(html, pub.website, perPubLimit)
+    const discoveryModes = ['raw-html']
+    let renderError = null
+
+    if (renderEnabled && (renderAll || candidates.length === 0)) {
+      const renderResult = await renderHtml(pub.website)
+      if (renderResult.error) {
+        renderError = renderResult.error
+      }
+      if (renderResult.html) {
+        discoveryModes.push('rendered-html')
+        candidates = mergeCandidates(
+          candidates,
+          discoverOfficialMenuSources(renderResult.html, pub.website, perPubLimit),
+          perPubLimit,
+        )
+      }
+    }
+
     fetched++
     candidateCount += candidates.length
     results.push({
@@ -68,6 +95,8 @@ for (let i = 0; i < pubs.length; i++) {
       suburb: pub.suburb,
       website: pub.website,
       candidate_count: candidates.length,
+      discovery_modes: discoveryModes,
+      ...(renderError ? { render_error: renderError } : {}),
       candidates,
     })
     console.log(`${candidates.length} candidate${candidates.length === 1 ? '' : 's'}`)
@@ -101,11 +130,32 @@ const artifact = {
 
 writeFileSync(output, JSON.stringify(artifact, null, 2))
 
+if (seedOutput) {
+  const seedArtifact = {
+    generated_at: artifact.generated_at,
+    source_artifact: output,
+    sources: results.flatMap((result) =>
+      result.candidates.map((candidate) => ({
+        pub_slug: result.pub_slug,
+        url: candidate.url,
+        label: candidate.label || `discovered ${candidate.type} menu source`,
+        source_score: candidate.score,
+        source_reasons: candidate.reasons,
+      })),
+    ),
+  }
+
+  writeFileSync(seedOutput, JSON.stringify(seedArtifact, null, 2))
+}
+
+await closeRenderBrowser()
+
 console.log('\n=== Official menu source discovery ===')
 console.log(`Fetched: ${fetched}`)
 console.log(`Failed: ${failed}`)
 console.log(`Candidates: ${candidateCount}`)
 console.log(`Written: ${output}`)
+if (seedOutput) console.log(`Seed written: ${seedOutput}`)
 
 function arg(flag) {
   const index = args.indexOf(flag)
@@ -130,4 +180,52 @@ async function fetchText(url) {
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function renderHtml(url) {
+  let page = null
+
+  try {
+    const { chromium } = await import('playwright')
+    renderBrowser ||= await chromium.launch({ headless: true })
+    page = await renderBrowser.newPage({
+      userAgent: 'PerthPintPricesBot/1.0 (+https://perthpintprices.com)',
+    })
+
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 })
+    await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {})
+    return { html: await page.content(), error: null }
+  } catch (err) {
+    return { html: '', error: err instanceof Error ? err.message : String(err) }
+  } finally {
+    if (page && !page.isClosed()) await page.close().catch(() => {})
+  }
+}
+
+async function closeRenderBrowser() {
+  if (!renderBrowser) return
+  await renderBrowser.close()
+  renderBrowser = null
+}
+
+function mergeCandidates(existing, next, limit) {
+  const byUrl = new Map()
+
+  for (const candidate of [...existing, ...next]) {
+    const key = canonicalSourceKey(candidate.url)
+    const current = byUrl.get(key)
+    if (!current || candidate.score > current.score) byUrl.set(key, candidate)
+  }
+
+  return Array.from(byUrl.values())
+    .sort((a, b) => b.score - a.score || a.url.localeCompare(b.url))
+    .slice(0, limit)
+}
+
+function canonicalSourceKey(url) {
+  const parsed = new URL(url)
+  if (parsed.pathname.length > 1) {
+    parsed.pathname = parsed.pathname.replace(/\/+$/, '')
+  }
+  return parsed.toString()
 }

--- a/scripts/import-official-menu-review.mjs
+++ b/scripts/import-official-menu-review.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Import approved official-menu review rows as pending price_reports.
+ *
+ * Default mode is dry-run: it writes a local import plan and does not touch
+ * Supabase. Use --write only after reviewing the plan.
+ *
+ * Usage:
+ *   npm run import:official-menu-review
+ *   npm run import:official-menu-review -- --file scripts/official-menu-review.suggested.json --write
+ */
+import { createClient } from '@supabase/supabase-js'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { config } from 'dotenv'
+
+config({ path: '.env.local' })
+
+const IMPORTER_VERSION = 'official-menu-review-import-v1'
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://ifxkoblvgttelzboenpi.supabase.co'
+const SUPABASE_ANON_KEY =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlmeGtvYmx2Z3R0ZWx6Ym9lbnBpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzExODUwNjgsImV4cCI6MjA4Njc2MTA2OH0.qLy6B-VeVnMh0QSOxHK3uQEJ6iZr6xNHmfKov_7B-fY'
+const args = process.argv.slice(2)
+const shouldWrite = args.includes('--write')
+const allowAnonWrite = args.includes('--allow-anon-write')
+const reviewFile = arg('--file') || 'scripts/official-menu-review.suggested.json'
+const output = arg('--output') || 'scripts/official-menu-import-plan.json'
+const decision = arg('--decision') || 'approve_suggested'
+
+const review = JSON.parse(readFileSync(reviewFile, 'utf8'))
+if (!Array.isArray(review.rows)) {
+  throw new Error(`${reviewFile} must contain a review "rows" array`)
+}
+
+const approvedRows = review.rows
+  .filter((row) => decision === 'all' || row.decision === decision)
+  .filter(isImportableReviewRow)
+
+const observedAt = new Date().toISOString()
+const plannedRows = approvedRows.map((row) => toPriceReportRow(row, observedAt))
+let existingRows = []
+let insertRows = plannedRows
+let inserted = 0
+let writeKeyMode = 'none'
+
+if (shouldWrite) {
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  const writeKey = serviceKey || (allowAnonWrite ? SUPABASE_ANON_KEY : null)
+  writeKeyMode = serviceKey ? 'service_role' : 'anon'
+  if (!writeKey) {
+    throw new Error('SUPABASE_SERVICE_ROLE_KEY is required when using --write, unless --allow-anon-write is provided')
+  }
+
+  const supabase = createClient(SUPABASE_URL, writeKey, { auth: { persistSession: false } })
+  const { data: existing, error: existingErr } = await supabase
+    .from('price_reports')
+    .select('id, pub_slug, reported_price, source_url, evidence_text')
+    .eq('submission_source', 'official_menu')
+
+  if (existingErr) {
+    throw new Error(`existing report lookup failed: ${existingErr.message}`)
+  }
+
+  existingRows = existing || []
+  const existingKeys = new Set(existingRows.map(reportKey))
+  insertRows = plannedRows.filter((row) => !existingKeys.has(reportKey(row)))
+
+  if (insertRows.length > 0) {
+    const { error: insertErr } = await supabase.from('price_reports').insert(insertRows)
+    if (insertErr) {
+      throw new Error(`insert failed: ${insertErr.message}`)
+    }
+    inserted = insertRows.length
+  }
+}
+
+const artifact = {
+  generated_at: observedAt,
+  mode: shouldWrite ? 'write' : 'dry_run',
+  review_file: reviewFile,
+  decision,
+  summary: {
+    review_rows: review.rows.length,
+    matched_rows: approvedRows.length,
+    planned_rows: plannedRows.length,
+    existing_official_menu_rows: existingRows.length,
+    insertable_rows: insertRows.length,
+    inserted,
+  },
+  write_key_mode: writeKeyMode,
+  rows: insertRows,
+}
+
+writeFileSync(output, JSON.stringify(artifact, null, 2))
+
+console.log(`Review file: ${reviewFile}`)
+console.log(`Decision: ${decision}`)
+console.log(`Mode: ${shouldWrite ? 'write' : 'dry run (no writes)'}`)
+console.log(`Write key mode: ${writeKeyMode}`)
+console.log(`Planned rows: ${plannedRows.length}`)
+console.log(`Insertable rows: ${insertRows.length}`)
+console.log(`Inserted rows: ${inserted}`)
+console.log(`Output: ${output}`)
+
+function isImportableReviewRow(row) {
+  if (!row || typeof row !== 'object') return false
+  if (typeof row.pub_slug !== 'string' || !row.pub_slug.trim()) return false
+  if (typeof row.source_url !== 'string' || !row.source_url.trim()) return false
+  if (typeof row.evidence_text !== 'string' || !row.evidence_text.trim()) return false
+
+  const price = Number(row.price)
+  return Number.isFinite(price) && price >= 3 && price <= 30
+}
+
+function toPriceReportRow(row, observedAt) {
+  return {
+    pub_slug: row.pub_slug,
+    reported_price: Number(row.price),
+    beer_type: importBeerType(row.beer_type),
+    reporter_name: 'Official menu crawler',
+    report_type: 'price_report',
+    notes: `Official menu review import: ${row.decision}`,
+    submission_source: 'official_menu',
+    source_url: row.source_url,
+    evidence_text: row.evidence_text,
+    observed_at: observedAt,
+    raw_extraction: {
+      review_row: row,
+    },
+    extractor_version: IMPORTER_VERSION,
+  }
+}
+
+function importBeerType(value) {
+  const beerType = typeof value === 'string' ? value.trim() : ''
+  if (!beerType || /[\\()]/.test(beerType)) return 'On tap'
+  return beerType
+}
+
+function reportKey(row) {
+  return [
+    row.pub_slug,
+    Number(row.reported_price).toFixed(2),
+    row.source_url || '',
+    row.evidence_text || '',
+  ].join('\n')
+}
+
+function arg(flag) {
+  const index = args.indexOf(flag)
+  return index >= 0 ? args[index + 1] : null
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -41,6 +41,10 @@ interface DashboardData {
       beerType: string
       reporter: string
       reportType: string
+      submissionSource: string | null
+      sourceUrl: string | null
+      evidenceText: string | null
+      observedAt: string | null
       status: string
       createdAt: string
     }>
@@ -104,6 +108,15 @@ function timeAgo(date: string): string {
   if (hours < 24) return `${hours}h ago`
   const days = Math.floor(hours / 24)
   return `${days}d ago`
+}
+
+function sourceLabel(url: string): string {
+  try {
+    const parsed = new URL(url)
+    return parsed.hostname.replace(/^www\./, '')
+  } catch {
+    return 'Source'
+  }
 }
 
 /* ================================================================
@@ -433,7 +446,7 @@ function ReportsTab({ data, password, onRefresh }: { data: DashboardData; passwo
               const rejectKey = `price_report-${r.id}-reject`
               return (
                 <div key={r.id} className={`px-4 py-4 ${i > 0 ? 'border-t-2 border-ink/10' : ''}`}>
-                  <div className="flex items-start justify-between gap-3">
+                  <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
                     <div className="flex-1 min-w-0">
                       <p className="font-mono text-[0.85rem] font-bold text-ink">{r.pubSlug.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}</p>
                       {isPending && !pubSlugs.has(r.pubSlug) && !pubOverrides[String(r.id)] && (
@@ -494,18 +507,40 @@ function ReportsTab({ data, password, onRefresh }: { data: DashboardData; passwo
                         )}
                         {r.beerType && <span className="font-mono text-[0.65rem] text-gray-mid">{r.beerType}</span>}
                         <span className="font-mono text-[0.65rem] text-gray-mid">by {r.reporter}</span>
+                        {r.submissionSource && (
+                          <span className="font-mono text-[0.6rem] font-bold uppercase tracking-[0.05em] text-amber">
+                            {r.submissionSource.replace(/_/g, ' ')}
+                          </span>
+                        )}
                       </div>
+                      {(r.evidenceText || r.sourceUrl) && (
+                        <div className="mt-2 border-l-3 border-amber pl-3 space-y-1">
+                          {r.evidenceText && (
+                            <p className="font-mono text-[0.65rem] text-ink break-words">{r.evidenceText}</p>
+                          )}
+                          {r.sourceUrl && (
+                            <a
+                              href={r.sourceUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="block font-mono text-[0.58rem] text-gray-mid hover:text-amber break-words transition-colors"
+                            >
+                              {sourceLabel(r.sourceUrl)}
+                            </a>
+                          )}
+                        </div>
+                      )}
                       <div className="flex items-center gap-2 mt-2">
                         <StatusBadge status={r.status} />
                         <span className="font-mono text-[0.6rem] text-gray-mid">{timeAgo(r.createdAt)}</span>
                       </div>
                     </div>
                     {isPending && (
-                      <div className="flex items-center gap-2 shrink-0">
+                      <div className="grid grid-cols-2 gap-2 w-full sm:flex sm:items-center sm:w-auto shrink-0">
                         <button
                           onClick={() => handleReview('price_report', r.id, 'approve')}
                           disabled={actionLoading !== null}
-                          className="flex items-center gap-1.5 px-4 py-2 bg-green text-white font-mono text-[0.65rem] font-bold uppercase tracking-[0.05em] border-3 border-ink rounded-card shadow-hard-sm hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-hard-hover disabled:opacity-50 transition-all"
+                          className="flex items-center justify-center gap-1.5 px-3 sm:px-4 py-2 bg-green text-white font-mono text-[0.65rem] font-bold uppercase tracking-[0.05em] border-3 border-ink rounded-card shadow-hard-sm hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-hard-hover disabled:opacity-50 transition-all"
                         >
                           {actionLoading === approveKey ? <Loader2 size={12} className="animate-spin" /> : <Check size={12} />}
                           Approve
@@ -513,7 +548,7 @@ function ReportsTab({ data, password, onRefresh }: { data: DashboardData; passwo
                         <button
                           onClick={() => handleReview('price_report', r.id, 'reject')}
                           disabled={actionLoading !== null}
-                          className="flex items-center gap-1.5 px-4 py-2 bg-red text-white font-mono text-[0.65rem] font-bold uppercase tracking-[0.05em] border-3 border-ink rounded-card shadow-hard-sm hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-hard-hover disabled:opacity-50 transition-all"
+                          className="flex items-center justify-center gap-1.5 px-3 sm:px-4 py-2 bg-red text-white font-mono text-[0.65rem] font-bold uppercase tracking-[0.05em] border-3 border-ink rounded-card shadow-hard-sm hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-hard-hover disabled:opacity-50 transition-all"
                         >
                           {actionLoading === rejectKey ? <Loader2 size={12} className="animate-spin" /> : <X size={12} />}
                           Reject
@@ -548,7 +583,7 @@ function ReportsTab({ data, password, onRefresh }: { data: DashboardData; passwo
               const rejectKey = `pub_submission-${s.id}-reject`
               return (
                 <div key={s.id} className={`px-4 py-4 ${i > 0 ? 'border-t-2 border-ink/10' : ''}`}>
-                  <div className="flex items-start justify-between gap-3">
+                  <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
                     <div className="flex-1 min-w-0">
                       <p className="font-mono text-[0.85rem] font-bold text-ink">{s.pubName}</p>
                       <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5">
@@ -568,11 +603,11 @@ function ReportsTab({ data, password, onRefresh }: { data: DashboardData; passwo
                       </div>
                     </div>
                     {isPending && (
-                      <div className="flex items-center gap-2 shrink-0">
+                      <div className="grid grid-cols-2 gap-2 w-full sm:flex sm:items-center sm:w-auto shrink-0">
                         <button
                           onClick={() => handleReview('pub_submission', s.id, 'approve')}
                           disabled={actionLoading !== null}
-                          className="flex items-center gap-1.5 px-4 py-2 bg-green text-white font-mono text-[0.65rem] font-bold uppercase tracking-[0.05em] border-3 border-ink rounded-card shadow-hard-sm hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-hard-hover disabled:opacity-50 transition-all"
+                          className="flex items-center justify-center gap-1.5 px-3 sm:px-4 py-2 bg-green text-white font-mono text-[0.65rem] font-bold uppercase tracking-[0.05em] border-3 border-ink rounded-card shadow-hard-sm hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-hard-hover disabled:opacity-50 transition-all"
                         >
                           {actionLoading === approveKey ? <Loader2 size={12} className="animate-spin" /> : <Check size={12} />}
                           Approve
@@ -580,7 +615,7 @@ function ReportsTab({ data, password, onRefresh }: { data: DashboardData; passwo
                         <button
                           onClick={() => handleReview('pub_submission', s.id, 'reject')}
                           disabled={actionLoading !== null}
-                          className="flex items-center gap-1.5 px-4 py-2 bg-red text-white font-mono text-[0.65rem] font-bold uppercase tracking-[0.05em] border-3 border-ink rounded-card shadow-hard-sm hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-hard-hover disabled:opacity-50 transition-all"
+                          className="flex items-center justify-center gap-1.5 px-3 sm:px-4 py-2 bg-red text-white font-mono text-[0.65rem] font-bold uppercase tracking-[0.05em] border-3 border-ink rounded-card shadow-hard-sm hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-hard-hover disabled:opacity-50 transition-all"
                         >
                           {actionLoading === rejectKey ? <Loader2 size={12} className="animate-spin" /> : <X size={12} />}
                           Reject

--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -164,6 +164,7 @@ export async function GET(request: NextRequest) {
       priceHistoryResult,
       priceReportsResult,
       pendingPriceReportsResult,
+      pendingPriceReportsListResult,
       pushSubsResult,
       activityResult,
       recentPubsResult,
@@ -184,6 +185,8 @@ export async function GET(request: NextRequest) {
       supabase.from('price_reports').select('*', { count: 'exact' }).order('created_at', { ascending: false }).limit(10),
       // All pending price reports, not just the latest display slice
       supabase.from('price_reports').select('id', { count: 'exact', head: true }).eq('status', 'pending'),
+      // Pending report review queue, so large imports can be fully actioned
+      supabase.from('price_reports').select('*').eq('status', 'pending').order('created_at', { ascending: false }).limit(100),
       // Push subscriptions
       supabase.from('push_subscriptions').select('*', { count: 'exact' }),
       // Agent activity (now readable by anon with RLS policy)
@@ -219,6 +222,9 @@ export async function GET(request: NextRequest) {
 
     // Pubs without prices
     const unpriced = pubs.filter(p => !p.price || p.price === 0)
+    const displayPriceReports = pendingPriceReportsListResult.data?.length
+      ? pendingPriceReportsListResult.data
+      : priceReportsResult.data || []
 
     return NextResponse.json({
       overview: {
@@ -245,13 +251,17 @@ export async function GET(request: NextRequest) {
       priceReports: {
         total: priceReportsResult.count || 0,
         pending: pendingPriceReportsResult.count || 0,
-        recent: (priceReportsResult.data || []).map((r: any) => ({
+        recent: displayPriceReports.map((r: any) => ({
           id: r.id,
           pubSlug: r.pub_slug,
           reportedPrice: r.reported_price,
           beerType: r.beer_type,
           reporter: r.reporter_name || 'Anonymous',
           reportType: r.report_type || 'price_report',
+          submissionSource: r.submission_source || null,
+          sourceUrl: r.source_url || null,
+          evidenceText: r.evidence_text || null,
+          observedAt: r.observed_at || null,
           status: r.status,
           createdAt: r.created_at,
         })),

--- a/src/lib/officialMenuExtract.test.ts
+++ b/src/lib/officialMenuExtract.test.ts
@@ -23,6 +23,8 @@ describe('official menu extraction', () => {
       Beef burger $24
       House wine $11
       Tap lager $9
+      Apple Juice, Dry Ginger Ale, Lime 12
+      Moscow Mule, vodka, ginger beer, lime + ice $18.90
     `)
 
     assert.deepEqual(candidates, [
@@ -39,5 +41,95 @@ describe('official menu extraction', () => {
 
   it('rejects prices outside the expected pint range', () => {
     assert.deepEqual(extractOfficialMenuCandidates('Tap beer $2\nFancy beer pint $42'), [])
+  })
+
+  it('accepts bare menu prices for clearly labelled draught beer lines', () => {
+    const candidates = extractOfficialMenuCandidates(`
+      Rotating Tap Beers 12
+      Stone and Wood Pacific Ale 13.50
+      Beer battered fish 28
+    `)
+
+    assert.deepEqual(candidates, [
+      { beerType: 'Rotating', price: 12, evidenceText: 'Rotating Tap Beers 12' },
+      { beerType: 'Stone and Wood Pacific Ale', price: 13.5, evidenceText: 'Stone and Wood Pacific Ale 13.50' },
+    ])
+  })
+
+  it('skips beer lines with multiple explicit prices', () => {
+    assert.deepEqual(extractOfficialMenuCandidates('Classic lager $10 $15'), [])
+  })
+
+  it('skips mixed beverage lines where the price belongs to cocktails or wine', () => {
+    assert.deepEqual(
+      extractOfficialMenuCandidates('SPRITZES $19 VASSE FELIX PREMIER CHARDONNAY (BTL ONLY) WA 99 COOPERS PALE ALE 4.5%'),
+      [],
+    )
+  })
+
+  it('skips cocktail mixer and food-combo pint lines', () => {
+    assert.deepEqual(
+      extractOfficialMenuCandidates(`
+        Makers Mark, ginger beer and lime $20 LUNCH SPECIALS
+        $30 Roast & Pint
+      `),
+      [],
+    )
+  })
+
+  it('skips non-alcoholic beer lines', () => {
+    assert.deepEqual(
+      extractOfficialMenuCandidates(`
+        Lightning Minds Non Alcoholic Pale Ale - 9
+        Pale Ale - Lightning Minds 12
+        Heaps Normal Another Lager 11
+        Hiatus Pacific Ale 11
+        Swan Draught pint $10
+      `),
+      [{ beerType: 'Swan', price: 10, evidenceText: 'Swan Draught pint $10' }],
+    )
+  })
+
+  it('combines drink lines with adjacent price-only lines', () => {
+    const candidates = extractOfficialMenuCandidates(`
+      Rotating Tap Beers
+      12
+      Fish Burger
+      26
+    `)
+
+    assert.deepEqual(candidates, [
+      { beerType: 'Rotating', price: 12, evidenceText: 'Rotating Tap Beers 12' },
+    ])
+  })
+
+  it('extracts schema.org MenuItem offers from JSON-LD', () => {
+    const candidates = extractOfficialMenuCandidates(`
+      <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "Menu",
+          "hasMenuSection": {
+            "@type": "MenuSection",
+            "hasMenuItem": [
+              {
+                "@type": "MenuItem",
+                "name": "Swan Draught pint",
+                "offers": { "@type": "Offer", "price": "10" }
+              },
+              {
+                "@type": "MenuItem",
+                "name": "Beef burger",
+                "offers": { "@type": "Offer", "price": "24" }
+              }
+            ]
+          }
+        }
+      </script>
+    `)
+
+    assert.deepEqual(candidates, [
+      { beerType: 'Swan', price: 10, evidenceText: 'Swan Draught pint $10' },
+    ])
   })
 })

--- a/src/lib/officialMenuExtract.ts
+++ b/src/lib/officialMenuExtract.ts
@@ -4,9 +4,13 @@ export interface OfficialMenuCandidate {
   evidenceText: string
 }
 
-const PRICE_RE = /(?:\$|aud\s*)\s*(\d{1,2}(?:\.\d{1,2})?)/i
+const PRICE_VALUE_RE = /(?:\$|aud\s*)\s*(\d{1,2}(?:\.\d{1,2})?)/gi
 const DRINK_RE = /\b(pint|pints|draught|draft|tap|lager|ale|beer|cider)\b/i
-const SKIP_RE = /\b(happy\s*hour|special|deal|promo|members?|jug|bottle|can|cocktail|wine|spirit|food)\b/i
+const BARE_PRICE_DRINK_RE = /\b(pints?|draught|draft|tap\s*beers?|lager|ale|cider)\b/i
+const BARE_PRICE_RE = /(?:^|\s)(\d{1,2}(?:\.\d{1,2})?)\s*$/
+const BARE_NUMBER_RE = /\b\d{1,2}(?:\.\d{1,2})?\b/g
+const SKIP_RE =
+  /\b(happy\s*hour|specials?|deal|promo|members?|jug|bottle|btl|can|cocktails?|mocktails?|wine|chardonnay|spirit|vodka|gin|rum|tequila|whisk(?:e)?y|bourbon|makers?\s+mark|mule|margarita|martini|spritz(?:es)?|negroni|liqueur|food|lunch\s*specials?|roast|juice|ginger\s*(?:ale|beer)|soft\s*drink|lemonade|soda|tonic|non[-\s]?alcoholic|alcohol[-\s]?free|zero[-\s]?alcohol|heaps\s+normal|lightning\s+minds|hiatus|battered|burger|fish|chips)\b/i
 
 export function extractOfficialMenuCandidates(input: string, limit = 10): OfficialMenuCandidate[] {
   const seen = new Set<string>()
@@ -15,13 +19,13 @@ export function extractOfficialMenuCandidates(input: string, limit = 10): Offici
   for (const line of menuLines(input)) {
     if (!DRINK_RE.test(line) || SKIP_RE.test(line)) continue
 
-    const priceMatch = line.match(PRICE_RE)
+    const priceMatch = findPrice(line)
     if (!priceMatch) continue
 
-    const price = Number.parseFloat(priceMatch[1])
+    const price = Number.parseFloat(priceMatch.value)
     if (!Number.isFinite(price) || price < 3 || price > 30) continue
 
-    const beerType = inferBeerType(line, priceMatch[0])
+    const beerType = inferBeerType(line, priceMatch.text)
     const key = `${beerType || 'pint'}:${price}:${line.toLowerCase()}`
     if (seen.has(key)) continue
     seen.add(key)
@@ -38,11 +42,136 @@ export function extractOfficialMenuCandidates(input: string, limit = 10): Offici
   return candidates
 }
 
+function structuredMenuLines(input: string): string[] {
+  const lines: string[] = []
+  const scriptRe = /<script\b[^>]*type=["'][^"']*application\/ld\+json[^"']*["'][^>]*>([\s\S]*?)<\/script>/gi
+
+  let match: RegExpExecArray | null
+  while ((match = scriptRe.exec(input)) !== null) {
+    try {
+      collectStructuredMenuLines(JSON.parse(decodeEntities(match[1] || '')), lines)
+    } catch {
+      // Ignore malformed JSON-LD; venue sites often include unrelated scripts.
+    }
+  }
+
+  return lines
+}
+
+function collectStructuredMenuLines(value: unknown, lines: string[]): void {
+  if (Array.isArray(value)) {
+    for (const item of value) collectStructuredMenuLines(item, lines)
+    return
+  }
+
+  if (!value || typeof value !== 'object') return
+
+  const node = value as Record<string, unknown>
+  if (isMenuItemType(node['@type'])) {
+    const name = stringValue(node.name)
+    const price = offerPrice(node.offers) || offerPrice(node.offer) || stringValue(node.price)
+    if (name && price) {
+      lines.push(`${name} ${formatPriceText(price)}`)
+    }
+  }
+
+  for (const child of Object.values(node)) {
+    collectStructuredMenuLines(child, lines)
+  }
+}
+
+function isMenuItemType(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(isMenuItemType)
+  return typeof value === 'string' && /\bMenuItem\b/i.test(value)
+}
+
+function offerPrice(value: unknown): string | null {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const price = offerPrice(item)
+      if (price) return price
+    }
+    return null
+  }
+
+  if (!value || typeof value !== 'object') return null
+
+  const offer = value as Record<string, unknown>
+  return stringValue(offer.price) || offerPrice(offer.priceSpecification)
+}
+
+function stringValue(value: unknown): string | null {
+  if (typeof value === 'number') return String(value)
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed || null
+}
+
+function formatPriceText(value: string): string {
+  return /(?:\$|aud\s*)/i.test(value) ? value : `$${value}`
+}
+
+function findPrice(line: string): { text: string; value: string } | null {
+  const explicitPrices = Array.from(line.matchAll(PRICE_VALUE_RE))
+  if (explicitPrices.length > 1) return null
+  if (explicitPrices.length === 1) {
+    const explicitPrice = explicitPrices[0]
+    return { text: explicitPrice[0], value: explicitPrice[1] }
+  }
+
+  if (!BARE_PRICE_DRINK_RE.test(line)) return null
+  if ((line.match(BARE_NUMBER_RE) || []).length > 1) return null
+
+  const barePrice = line.match(BARE_PRICE_RE)
+  if (!barePrice) return null
+
+  return { text: barePrice[1], value: barePrice[1] }
+}
+
 export function menuLines(input: string): string[] {
-  return htmlToText(input)
+  const lines = htmlToText(input)
     .split('\n')
     .map((line) => line.replace(/\s+/g, ' ').trim())
-    .filter((line) => line.length >= 8 && line.length <= 180)
+    .filter(Boolean)
+
+  return dedupeLines([
+    ...structuredMenuLines(input),
+    ...expandAdjacentPriceLines(lines),
+  ]).filter((line) => line.length >= 8 && line.length <= 180)
+}
+
+function expandAdjacentPriceLines(lines: string[]): string[] {
+  const expanded: string[] = []
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    expanded.push(line)
+
+    const next = lines[i + 1]
+    if (next && DRINK_RE.test(line) && standalonePriceLine(next)) {
+      expanded.push(`${line} ${next}`)
+    }
+  }
+
+  return expanded
+}
+
+function standalonePriceLine(line: string): boolean {
+  return /^(?:\$|aud\s*)?\s*\d{1,2}(?:\.\d{1,2})?\s*$/i.test(line)
+}
+
+function dedupeLines(lines: string[]): string[] {
+  const seen = new Set<string>()
+  const unique: string[] = []
+
+  for (const line of lines) {
+    const key = line.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    unique.push(line)
+  }
+
+  return unique
 }
 
 function htmlToText(input: string): string {
@@ -59,6 +188,8 @@ function decodeEntities(input: string): string {
   return input
     .replace(/&nbsp;/gi, ' ')
     .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
     .replace(/&dollar;/gi, '$')
     .replace(/&#36;/g, '$')
     .replace(/&ndash;|&mdash;/gi, '-')
@@ -67,7 +198,7 @@ function decodeEntities(input: string): string {
 function inferBeerType(line: string, priceText: string): string | null {
   const beforePrice = line.split(priceText)[0] || line
   const cleaned = beforePrice
-    .replace(/\b(pints?|draught|draft|tap|beer|cider|from|only|glass|middy|schooner)\b/gi, ' ')
+    .replace(/\b(pints?|draught|draft|tap|beers?|cider|from|only|glass|middy|schooner)\b/gi, ' ')
     .replace(/[|:,-]+/g, ' ')
     .replace(/\s+/g, ' ')
     .trim()

--- a/src/lib/officialMenuSources.test.ts
+++ b/src/lib/officialMenuSources.test.ts
@@ -41,4 +41,86 @@ describe('official menu source discovery', () => {
     assert.equal(candidates[0].url, 'https://example.com/menu')
     assert.equal(candidates[0].score, 13)
   })
+
+  it('deduplicates trailing slash variants', () => {
+    const candidates = discoverOfficialMenuSources(`
+      <a href="/drinks">Drinks</a>
+      <a href="/drinks/">Drinks</a>
+    `, 'https://example.com/')
+
+    assert.equal(candidates.length, 1)
+    assert.equal(candidates[0].url, 'https://example.com/drinks')
+  })
+
+  it('skips unresolved CMS template links', () => {
+    const candidates = discoverOfficialMenuSources(`
+      <a href="/eat-drink/[%= item.url %]">Drinks menu</a>
+      <a href="/menu">Menu</a>
+    `, 'https://example.com/')
+
+    assert.deepEqual(candidates.map((candidate) => candidate.url), [
+      'https://example.com/menu',
+    ])
+  })
+
+  it('discovers embedded menu provider resources', () => {
+    const candidates = discoverOfficialMenuSources(`
+      <iframe src="https://mryum.com/example-venue" title="Order menu"></iframe>
+      <script src="https://cdn.example.com/site.js"></script>
+    `, 'https://example.com/')
+
+    assert.equal(candidates[0].url, 'https://mryum.com/example-venue')
+    assert.deepEqual(candidates[0].reasons, ['menu', 'menu-provider'])
+  })
+
+  it('skips static assets and generic images', () => {
+    const candidates = discoverOfficialMenuSources(`
+      <link href="/wp-content/plugins/nav-menu.css" rel="stylesheet">
+      <a href="/photos/banner.jpg">Photo</a>
+      <a href="/photos/outdoor-beer-garden.jpg">Beer garden</a>
+      <a href="/assets/beer-C32UEuZ2.avif">Beer image</a>
+      <a href="/files/bar-menu.png">Bar menu image</a>
+    `, 'https://example.com/')
+
+    assert.deepEqual(candidates.map((candidate) => candidate.url), [
+      'https://example.com/files/bar-menu.png',
+    ])
+    assert.deepEqual(candidates[0].reasons, ['drinks-or-beer', 'menu', 'image-asset'])
+  })
+
+  it('skips booking and gift-card providers without menu intent', () => {
+    const candidates = discoverOfficialMenuSources(`
+      <a href="https://bookings.nowbookit.com/?accountid=123">Book now</a>
+      <a href="https://giftcards.nowbookit.com/cards/card-selection?accountid=123">Gift cards</a>
+    `, 'https://example.com/')
+
+    assert.deepEqual(candidates, [])
+  })
+
+  it('skips ecommerce product pages without menu intent', () => {
+    const candidates = discoverOfficialMenuSources(`
+      <a href="/product-category/beer/">Beer shop</a>
+      <a href="/shop/lager/">Buy lager</a>
+      <a href="/bar-menu/">Bar menu</a>
+    `, 'https://example.com/')
+
+    assert.deepEqual(candidates.map((candidate) => candidate.url), [
+      'https://example.com/bar-menu/',
+    ])
+  })
+
+  it('discovers menu URLs from JSON-LD', () => {
+    const candidates = discoverOfficialMenuSources(`
+      <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "Restaurant",
+          "menu": "/drinks-menu"
+        }
+      </script>
+    `, 'https://example.com/pub/')
+
+    assert.equal(candidates[0].url, 'https://example.com/drinks-menu')
+    assert.deepEqual(candidates[0].reasons, ['drinks-or-beer', 'menu'])
+  })
 })

--- a/src/lib/officialMenuSources.ts
+++ b/src/lib/officialMenuSources.ts
@@ -15,8 +15,14 @@ interface RawLink {
 
 const HIGH_INTENT_RE = /\b(drinks?|beverages?|beer|tap[-\s]?list|wine-list|bar-menu)\b/i
 const MENU_RE = /\b(menu|menus|eat[-\s]?drink|food[-\s]?drink)\b/i
-const LOW_INTENT_RE = /\b(contact|booking|bookings|function|events?|privacy|terms|feed|wp-json|xmlrpc|login|cart|checkout)\b/i
-const ASSET_RE = /\.(pdf|png|jpe?g|webp)(?:[?#].*)?$/i
+const MENU_PROVIDER_RE =
+  /\b(mr\s*yum|mryum|me\s*&\s*u|meandu|hungry\s*hungry|hungryhungry|bopple|oolio|qrd|qr[-\s]?menu)\b/i
+const LOW_INTENT_RE =
+  /\b(contact|booking|bookings|function|events?|privacy|terms|feed|wp-json|xmlrpc|login|cart|checkout|shop|products?|product-category|giftcards?|gift[-\s]?cards?)\b/i
+const BLOCKED_SOURCE_RE = /\b(shop|products?|product-category|cart|checkout|giftcards?|gift[-\s]?cards?)\b/i
+const ASSET_RE = /\.(pdf|png|jpe?g|webp|avif)(?:[?#].*)?$/i
+const IMAGE_SOURCE_RE = /\b(tap[-\s]?list|wine-list|bar-menu|drink[-\s]?menu|drinks[-\s]?menu|menu|menus)\b/i
+const STATIC_ASSET_RE = /\.(css|m?js|map|woff2?|ttf|otf)(?:[?#].*)?$/i
 
 export function discoverOfficialMenuSources(html: string, baseUrl: string, limit = 5): OfficialMenuSourceCandidate[] {
   const byUrl = new Map<string, OfficialMenuSourceCandidate>()
@@ -25,9 +31,10 @@ export function discoverOfficialMenuSources(html: string, baseUrl: string, limit
     const candidate = scoreLink(link)
     if (candidate.score <= 0) continue
 
-    const existing = byUrl.get(candidate.url)
+    const key = canonicalUrlKey(candidate.url)
+    const existing = byUrl.get(key)
     if (!existing || candidate.score > existing.score) {
-      byUrl.set(candidate.url, candidate)
+      byUrl.set(key, candidate)
     }
   }
 
@@ -50,6 +57,7 @@ export function extractLinks(html: string, baseUrl: string): RawLink[] {
       const url = new URL(href, base)
       url.hash = ''
       if (!url.protocol.startsWith('http')) continue
+      if (isTemplateUrl(url.toString())) continue
 
       links.push({
         url: url.toString(),
@@ -60,6 +68,19 @@ export function extractLinks(html: string, baseUrl: string): RawLink[] {
     }
   }
 
+  const resourceRe = /<(?:iframe|script|img|source|link)\b[^>]*(?:href|src|data-href|data-src)=["']([^"']+)["'][^>]*>/gi
+  while ((match = resourceRe.exec(html)) !== null) {
+    const url = resolveHttpUrl(match[1], base)
+    if (!url) continue
+
+    links.push({
+      url,
+      label: cleanLabel(attributeValue(match[0], 'title') || attributeValue(match[0], 'aria-label') || ''),
+    })
+  }
+
+  links.push(...extractStructuredMenuLinks(html, base))
+
   return links
 }
 
@@ -67,6 +88,37 @@ function scoreLink(link: RawLink): OfficialMenuSourceCandidate {
   const haystack = `${link.url} ${link.label}`
   const reasons: string[] = []
   let score = 0
+  const type = sourceType(link.url)
+
+  if (STATIC_ASSET_RE.test(link.url)) {
+    return {
+      url: link.url,
+      label: link.label,
+      type,
+      score: 0,
+      reasons: ['static-asset'],
+    }
+  }
+
+  if (BLOCKED_SOURCE_RE.test(haystack)) {
+    return {
+      url: link.url,
+      label: link.label,
+      type,
+      score: 0,
+      reasons: ['blocked-source'],
+    }
+  }
+
+  if (type === 'image' && !IMAGE_SOURCE_RE.test(haystack)) {
+    return {
+      url: link.url,
+      label: link.label,
+      type,
+      score: 0,
+      reasons: ['generic-image'],
+    }
+  }
 
   if (HIGH_INTENT_RE.test(haystack)) {
     score += 8
@@ -78,12 +130,17 @@ function scoreLink(link: RawLink): OfficialMenuSourceCandidate {
     reasons.push('menu')
   }
 
+  if (MENU_PROVIDER_RE.test(haystack)) {
+    score += 10
+    reasons.push('menu-provider')
+  }
+
   if (/\.pdf(?:[?#].*)?$/i.test(link.url)) {
     score += 4
     reasons.push('pdf')
   }
 
-  if (ASSET_RE.test(link.url) && !/\.pdf/i.test(link.url)) {
+  if (ASSET_RE.test(link.url) && !/\.pdf/i.test(link.url) && score > 0) {
     score += 1
     reasons.push('image-asset')
   }
@@ -96,15 +153,80 @@ function scoreLink(link: RawLink): OfficialMenuSourceCandidate {
   return {
     url: link.url,
     label: link.label,
-    type: sourceType(link.url),
+    type,
     score,
     reasons,
   }
 }
 
+function extractStructuredMenuLinks(html: string, base: URL): RawLink[] {
+  const links: RawLink[] = []
+  const scriptRe = /<script\b[^>]*type=["'][^"']*application\/ld\+json[^"']*["'][^>]*>([\s\S]*?)<\/script>/gi
+
+  let match: RegExpExecArray | null
+  while ((match = scriptRe.exec(html)) !== null) {
+    try {
+      collectStructuredMenuLinks(JSON.parse(decodeEntities(match[1] || '')), base, links)
+    } catch {
+      // Ignore malformed JSON-LD; venue pages commonly mix unrelated scripts.
+    }
+  }
+
+  return links
+}
+
+function collectStructuredMenuLinks(value: unknown, base: URL, links: RawLink[]): void {
+  if (Array.isArray(value)) {
+    for (const item of value) collectStructuredMenuLinks(item, base, links)
+    return
+  }
+
+  if (!value || typeof value !== 'object') return
+
+  const node = value as Record<string, unknown>
+  for (const key of ['menu', 'hasMenu', 'url', '@id']) {
+    const rawValue = node[key]
+    if (typeof rawValue === 'string' && /menu/i.test(`${key} ${rawValue}`)) {
+      const url = resolveHttpUrl(rawValue, base)
+      if (url) links.push({ url, label: key })
+    }
+  }
+
+  for (const child of Object.values(node)) {
+    collectStructuredMenuLinks(child, base, links)
+  }
+}
+
+function isTemplateUrl(url: string): boolean {
+  return /(?:\[%|%\]|\{\{|\}\})/.test(url)
+}
+
+function resolveHttpUrl(value: string | undefined, base: URL): string | null {
+  const href = value?.trim()
+  if (!href || href.startsWith('#') || href.startsWith('mailto:') || href.startsWith('tel:')) return null
+
+  try {
+    const url = new URL(href, base)
+    url.hash = ''
+    if (!url.protocol.startsWith('http')) return null
+    if (isTemplateUrl(url.toString())) return null
+    return url.toString()
+  } catch {
+    return null
+  }
+}
+
+function canonicalUrlKey(url: string): string {
+  const parsed = new URL(url)
+  if (parsed.pathname.length > 1) {
+    parsed.pathname = parsed.pathname.replace(/\/+$/, '')
+  }
+  return parsed.toString()
+}
+
 function sourceType(url: string): OfficialMenuSourceType {
   if (/\.pdf(?:[?#].*)?$/i.test(url)) return 'pdf'
-  if (/\.(png|jpe?g|webp)(?:[?#].*)?$/i.test(url)) return 'image'
+  if (/\.(png|jpe?g|webp|avif)(?:[?#].*)?$/i.test(url)) return 'image'
   if (/^https?:\/\//i.test(url)) return 'html'
   return 'other'
 }
@@ -117,4 +239,17 @@ function cleanLabel(value: string): string {
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, 120)
+}
+
+function attributeValue(tag: string, name: string): string | null {
+  const match = tag.match(new RegExp(`\\b${name}=["']([^"']+)["']`, 'i'))
+  return match?.[1] || null
+}
+
+function decodeEntities(input: string): string {
+  return input
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
 }


### PR DESCRIPTION
## What changed

- Expanded the official-menu workflow into discovery, seed building, crawling, review export, suggested decisions, and guarded import scripts.
- Added layered extraction for rendered HTML, PDF text/tables, image OCR, scanned-PDF OCR fallback, JSON-LD MenuItem data, adjacent price lines, and stricter false-positive filtering.
- Preserved linked-source provenance so candidates found through `--follow-links` keep the actual linked menu/PDF/image URL and extraction mode in review exports.
- Added admin review ergonomics so pending price reports are returned as a real review queue instead of only the latest 10 reports, with source/evidence visible in the Reports tab.
- Added an approval pack and project-status entry; generated crawl/review/import artifacts are gitignored.

## Production data review

The 26 imported `official_menu` reports were reviewed via the service-role admin path using Infisical-provided production Supabase credentials.

- Approved: 5 clear official-menu rows into canonical pub prices.
- Rejected: 21 ambiguous or duplicate rows.
- Remaining pending `official_menu` reports: 0.

Approved canonical prices:

- 18 Knots Rooftop Bar: `$10`, evidence `DRAUGHT BEER 10`
- Argyle Social: `$10`, evidence `CARLTON DRAUGHT 10`
- Frisk. Small Bar: `$10`, evidence `tap beer 10`
- Noble Falls Tavern: `$12`, evidence `$12 Pint`
- Otherside Brew Lounge: `$13`, evidence `GUINNESS Draught $13`

## Current PR state

- Branch: `codex/official-menu-crawler-finish`
- Commits: `d8e976d`, `ba6976c`, `99b8200`, `0c241e6`
- CI: green
- Vercel preview: green

## Verification

- `node --check scripts/crawl-official-menus.mjs`
- `node --check scripts/build-official-menu-review.mjs`
- Provenance smoke test for linked-source review export -> kept linked `menu.pdf` URL and `pdf-text` mode
- `npm run import:official-menu-review -- --output scripts/official-menu-import-plan.verify.json`
- `npm test` -> 246/246 passed
- `npx tsc --noEmit`
- `npm run lint` -> passed with existing warnings only
- `npm run build` -> passed with existing warnings only
- `git diff --check`
- Playwright desktop/mobile screenshots for the admin Reports tab before/after:
  - `artifacts/playwright/official-menu-admin-before-desktop.png`
  - `artifacts/playwright/official-menu-admin-after-desktop.png`
  - `artifacts/playwright/official-menu-admin-before-mobile.png`
  - `artifacts/playwright/official-menu-admin-after-mobile.png`

## Follow-up

Rotate/revoke the Infisical credential pasted in chat. It was not used by this agent, but it should be treated as exposed.
