### PR TITLE
[codex] Harden official menu extractor filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ scripts/official-menu-crawl-results*.json
 scripts/official-menu-import-plan*.json
 scripts/official-menu-review*.csv
 scripts/official-menu-review*.json
-scripts/official-menu-seeds.json
+scripts/official-menu-seeds*.json
 scripts/official-menu-seeds.generated*.json
 scripts/official-menu-seeds.large*.json
 scripts/official-menu-source-candidates*.json

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -1,6 +1,6 @@
 # Perth Pint Prices Project Status
 
-Last updated: 2026-06-02
+Last updated: 2026-06-03
 
 ## What this is
 
@@ -9,6 +9,12 @@ Perth Pint Prices (perthpintprices.com) tracks pint prices across **857 Perth pu
 Stack, database, routes, components, and lib files are documented in `CLAUDE.md` (auto-loaded every session). This file covers history, recent work, and the backlog.
 
 ## What's done recently
+
+### Official menu extractor hardening + second dry run (2026-06-03)
+- **Branch `codex/official-menu-extractor-hardening` / commit `f69c55e`:** tightened official-menu source and row filters after the larger dry run surfaced false positives. The extractor now skips `Non-Alc` shorthand, apple-cider-vinaigrette food rows, and beer-in-food-description rows such as macaroni/panko/deep-fried items; source discovery and seed building now block breakfast/kids menu URLs even when filenames use underscores.
+- **Second dry run:** rebuilt seeds from the large discovery artifact with the hardened filters, producing 202 crawl sources. Ran a no-write crawl with linked-source follow-up and OCR disabled for native-tooling stability: 195 fetched, 131 linked fetched, 11 linked failed, 39 candidates, 7 failed sources, 0 inserted.
+- **Review pack:** generated `scripts/official-menu-review-next.json` and `.csv` locally with suggested decisions: 9 `approve_suggested`, 30 `needs_manual_review`. No production import was run; rows still need manual review before any pending reports are inserted.
+- **Verification:** verified focused official-menu tests, `npm test` (**248/248 tests**), `npx tsc --noEmit`, `npm run lint` (existing warnings only), `npm run build` (existing warnings only), `git diff --check`, and seed/crawl/review smoke checks.
 
 ### Official menu crawler scaled to review + pending reports (2026-06-02)
 - **Local uncommitted work:** expanded the official-menu workflow from MVP into a dry-run-first discovery, seed, crawl, review, suggested-decision, and guarded import pipeline. The approval pack lives at `docs/official-menu-crawler-approval.html`; generated crawl/review/import artifacts are gitignored.

