### PR TITLE
Measure editorial and page-depth impact

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,11 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Editorial/page-depth measurement ready (2026-06-03)
+- **Issue #140 / branch `codex/measure-editorial-impact-140` / commit `c587238`:** added one Vercel+GA4 event helper and tracked link wrapper, then wired article hub/rail/detail clicks, article-to-pub clicks, report-price CTAs, pub-page nearby/internal clicks, and website/directions clicks so the page-depth/editorial push can be measured instead of guessed.
+- **Snapshot process:** expanded `docs/seo-snapshots/TEMPLATE.md` with editorial URL baselines, article engagement metrics, pub-page engagement events, and thin-content watch notes for the first weekly baseline.
+- **Verification:** verified `npx tsc --noEmit`, `git diff --check`, `npm run lint` (existing warnings only), `npm test` (**249/249 tests**), `npm run test:e2e` (**4/4 Playwright tests**), `npm run build`, reviewer sub-agent LGTM, and desktop/mobile screenshots for `/articles`, `/articles/pints-under-10-perth`, and `/perth/18-knots-rooftop-bar` under `/tmp/perth-pint-prices-measure-140/`.
+
 ### Pub-page depth work in progress (2026-06-03)
 - **Issue #138 / branch `codex/pub-page-depth-138` / commits `6c737d6`, `c690a0f`:** added fact-earned pub-page quick reads, cleaner price-card contrast, best-time/nearby summary copy, gated seeded mini FAQs for pubs with enough real answers, and de-duplicated metadata via the pub voice builders. Reviewer follow-up normalized happy-hour metadata labels, removed duplicate Tier-C stub copy, and updated PR proof for the new nearby heading states. Visual proof covers priced, Tier-C, and FAQ-rich pub states under `/tmp/perth-pint-prices-pub-depth-138/`.
 - **Verification:** verified `npx tsc --noEmit`, `git diff --check`, `npm run lint` (existing warnings only), `npm test` (**249/249 tests**), `npm run test:e2e` (**4/4 Playwright tests**), `npm run build`, and desktop/mobile browser screenshots.

--- a/docs/seo-snapshots/TEMPLATE.md
+++ b/docs/seo-snapshots/TEMPLATE.md
@@ -71,6 +71,56 @@ Use `Session source` or `Session source / medium` to split Google, Bing, and Duc
 | bing / organic |  |  |  |  |  |
 | duckduckgo / organic |  |  |  |  |  |
 
+## Editorial & Page-Depth Measurement
+
+Use this section for the article system and beefed-out pub/suburb pages. The first baseline should be captured within one week of publishing a new article batch, then compared weekly.
+
+### Editorial URL Baseline
+
+| URL | GSC clicks | GSC impressions | CTR | Average position | Indexed status | Note |
+|---|---:|---:|---:|---:|---|---|
+| `/articles` |  |  |  |  |  |  |
+| `/articles/pints-under-10-perth` |  |  |  |  |  |  |
+| `/articles/perth-happy-hours-by-day` |  |  |  |  |  |  |
+| `/articles/proper-pint-schooner-middy-perth` |  |  |  |  |  |  |
+
+### Editorial Engagement
+
+Use GA4 pages + screens for page engagement, then the events below for internal movement and report-price intent.
+
+| Surface | Sessions | Engaged sessions | Avg engagement time | `article_click` | `article_internal_click` | `article_pub_click` | `report_price_click` | Note |
+|---|---:|---:|---:|---:|---:|---:|---:|---|
+| `/articles` |  |  |  |  |  |  |  |  |
+| Article detail pages |  |  |  |  |  |  |  |  |
+| Pub pages |  |  |  |  |  |  |  |  |
+| Suburb pages |  |  |  |  |  |  |  |  |
+
+### Pub-Page Engagement
+
+| Surface | `report_price_click` | `pub_nearby_click` | `pub_external_click` | `pub_internal_click` | Note |
+|---|---:|---:|---:|---:|---|
+| Priced pub pages |  |  |  |  |  |
+| Tier-C pub pages |  |  |  |  |  |
+| Pub pages from article clicks |  |  |  |  |  |
+
+Tracked event names:
+
+- `article_click`: card/link clicks into article detail pages from hubs and rails.
+- `article_hub_click`: clicks back to `/articles`.
+- `article_internal_click`: article related-link clicks to non-pub site pages.
+- `article_pub_click`: article live-module clicks into pub pages.
+- `report_price_click`: report-price CTA clicks from article, home, and pub surfaces.
+- `report_price_open`: form auto-opens from `?submit=1`, useful for direct/shared article CTAs.
+- `pub_nearby_click`: pub-page nearby-price clicks, including Tier-C nearest checked pub links.
+- `pub_external_click`: pub-page website and directions clicks.
+- `pub_internal_click`: pub-page clicks to non-pub site pages such as suburb pages.
+
+### Thin-Content Watch
+
+- Article URLs with impressions but weak engagement:
+- Pub/suburb pages gaining impressions after page-depth work:
+- Pages to rewrite, noindex, or consolidate:
+
 ## AI-Referral Callouts
 
 Report every AI/search-assistant source with more than 0 sessions. If none are present, write `None observed this period`.

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -21,6 +21,7 @@ import MobileNav from '@/components/MobileNav'
 import PintIndexBadge from '@/components/PintIndexBadge'
 import ScrollReveal from '@/components/ScrollReveal'
 import ArticleRail from '@/components/ArticleRail'
+import { trackSiteEvent } from '@/lib/analytics'
 
 const INITIAL_PUB_COUNT = 10
 const HH_ROTATE_INTERVAL = 4000
@@ -122,9 +123,15 @@ function HomeContent({ initialPubs }: { initialPubs: Pub[] }) {
   const headerRef = useRef<HTMLElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
 
+  const openSubmitForm = useCallback((source: string) => {
+    trackSiteEvent('report_price_click', { source })
+    setShowSubmitForm(true)
+  }, [])
+
   // Auto-open submit form when ?submit=1 is in URL (e.g. from suburb page links)
   useEffect(() => {
     if (searchParams.get('submit') === '1') {
+      trackSiteEvent('report_price_open', { source: 'submit_query_param' })
       setShowSubmitForm(true)
       // Clean the param from URL
       const params = new URLSearchParams(searchParams.toString())
@@ -338,7 +345,7 @@ function HomeContent({ initialPubs }: { initialPubs: Pub[] }) {
         <div className="flex items-center gap-2">
           <PintIndexBadge />
           <button
-            onClick={() => setShowSubmitForm(true)}
+            onClick={() => openSubmitForm('home_header')}
             className="hidden sm:inline-flex font-mono text-[0.72rem] font-bold uppercase tracking-[0.05em] text-ink bg-white border-3 border-ink rounded-pill px-5 py-2.5 shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all cursor-pointer"
             data-submit-trigger
           >
@@ -359,6 +366,7 @@ function HomeContent({ initialPubs }: { initialPubs: Pub[] }) {
       <ArticleRail
         title="Pub notes with numbers attached"
         intro="Start with the new under-$10 list, then sanity-check happy hours and glass sizes before someone declares a $9 schooner a bargain."
+        source="home_article_rail"
       />
 
       {/* ═══ FILTER BAR - below header, above content ═══ */}
@@ -408,7 +416,7 @@ function HomeContent({ initialPubs }: { initialPubs: Pub[] }) {
       </div>
 
       <ScrollReveal><HowItWorks venueCount={pubs.length} suburbCount={suburbs.length} /></ScrollReveal>
-      <ScrollReveal><SocialProof venueCount={pubs.length} suburbCount={suburbs.length} avgPrice={stats.avgPrice} cheapestPrice={stats.minPrice} priciestPrice={stats.maxPriceValue} onSubmitClick={() => setShowSubmitForm(true)} /></ScrollReveal>
+      <ScrollReveal><SocialProof venueCount={pubs.length} suburbCount={suburbs.length} avgPrice={stats.avgPrice} cheapestPrice={stats.minPrice} priciestPrice={stats.maxPriceValue} onSubmitClick={() => openSubmitForm('home_social_proof')} /></ScrollReveal>
       <ScrollReveal><FAQ /></ScrollReveal>
       <Footer />
 

--- a/src/app/[suburb]/[pub]/PubDetailClient.tsx
+++ b/src/app/[suburb]/[pub]/PubDetailClient.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/lib/voiceCopy'
 import { formatDistance } from '@/lib/location'
 import { describePriceSource } from '@/lib/priceProvenance'
+import { trackSiteEvent } from '@/lib/analytics'
 import type { PriceRecencyInfo, PriceRecencyTier } from '@/lib/freshness'
 
 const PubDetailMap = dynamic(() => import('@/components/PubDetailMap'), {
@@ -250,6 +251,17 @@ export default function PubDetailClient({
     },
   ].filter((item): item is PubFaq => Boolean(item.answer))
   const showFaq = faqItems.length >= 3
+  const trackingTier = isTierCPage ? 'tier_c' : 'priced'
+
+  function openReportForm(source: string) {
+    trackSiteEvent('report_price_click', {
+      source,
+      pub_slug: pub.slug,
+      suburb: pub.suburb,
+      page_tier: trackingTier,
+    })
+    setShowSubmitForm(true)
+  }
 
   return (
     <div className="min-h-screen bg-[#FDF8F0]">
@@ -373,6 +385,14 @@ export default function PubDetailClient({
                   {nearestVerifiedPub ? (
                     <Link
                       href={pubUrl({ suburb: nearestVerifiedPub.suburb, slug: nearestVerifiedPub.slug })}
+                      onClick={() => trackSiteEvent('pub_nearby_click', {
+                        source: 'pub_missing_price_stub',
+                        pub_slug: pub.slug,
+                        suburb: pub.suburb,
+                        target_slug: nearestVerifiedPub.slug,
+                        target_suburb: nearestVerifiedPub.suburb,
+                        page_tier: trackingTier,
+                      })}
                       className="block text-[0.86rem] leading-relaxed text-ink hover:text-amber transition-colors no-underline"
                     >
                       {priceMissingCopy}
@@ -411,7 +431,7 @@ export default function PubDetailClient({
 
             {/* Report a price — prominent CTA */}
             <button
-              onClick={() => setShowSubmitForm(true)}
+              onClick={() => openReportForm('pub_page_cta')}
               className={`w-full flex items-center justify-center gap-2 font-mono font-bold uppercase tracking-[0.05em] border-3 border-ink rounded-pill shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all ${
                 isTierCPage
                   ? 'text-white bg-amber py-4 text-[0.85rem]'
@@ -440,6 +460,12 @@ export default function PubDetailClient({
                   href={pub.website}
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={() => trackSiteEvent('pub_external_click', {
+                    action: 'website',
+                    pub_slug: pub.slug,
+                    suburb: pub.suburb,
+                    page_tier: trackingTier,
+                  })}
                   className="flex-1 font-mono text-[0.72rem] font-bold uppercase tracking-[0.05em] text-white bg-amber border-3 border-ink rounded-pill py-2.5 shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all text-center no-underline"
                 >
                   Visit Website
@@ -449,6 +475,12 @@ export default function PubDetailClient({
                 href={directionsUrl}
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={() => trackSiteEvent('pub_external_click', {
+                  action: 'directions',
+                  pub_slug: pub.slug,
+                  suburb: pub.suburb,
+                  page_tier: trackingTier,
+                })}
                 className="flex-1 font-mono text-[0.72rem] font-bold uppercase tracking-[0.05em] text-white bg-ink border-3 border-ink rounded-pill py-2.5 shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all text-center no-underline"
               >
                 Get Directions
@@ -475,6 +507,12 @@ export default function PubDetailClient({
               </div>
               <Link
                 href={suburbUrl(pub.suburb)}
+                onClick={() => trackSiteEvent('pub_internal_click', {
+                  source: 'pub_nearby_header',
+                  pub_slug: pub.slug,
+                  suburb: pub.suburb,
+                  target_path: suburbUrl(pub.suburb),
+                })}
                 className="font-mono text-[0.7rem] font-bold text-amber hover:underline no-underline whitespace-nowrap"
               >
                 View suburb →
@@ -494,6 +532,17 @@ export default function PubDetailClient({
                   key={nearby.id}
                   href={pubUrl({ suburb: nearby.suburb, slug: nearby.slug })}
                   aria-label={`${nearby.name} in ${nearby.suburb}: ${priceText} pints${distanceText ? `, ${distanceText}` : ''}`}
+                  onClick={() => trackSiteEvent('pub_nearby_click', {
+                    source: 'pub_nearby_list',
+                    pub_slug: pub.slug,
+                    suburb: pub.suburb,
+                    target_slug: nearby.slug,
+                    target_suburb: nearby.suburb,
+                    target_price: nearby.price,
+                    cheaper: priceDelta !== null && priceDelta > 0,
+                    page_tier: trackingTier,
+                    position: i + 1,
+                  })}
                   className={`flex items-center justify-between px-4 py-3 no-underline group hover:bg-off-white transition-colors ${
                     i < nearbyPubs.length - 1 ? 'border-b border-gray-light' : ''
                   }`}

--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from 'next'
 import Image from 'next/image'
-import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { ArrowUpRight, Beer, CalendarDays, Clock, GlassWater } from 'lucide-react'
 import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 import Footer from '@/components/Footer'
 import SubPageNav from '@/components/SubPageNav'
+import TrackedLink from '@/components/TrackedLink'
 import { buildArticleJsonLd } from '@/lib/articleJsonLd'
 import { absoluteArticleUrl, articleUrl, articles, formatArticleDate, getArticle, type ArticleInlineImage } from '@/lib/articles'
 import { formatHappyHourDays } from '@/lib/happyHourLive'
@@ -58,6 +58,42 @@ function formatPrice(price: number | null | undefined): string {
   return price == null ? 'TBC' : `$${price.toFixed(2)}`
 }
 
+function relatedLinkTracking(link: { href: string; label: string }) {
+  if (link.href === '/?submit=1') {
+    return {
+      eventName: 'report_price_click',
+      eventProperties: {
+        target_path: link.href,
+        target_label: link.label,
+      },
+    }
+  }
+
+  const pathParts = link.href.split('?')[0].split('/').filter(Boolean)
+  const isPubDetailPath = pathParts.length === 2 && !['articles', 'guides', 'insights'].includes(pathParts[0])
+
+  if (isPubDetailPath) {
+    return {
+      eventName: 'article_pub_click',
+      eventProperties: {
+        source: 'article_related_links',
+        target_path: link.href,
+        target_label: link.label,
+        suburb_slug: pathParts[0],
+        pub_slug: pathParts[1],
+      },
+    }
+  }
+
+  return {
+    eventName: 'article_internal_click',
+    eventProperties: {
+      target_path: link.href,
+      target_label: link.label,
+    },
+  }
+}
+
 function ArticleFigure({ image }: { image: ArticleInlineImage }) {
   return (
     <figure className="my-5 overflow-hidden rounded-card border-3 border-ink bg-white shadow-hard-sm">
@@ -102,7 +138,7 @@ function parseHappyHourDayIndexes(days: string | null): number[] {
     .filter((value): value is number => value !== undefined)
 }
 
-function Under10Module({ pubs }: { pubs: Pub[] }) {
+function Under10Module({ pubs, articleSlug }: { pubs: Pub[]; articleSlug: string }) {
   const under10 = pubs
     .filter(pub => pub.priceVerified && pub.regularPrice !== null && pub.regularPrice < 10)
     .sort((a, b) => (a.regularPrice ?? 99) - (b.regularPrice ?? 99))
@@ -129,8 +165,21 @@ function Under10Module({ pubs }: { pubs: Pub[] }) {
         <Beer className="h-5 w-5 text-amber" />
       </div>
       <div className="divide-y divide-gray-light">
-        {under10.map(pub => (
-          <Link key={pub.id} href={pubUrl(pub)} className="group flex items-center justify-between gap-4 py-3 no-underline">
+        {under10.map((pub, index) => (
+          <TrackedLink
+            key={pub.id}
+            href={pubUrl(pub)}
+            eventName="article_pub_click"
+            eventProperties={{
+              source: 'article_under10_module',
+              article_slug: articleSlug,
+              pub_slug: pub.slug,
+              suburb: pub.suburb,
+              position: index + 1,
+              price: pub.regularPrice,
+            }}
+            className="group flex items-center justify-between gap-4 py-3 no-underline"
+          >
             <div className="min-w-0">
               <p className="truncate font-mono text-[0.86rem] font-extrabold text-ink group-hover:text-amber">{pub.name}</p>
               <p className="text-[0.68rem] text-gray-mid">
@@ -138,14 +187,14 @@ function Under10Module({ pubs }: { pubs: Pub[] }) {
               </p>
             </div>
             <span className="font-mono text-lg font-extrabold text-ink">{formatPrice(pub.regularPrice)}</span>
-          </Link>
+          </TrackedLink>
         ))}
       </div>
     </section>
   )
 }
 
-function HappyHoursByDayModule({ pubs }: { pubs: Pub[] }) {
+function HappyHoursByDayModule({ pubs, articleSlug }: { pubs: Pub[]; articleSlug: string }) {
   const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
   const rows = days.map((day, index) => {
     const dayPubs = pubs
@@ -169,9 +218,21 @@ function HappyHoursByDayModule({ pubs }: { pubs: Pub[] }) {
             <p className="font-mono text-[0.8rem] font-extrabold text-ink">{row.day}</p>
             {row.cheapest ? (
               <>
-                <Link href={pubUrl(row.cheapest)} className="mt-2 block font-mono text-[0.82rem] font-bold text-amber hover:underline">
+                <TrackedLink
+                  href={pubUrl(row.cheapest)}
+                  eventName="article_pub_click"
+                  eventProperties={{
+                    source: 'article_happy_hour_day_module',
+                    article_slug: articleSlug,
+                    pub_slug: row.cheapest.slug,
+                    suburb: row.cheapest.suburb,
+                    day: row.day,
+                    price: row.cheapest.happyHourPrice,
+                  }}
+                  className="mt-2 block font-mono text-[0.82rem] font-bold text-amber hover:underline"
+                >
                   {row.cheapest.name}
-                </Link>
+                </TrackedLink>
                 <p className="mt-1 text-[0.68rem] text-gray-mid">
                   {formatPrice(row.cheapest.happyHourPrice)} - {formatHappyHourDays(row.cheapest.happyHourDays)}
                 </p>
@@ -213,9 +274,9 @@ function GlassSizesModule() {
   )
 }
 
-function ArticleLiveModule({ module, pubs }: { module: string; pubs: Pub[] }) {
-  if (module === 'under10') return <Under10Module pubs={pubs} />
-  if (module === 'happyHoursByDay') return <HappyHoursByDayModule pubs={pubs} />
+function ArticleLiveModule({ module, pubs, articleSlug }: { module: string; pubs: Pub[]; articleSlug: string }) {
+  if (module === 'under10') return <Under10Module pubs={pubs} articleSlug={articleSlug} />
+  if (module === 'happyHoursByDay') return <HappyHoursByDayModule pubs={pubs} articleSlug={articleSlug} />
   return <GlassSizesModule />
 }
 
@@ -315,28 +376,46 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
             )
           })}
 
-          <ArticleLiveModule module={article.liveModule} pubs={pubs} />
+          <ArticleLiveModule module={article.liveModule} pubs={pubs} articleSlug={article.slug} />
 
           <section className="rounded-card border-3 border-ink bg-ink p-5 shadow-hard-sm">
             <h2 className="font-mono text-lg font-extrabold text-white">Keep going</h2>
             <div className="mt-4 grid gap-3 sm:grid-cols-3">
-              {article.relatedLinks.map(link => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  className="flex min-h-[88px] flex-col justify-between rounded-card border border-white/15 bg-white/5 p-4 no-underline transition-colors hover:bg-white/10"
-                >
-                  <span className="font-mono text-[0.8rem] font-bold leading-tight text-white">{link.label}</span>
-                  <ArrowUpRight className="mt-3 h-4 w-4 text-amber-light" />
-                </Link>
-              ))}
+              {article.relatedLinks.map((link, index) => {
+                const tracking = relatedLinkTracking(link)
+                return (
+                  <TrackedLink
+                    key={link.href}
+                    href={link.href}
+                    eventName={tracking.eventName}
+                    eventProperties={{
+                      source: 'article_related_links',
+                      article_slug: article.slug,
+                      position: index + 1,
+                      ...tracking.eventProperties,
+                    }}
+                    className="flex min-h-[88px] flex-col justify-between rounded-card border border-white/15 bg-white/5 p-4 no-underline transition-colors hover:bg-white/10"
+                  >
+                    <span className="font-mono text-[0.8rem] font-bold leading-tight text-white">{link.label}</span>
+                    <ArrowUpRight className="mt-3 h-4 w-4 text-amber-light" />
+                  </TrackedLink>
+                )
+              })}
             </div>
           </section>
 
           <div className="pt-2">
-            <Link href={articleUrl(article.slug) === '/articles/pints-under-10-perth' ? '/?submit=1' : '/articles'} className="font-mono text-[0.75rem] font-bold uppercase text-amber hover:underline">
+            <TrackedLink
+              href={articleUrl(article.slug) === '/articles/pints-under-10-perth' ? '/?submit=1' : '/articles'}
+              eventName={articleUrl(article.slug) === '/articles/pints-under-10-perth' ? 'report_price_click' : 'article_hub_click'}
+              eventProperties={{
+                source: 'article_detail_bottom_cta',
+                article_slug: article.slug,
+              }}
+              className="font-mono text-[0.75rem] font-bold uppercase text-amber hover:underline"
+            >
               {articleUrl(article.slug) === '/articles/pints-under-10-perth' ? 'Know a cheaper pint? Report it' : 'Back to articles'}
-            </Link>
+            </TrackedLink>
           </div>
         </div>
       </article>

--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from 'next'
-import Link from 'next/link'
 import { ArrowUpRight, BookOpen, CalendarDays } from 'lucide-react'
 import ArticleImageSlot from '@/components/ArticleImageSlot'
 import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 import Footer from '@/components/Footer'
 import SubPageNav from '@/components/SubPageNav'
+import TrackedLink from '@/components/TrackedLink'
 import { articleUrl, articles, formatArticleDate } from '@/lib/articles'
 
 const canonical = 'https://perthpintprices.com/articles'
@@ -50,7 +50,17 @@ export default function ArticlesPage() {
         </div>
 
         {featured && (
-          <Link href={articleUrl(featured.slug)} className="group block no-underline mb-10">
+          <TrackedLink
+            href={articleUrl(featured.slug)}
+            eventName="article_click"
+            eventProperties={{
+              source: 'articles_hub_featured',
+              slug: featured.slug,
+              category: featured.category,
+              position: 1,
+            }}
+            className="group block no-underline mb-10"
+          >
             <article className="overflow-hidden rounded-card border-3 border-ink bg-white shadow-hard-sm transition-all group-hover:translate-x-[1.5px] group-hover:translate-y-[1.5px] group-hover:shadow-hard-hover">
               <div className="grid sm:grid-cols-[1fr_260px]">
                 <div className="bg-ink p-6 text-white sm:p-8">
@@ -90,7 +100,7 @@ export default function ArticlesPage() {
                 </div>
               </div>
             </article>
-          </Link>
+          </TrackedLink>
         )}
 
         <section>
@@ -99,10 +109,17 @@ export default function ArticlesPage() {
             <BookOpen className="h-5 w-5 text-gray-mid" />
           </div>
           <div className="grid gap-5 sm:grid-cols-2">
-            {rest.map(article => (
-              <Link
+            {rest.map((article, index) => (
+              <TrackedLink
                 key={article.slug}
                 href={articleUrl(article.slug)}
+                eventName="article_click"
+                eventProperties={{
+                  source: 'articles_hub_latest',
+                  slug: article.slug,
+                  category: article.category,
+                  position: index + 2,
+                }}
                 className="group flex min-h-[390px] flex-col overflow-hidden rounded-card border-3 border-ink bg-white shadow-hard-sm transition-all hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover no-underline"
               >
                 <ArticleImageSlot article={article} size="card" className="aspect-[16/9] border-b-3 border-ink" />
@@ -122,7 +139,7 @@ export default function ArticlesPage() {
                     Read it <ArrowUpRight className="h-3.5 w-3.5" />
                   </span>
                 </div>
-              </Link>
+              </TrackedLink>
             ))}
           </div>
         </section>

--- a/src/app/discover/DiscoverClient.tsx
+++ b/src/app/discover/DiscoverClient.tsx
@@ -153,6 +153,7 @@ export default function DiscoverClient() {
             eyebrow="New"
             title="Pub notes worth reading first"
             intro="The price-led explainers behind the lists: under-$10 pints, happy hours that actually drop, and why glass size does the maths."
+            source="discover_article_rail"
           />
         </div>
 

--- a/src/components/ArticleRail.tsx
+++ b/src/components/ArticleRail.tsx
@@ -1,6 +1,6 @@
-import Link from 'next/link'
 import { ArrowUpRight, BookOpen } from 'lucide-react'
 import ArticleImageSlot from '@/components/ArticleImageSlot'
+import TrackedLink from '@/components/TrackedLink'
 import { articleUrl, articles, formatArticleDate } from '@/lib/articles'
 
 interface ArticleRailProps {
@@ -9,6 +9,7 @@ interface ArticleRailProps {
   intro?: string
   limit?: number
   variant?: 'light' | 'dark'
+  source?: string
 }
 
 export default function ArticleRail({
@@ -17,6 +18,7 @@ export default function ArticleRail({
   intro = 'Useful drinking notes with the prices left in.',
   limit = 3,
   variant = 'light',
+  source = 'article_rail',
 }: ArticleRailProps) {
   const shownArticles = articles.slice(0, limit)
   const isDark = variant === 'dark'
@@ -40,10 +42,17 @@ export default function ArticleRail({
         </div>
 
         <div className="grid gap-4 sm:grid-cols-3">
-          {shownArticles.map(article => (
-            <Link
+          {shownArticles.map((article, index) => (
+            <TrackedLink
               key={article.slug}
               href={articleUrl(article.slug)}
+              eventName="article_click"
+              eventProperties={{
+                source,
+                slug: article.slug,
+                category: article.category,
+                position: index + 1,
+              }}
               className={`group flex min-h-[380px] flex-col overflow-hidden rounded-card border-3 no-underline shadow-hard-sm transition-all hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover ${
                 isDark
                   ? 'border-white/20 bg-white text-ink'
@@ -67,18 +76,20 @@ export default function ArticleRail({
                   Read it <ArrowUpRight className="h-3.5 w-3.5" />
                 </span>
               </div>
-            </Link>
+            </TrackedLink>
           ))}
         </div>
 
-        <Link
+        <TrackedLink
           href="/articles"
+          eventName="article_hub_click"
+          eventProperties={{ source }}
           className={`mt-5 inline-flex items-center gap-1 font-mono text-[0.72rem] font-bold uppercase no-underline hover:underline ${
             isDark ? 'text-amber-light' : 'text-amber'
           }`}
         >
           All articles <ArrowUpRight className="h-3.5 w-3.5" />
-        </Link>
+        </TrackedLink>
       </div>
     </section>
   )

--- a/src/components/TrackedLink.tsx
+++ b/src/components/TrackedLink.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import Link from 'next/link'
+import type { ComponentProps, MouseEventHandler } from 'react'
+import { trackSiteEvent, type AnalyticsProperties } from '@/lib/analytics'
+
+type TrackedLinkProps = Omit<ComponentProps<typeof Link>, 'onClick'> & {
+  eventName: string
+  eventProperties?: AnalyticsProperties
+  onClick?: MouseEventHandler<HTMLAnchorElement>
+}
+
+export default function TrackedLink({
+  eventName,
+  eventProperties,
+  onClick,
+  ...props
+}: TrackedLinkProps) {
+  const handleClick: MouseEventHandler<HTMLAnchorElement> = (event) => {
+    trackSiteEvent(eventName, eventProperties)
+    onClick?.(event)
+  }
+
+  return <Link {...props} onClick={handleClick} />
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,29 @@
+'use client'
+
+import { track } from '@vercel/analytics'
+
+export type AnalyticsPropertyValue = string | number | boolean
+export type AnalyticsProperties = Record<string, AnalyticsPropertyValue | null | undefined>
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void
+  }
+}
+
+function cleanProperties(properties: AnalyticsProperties): Record<string, AnalyticsPropertyValue> {
+  return Object.fromEntries(
+    Object.entries(properties).filter((entry): entry is [string, AnalyticsPropertyValue] => (
+      entry[1] !== null && entry[1] !== undefined
+    )),
+  )
+}
+
+export function trackSiteEvent(name: string, properties: AnalyticsProperties = {}) {
+  const clean = cleanProperties(properties)
+  track(name, clean)
+
+  if (typeof window !== 'undefined') {
+    window.gtag?.('event', name, clean)
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared Vercel+GA4 event helper plus a tracked Link wrapper
- instrument article hub/rail/detail clicks, article-to-pub movement, report-price CTAs, pub nearby/internal clicks, and pub website/directions clicks
- expand the weekly SEO snapshot template with editorial baselines, engagement events, and pub-page measurement

Closes #140

## Verification
- `npx tsc --noEmit`
- `git diff --check`
- `npm run lint` (existing warnings only)
- `npm test` (249/249)
- `npm run test:e2e` (4/4)
- `npm run build`
- Independent reviewer: LGTM after one measurement-classification fix

## Screenshot proof
- `/tmp/perth-pint-prices-measure-140/articles-desktop.png`
- `/tmp/perth-pint-prices-measure-140/articles-mobile.png`
- `/tmp/perth-pint-prices-measure-140/article-detail-desktop.png`
- `/tmp/perth-pint-prices-measure-140/article-detail-mobile.png`
- `/tmp/perth-pint-prices-measure-140/pub-desktop.png`
- `/tmp/perth-pint-prices-measure-140/pub-mobile.png`