--- a/scripts/build-official-menu-seeds.mjs
+++ b/scripts/build-official-menu-seeds.mjs
@@ -19,7 +19,8 @@ const includeImages = !args.includes('--no-images')
 const IMAGE_SOURCE_RE = /\b(tap[-\s]?list|wine-list|bar-menu|drink[-\s]?menu|drinks[-\s]?menu|menu|menus)\b/i
 const IMAGE_ASSET_RE = /\.(png|jpe?g|webp|avif)(?:[?#].*)?$/i
 const UNSUPPORTED_IMAGE_RE = /\.avif(?:[?#].*)?$/i
-const LOW_INTENT_URL_RE = /\b(shop|products?|product-category|cart|checkout|giftcards?|gift[-\s]?cards?)\b/i
+const LOW_INTENT_URL_RE =
+  /(?:^|[\W_])(shop|products?|product-category|cart|checkout|giftcards?|gift[-\s]?cards?|breakfast|kids?)(?:$|[\W_])/i
 
 const artifact = JSON.parse(readFileSync(input, 'utf8'))
 if (!Array.isArray(artifact.results)) {

--- a/src/lib/officialMenuExtract.test.ts
+++ b/src/lib/officialMenuExtract.test.ts
@@ -81,12 +81,26 @@ describe('official menu extraction', () => {
     assert.deepEqual(
       extractOfficialMenuCandidates(`
         Lightning Minds Non Alcoholic Pale Ale - 9
+        The Cidery Apple Cider $15 (Non-Alc)
+        Apple Thief Non - Alc. Cider 12
         Pale Ale - Lightning Minds 12
         Heaps Normal Another Lager 11
         Hiatus Pacific Ale 11
         Swan Draught pint $10
       `),
       [{ beerType: 'Swan', price: 10, evidenceText: 'Swan Draught pint $10' }],
+    )
+  })
+
+  it('skips food rows that mention apple cider vinegar', () => {
+    assert.deepEqual(
+      extractOfficialMenuCandidates(`
+        crumbled Danish feta, apple cider vinaigrette 28
+        BUTTERNUT PUMPKIN & QUINOA SALAD V apple cider vinaigrette 28
+        Made with macaroni & Mash hazy beer and cheese, deep fried in a crispy panko coating. $19
+        Swan Draught Lager 13
+      `),
+      [{ beerType: 'Swan Lager', price: 13, evidenceText: 'Swan Draught Lager 13' }],
     )
   })
 

--- a/src/lib/officialMenuExtract.ts
+++ b/src/lib/officialMenuExtract.ts
@@ -10,7 +10,7 @@ const BARE_PRICE_DRINK_RE = /\b(pints?|draught|draft|tap\s*beers?|lager|ale|cide
 const BARE_PRICE_RE = /(?:^|\s)(\d{1,2}(?:\.\d{1,2})?)\s*$/
 const BARE_NUMBER_RE = /\b\d{1,2}(?:\.\d{1,2})?\b/g
 const SKIP_RE =
-  /\b(happy\s*hour|specials?|deal|promo|members?|jug|bottle|btl|can|cocktails?|mocktails?|wine|chardonnay|spirit|vodka|gin|rum|tequila|whisk(?:e)?y|bourbon|makers?\s+mark|mule|margarita|martini|spritz(?:es)?|negroni|liqueur|food|lunch\s*specials?|roast|juice|ginger\s*(?:ale|beer)|soft\s*drink|lemonade|soda|tonic|non[-\s]?alcoholic|alcohol[-\s]?free|zero[-\s]?alcohol|heaps\s+normal|lightning\s+minds|hiatus|battered|burger|fish|chips)\b/i
+  /\b(happy\s*hour|specials?|deal|promo|members?|jug|bottle|btl|can|cocktails?|mocktails?|wine|chardonnay|spirit|vodka|gin|rum|tequila|whisk(?:e)?y|bourbon|makers?\s+mark|mule|margarita|martini|spritz(?:es)?|negroni|liqueur|food|breakfast|kids?|lunch\s*specials?|roast|salad|vinaigrette|feta|quinoa|pumpkin|macaroni|panko|deep[-\s]?fried|juice|ginger\s*(?:ale|beer)|soft\s*drink|lemonade|soda|tonic|non\s*[-–—]?\s*(?:alcoholic|alc\.?)|alcohol[-\s]?free|zero[-\s]?alcohol|heaps\s+normal|lightning\s+minds|hiatus|battered|burger|fish|chips)\b/i
 
 export function extractOfficialMenuCandidates(input: string, limit = 10): OfficialMenuCandidate[] {
   const seen = new Set<string>()

--- a/src/lib/officialMenuSources.test.ts
+++ b/src/lib/officialMenuSources.test.ts
@@ -109,6 +109,19 @@ describe('official menu source discovery', () => {
     ])
   })
 
+  it('skips breakfast and kids menu pages', () => {
+    const candidates = discoverOfficialMenuSources(`
+      <a href="/breakfast-menu">Breakfast menu</a>
+      <a href="/kids-menu">Kids menu</a>
+      <a href="/Breakfast_Menu.pdf">Breakfast PDF</a>
+      <a href="/drinks-menu">Drinks menu</a>
+    `, 'https://example.com/')
+
+    assert.deepEqual(candidates.map((candidate) => candidate.url), [
+      'https://example.com/drinks-menu',
+    ])
+  })
+
   it('discovers menu URLs from JSON-LD', () => {
     const candidates = discoverOfficialMenuSources(`
       <script type="application/ld+json">

--- a/src/lib/officialMenuSources.ts
+++ b/src/lib/officialMenuSources.ts
@@ -18,8 +18,8 @@ const MENU_RE = /\b(menu|menus|eat[-\s]?drink|food[-\s]?drink)\b/i
 const MENU_PROVIDER_RE =
   /\b(mr\s*yum|mryum|me\s*&\s*u|meandu|hungry\s*hungry|hungryhungry|bopple|oolio|qrd|qr[-\s]?menu)\b/i
 const LOW_INTENT_RE =
-  /\b(contact|booking|bookings|function|events?|privacy|terms|feed|wp-json|xmlrpc|login|cart|checkout|shop|products?|product-category|giftcards?|gift[-\s]?cards?)\b/i
-const BLOCKED_SOURCE_RE = /\b(shop|products?|product-category|cart|checkout|giftcards?|gift[-\s]?cards?)\b/i
+  /(?:^|[\W_])(contact|booking|bookings|function|events?|privacy|terms|feed|wp-json|xmlrpc|login|cart|checkout|shop|products?|product-category|giftcards?|gift[-\s]?cards?|breakfast|kids?)(?:$|[\W_])/i
+const BLOCKED_SOURCE_RE = /(?:^|[\W_])(shop|products?|product-category|cart|checkout|giftcards?|gift[-\s]?cards?|breakfast|kids?)(?:$|[\W_])/i
 const ASSET_RE = /\.(pdf|png|jpe?g|webp|avif)(?:[?#].*)?$/i
 const IMAGE_SOURCE_RE = /\b(tap[-\s]?list|wine-list|bar-menu|drink[-\s]?menu|drinks[-\s]?menu|menu|menus)\b/i
 const STATIC_ASSET_RE = /\.(css|m?js|map|woff2?|ttf|otf)(?:[?#].*)?$/i


### PR DESCRIPTION
## What changed

- Tightened official-menu extraction filters for false positives found during the larger dry run:
  - `Non-Alc` / `Non - Alc.` shorthand
  - apple-cider-vinaigrette food rows
  - beer-in-food-description rows such as macaroni/panko/deep-fried items
- Tightened source discovery and seed building so breakfast/kids menu URLs are blocked even when filenames use underscores.
- Broadened `.gitignore` so generated `official-menu-seeds*.json` files stay local.
- Updated `docs/PROJECT-STATUS.md` with the June 3 hardening and second dry-run summary.

## Dry-run outcome

Rebuilt seeds from the large discovery artifact and reran the crawler with no writes:

- Sources: 202
- Fetched: 195
- Linked fetched: 131
- Linked failed: 11
- Candidates found: 39
- Failed sources: 7 (`HTTP 403` x1, `HTTP 500` x1, `HTTP 404` x5)
- Inserted pending reports: 0

Generated local review pack:

- `scripts/official-menu-review-next.json`
- `scripts/official-menu-review-next.csv`
- Suggested decisions: 9 `approve_suggested`, 30 `needs_manual_review`

No production import was run. The review rows still need manual review before inserting pending reports.

## Verification

- Focused official-menu tests
- Seed-builder smoke test for breakfast/kids underscore filtering
- `npm test` -> 248/248 passed
- `npx tsc --noEmit`
- `npm run lint` -> passed with existing warnings only
- `npm run build` -> passed with existing warnings only
- `git diff --check`
- No-write crawler run with `--no-ocr --follow-links --linked-source-limit 2`
