### PR TITLE
Add cheap-pints and happy-hour day landing pages

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,12 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### High-intent landing pages ready for preview (2026-06-03)
+- **Issue #32 first slice / branch `codex/high-intent-landing-pages-32` / commit `68754c5`:** added `/cheapest-pints` as a verified regular-price landing page and `/happy-hour/[day]` static pages for all seven weekdays, with canonical metadata, OG/Twitter tags, Breadcrumb + ItemList JSON-LD, answer-first copy, ranked rows, Q&A blocks, and useful internal links.
+- **Happy-hour day linking:** added a planning-board rail to `/happy-hour`, linked Cheap Pints from the footer, added the new pages to `sitemap.xml`, and exposed `/cheapest-pints` in `/llms.txt`.
+- **Data guardrails:** added a shared happy-hour day parser with tests for weekday ranges, wrapped ranges, en-dash ranges, daily labels, weekday/weekend labels, and Postgres array-ish strings. Day pages sort by `happyHourPrice`, show `TBC` when a deal has no confirmed price, and avoid mixing regular pint prices into happy-hour claims.
+- **Verification:** verified `npm test` (**254/254 tests**), `npx tsc --noEmit`, `git diff --check`, `npm run lint` (existing warnings only), `npm run build`, `npm run test:e2e` (**4/4 Playwright tests**), reviewer sub-agent LGTM, and desktop/mobile in-app browser screenshots under `/tmp/perth-pint-prices-high-intent-32/`.
+
 ### Editorial/page-depth measurement ready (2026-06-03)
 - **Issue #140 / branch `codex/measure-editorial-impact-140` / commit `c587238`:** added one Vercel+GA4 event helper and tracked link wrapper, then wired article hub/rail/detail clicks, article-to-pub clicks, report-price CTAs, pub-page nearby/internal clicks, and website/directions clicks so the page-depth/editorial push can be measured instead of guessed.
 - **Snapshot process:** expanded `docs/seo-snapshots/TEMPLATE.md` with editorial URL baselines, article engagement metrics, pub-page engagement events, and thin-content watch notes for the first weekly baseline.

--- a/src/app/cheapest-pints/page.tsx
+++ b/src/app/cheapest-pints/page.tsx
@@ -1,0 +1,200 @@
+import type { Metadata } from 'next'
+import Image from 'next/image'
+import Link from 'next/link'
+import { ArrowUpRight, Beer, CalendarDays, ListChecks } from 'lucide-react'
+import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
+import Footer from '@/components/Footer'
+import SubPageNav from '@/components/SubPageNav'
+import { getPubs } from '@/lib/supabase'
+import { BASE_URL, pubUrl } from '@/lib/urls'
+import type { Pub } from '@/types/pub'
+
+const canonical = `${BASE_URL}/cheapest-pints`
+const description = 'The cheapest verified pints in Perth, sorted from live Perth Pint Prices data with checked dates, suburb notes, and useful pub links.'
+
+export const revalidate = 3600
+
+export const metadata: Metadata = {
+  title: 'Cheapest Pints in Perth',
+  description,
+  alternates: { canonical },
+  openGraph: {
+    title: 'Cheapest Pints in Perth | Perth Pint Prices',
+    description,
+    url: canonical,
+    type: 'website',
+    siteName: 'Perth Pint Prices',
+    locale: 'en_AU',
+    images: [{ url: `${BASE_URL}/articles/pints-under-10-perth-01-fremantle-6-pint.png`, width: 1200, height: 630, alt: 'A cheap Perth pint on a pub table' }],
+  },
+  twitter: { card: 'summary_large_image' },
+}
+
+function formatPrice(price: number | null | undefined): string {
+  if (price == null) return 'TBC'
+  return Number.isInteger(price) ? `$${price.toFixed(0)}` : `$${price.toFixed(2)}`
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return 'date TBC'
+  return new Date(value).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: 'numeric', timeZone: 'Australia/Perth' })
+}
+
+function buildItemList(rows: Pub[]) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: 'Cheapest verified pints in Perth',
+    itemListOrder: 'https://schema.org/ItemListOrderAscending',
+    numberOfItems: rows.length,
+    itemListElement: rows.slice(0, 20).map((pub, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      url: `${BASE_URL}${pubUrl(pub)}`,
+      name: `${pub.name} - ${formatPrice(pub.regularPrice)} pint`,
+    })),
+  }
+}
+
+export default async function CheapestPintsPage() {
+  const pubs = await getPubs()
+  const verified = pubs
+    .filter(pub => pub.priceVerified && pub.regularPrice !== null)
+    .sort((a, b) => (a.regularPrice ?? 999) - (b.regularPrice ?? 999))
+  const under10 = verified.filter(pub => (pub.regularPrice ?? 999) < 10)
+  const topRows = verified.slice(0, 24)
+  const cheapest = topRows[0] ?? null
+  const suburbCount = new Set(topRows.map(pub => pub.suburb)).size
+  const average = verified.length > 0
+    ? verified.reduce((sum, pub) => sum + (pub.regularPrice ?? 0), 0) / verified.length
+    : null
+
+  return (
+    <main className="min-h-screen bg-[#FDF8F0]">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(buildItemList(topRows)).replace(/</g, '\\u003c') }}
+      />
+      <BreadcrumbJsonLd items={[
+        { name: 'Home', url: BASE_URL },
+        { name: 'Cheapest pints', url: canonical },
+      ]} />
+      <SubPageNav breadcrumbs={[{ label: 'Cheapest pints' }]} />
+
+      <section className="max-w-container mx-auto px-6 pt-8 pb-12">
+        <div className="grid gap-6 sm:grid-cols-[1fr_260px] sm:items-end">
+          <div>
+            <p className="mb-3 font-mono text-[0.68rem] font-bold uppercase text-gray-mid">Live ranked list</p>
+            <h1 className="font-display text-[3rem] leading-[1] text-ink sm:text-[4.8rem]">
+              Cheapest pints in Perth
+            </h1>
+            <p className="mt-5 max-w-[620px] font-body text-[0.96rem] leading-relaxed text-gray-mid">
+              The cheapest verified pint we have right now is {cheapest ? <><span className="font-mono font-bold text-ink">{formatPrice(cheapest.regularPrice)}</span> at {cheapest.name} in {cheapest.suburb}</> : 'still being checked'}. This page only uses pubs with a verified regular pint price, then sorts the lot from cheapest up. Happy-hour prices are useful, but they do not get smuggled into the regular-price table.
+            </p>
+          </div>
+          <div className="overflow-hidden rounded-card border-3 border-ink bg-white shadow-hard-sm">
+            <Image
+              src="/articles/pints-under-10-perth-01-fremantle-6-pint.png"
+              alt="A verified cheap pint in Perth"
+              width={700}
+              height={700}
+              className="aspect-square w-full object-cover"
+              priority
+            />
+          </div>
+        </div>
+
+        <section className="my-8 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Cheapest checked</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{formatPrice(cheapest?.regularPrice)}</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">{cheapest ? `${cheapest.name}, ${cheapest.suburb}` : 'No verified rows yet.'}</p>
+          </div>
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Under $10</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{under10.length}</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Verified regular pint rows below the ten-dollar line.</p>
+          </div>
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">City average</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{formatPrice(average)}</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">{verified.length} verified pubs across the live dataset.</p>
+          </div>
+        </section>
+
+        <section className="mb-8 rounded-card border-3 border-ink bg-ink p-5 text-white shadow-hard-sm">
+          <p className="font-mono text-[0.65rem] font-bold uppercase text-white/55">Answer first</p>
+          <h2 className="mt-2 font-mono text-xl font-extrabold">Where is the cheapest pint in Perth?</h2>
+          <p className="mt-3 font-body text-[0.9rem] leading-relaxed text-white/70">
+            {cheapest ? <>The cheapest verified pint in Perth is {formatPrice(cheapest.regularPrice)} at <Link href={pubUrl(cheapest)} className="font-bold text-amber-light hover:underline">{cheapest.name}</Link> in {cheapest.suburb}, checked {formatDate(cheapest.lastVerified ?? cheapest.priceVerifiedAt)}. The top 24 checked rows currently cover {suburbCount} suburbs, which is why the useful answer is a ranked list rather than one suburb headline.</> : 'We do not have a verified regular pint row to publish yet.'}
+          </p>
+        </section>
+
+        <section className="rounded-card border-3 border-ink bg-white shadow-hard-sm">
+          <div className="flex items-center justify-between gap-4 border-b-3 border-ink bg-off-white px-5 py-4">
+            <div>
+              <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Verified regular prices</p>
+              <h2 className="font-mono text-xl font-extrabold text-ink">Cheapest rows</h2>
+            </div>
+            <ListChecks className="h-5 w-5 text-amber" />
+          </div>
+          <div className="divide-y divide-gray-light">
+            {topRows.map((pub, index) => (
+              <Link key={pub.id} href={pubUrl(pub)} className="group grid grid-cols-[2.25rem_1fr_auto] items-center gap-3 px-5 py-4 no-underline hover:bg-off-white">
+                <span className="font-mono text-[0.72rem] font-bold text-gray-mid">{index + 1}</span>
+                <span className="min-w-0">
+                  <span className="block truncate font-mono text-[0.86rem] font-extrabold text-ink group-hover:text-amber">{pub.name}</span>
+                  <span className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[0.68rem] text-gray-mid">
+                    <span>{pub.suburb}</span>
+                    <span>Checked {formatDate(pub.lastVerified ?? pub.priceVerifiedAt)}</span>
+                    {pub.beerType && <span>{pub.beerType}</span>}
+                  </span>
+                </span>
+                <span className="font-mono text-lg font-extrabold text-ink">{formatPrice(pub.regularPrice)}</span>
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        <section className="mt-8 grid gap-4 sm:grid-cols-2">
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <div className="mb-3 flex items-center gap-2">
+              <Beer className="h-4 w-4 text-amber" />
+              <h2 className="font-mono text-lg font-extrabold text-ink">Useful next clicks</h2>
+            </div>
+            <div className="grid gap-2">
+              {[
+                { href: '/happy-hour', label: 'Happy hours running now' },
+                { href: '/happy-hour/friday', label: 'Friday happy hours' },
+                { href: '/articles/pints-under-10-perth', label: 'Read the under-$10 guide' },
+                { href: '/discover', label: 'Filter every pub price' },
+              ].map(link => (
+                <Link key={link.href} href={link.href} className="flex items-center justify-between rounded-card border border-gray-light px-4 py-3 font-mono text-[0.78rem] font-bold text-ink no-underline hover:border-amber hover:text-amber">
+                  {link.label}<ArrowUpRight className="h-3.5 w-3.5" />
+                </Link>
+              ))}
+            </div>
+          </div>
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <div className="mb-3 flex items-center gap-2">
+              <CalendarDays className="h-4 w-4 text-amber" />
+              <h2 className="font-mono text-lg font-extrabold text-ink">Quick Q&A</h2>
+            </div>
+            <div className="space-y-4">
+              <div>
+                <h3 className="font-mono text-[0.82rem] font-extrabold text-ink">Do happy-hour prices count here?</h3>
+                <p className="mt-1 text-[0.78rem] leading-relaxed text-gray-mid">No. This page ranks regular pint prices only. Happy hours get their own day pages because a one-hour pint is not the same promise as the normal price.</p>
+              </div>
+              <div>
+                <h3 className="font-mono text-[0.82rem] font-extrabold text-ink">Why is a pub missing?</h3>
+                <p className="mt-1 text-[0.78rem] leading-relaxed text-gray-mid">Usually because the regular pint price is still TBC or stale. We would rather show an honest gap than a tidy guess.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+      </section>
+
+      <Footer />
+    </main>
+  )
+}

--- a/src/app/happy-hour/HappyHourClient.tsx
+++ b/src/app/happy-hour/HappyHourClient.tsx
@@ -10,6 +10,7 @@ import { getDistanceKm, formatDistance } from '@/lib/location'
 import { pubUrl } from '@/lib/urls'
 import { getHappyHourStatus, formatHappyHourDays, type HappyHourStatus } from '@/lib/happyHourLive'
 import { getPriceRecency } from '@/lib/freshness'
+import { HAPPY_HOUR_DAYS } from '@/lib/happyHourDays'
 
 type SortMode = 'price' | 'nearest'
 
@@ -293,6 +294,29 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
             </div>
           </section>
         )}
+
+        <section className="mb-6 rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+          <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="font-mono text-[0.65rem] font-bold uppercase tracking-[0.05em] text-gray-mid">Planning board</p>
+              <h2 className="font-mono text-[1.15rem] font-extrabold leading-tight text-ink">Happy hours by day</h2>
+            </div>
+            <Link href="/articles/perth-happy-hours-by-day" className="font-mono text-[0.72rem] font-bold uppercase text-amber no-underline hover:underline">
+              Read the guide →
+            </Link>
+          </div>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-7">
+            {HAPPY_HOUR_DAYS.map(day => (
+              <Link
+                key={day.slug}
+                href={`/happy-hour/${day.slug}`}
+                className="rounded-card border border-gray-light bg-off-white px-3 py-3 text-center font-mono text-[0.72rem] font-bold uppercase text-ink no-underline hover:border-amber hover:text-amber"
+              >
+                {day.label.slice(0, 3)}
+              </Link>
+            ))}
+          </div>
+        </section>
 
         {/* Sort Controls */}
         {!loading && pubs.length > 0 && (

--- a/src/app/happy-hour/[day]/page.tsx
+++ b/src/app/happy-hour/[day]/page.tsx
@@ -1,0 +1,241 @@
+import type { Metadata } from 'next'
+import Image from 'next/image'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ArrowUpRight, Clock, GlassWater } from 'lucide-react'
+import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
+import Footer from '@/components/Footer'
+import SubPageNav from '@/components/SubPageNav'
+import { HAPPY_HOUR_DAYS, getHappyHourDayBySlug, pubHasHappyHourOnDay } from '@/lib/happyHourDays'
+import { formatHappyHourDays } from '@/lib/happyHourLive'
+import { getPubs } from '@/lib/supabase'
+import { BASE_URL, pubUrl } from '@/lib/urls'
+import type { Pub } from '@/types/pub'
+
+type DayPageProps = {
+  params: { day: string }
+}
+
+export const revalidate = 3600
+
+export function generateStaticParams() {
+  return HAPPY_HOUR_DAYS.map(day => ({ day: day.slug }))
+}
+
+export function generateMetadata({ params }: DayPageProps): Metadata {
+  const day = getHappyHourDayBySlug(params.day)
+  if (!day) return {}
+  const canonical = `${BASE_URL}/happy-hour/${day.slug}`
+  const description = `${day.label} happy hours in Perth, sorted by checked happy-hour deals with venues, suburbs, windows, and useful links.`
+
+  return {
+    title: `${day.label} Happy Hours Perth`,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title: `${day.label} Happy Hours Perth | Perth Pint Prices`,
+      description,
+      url: canonical,
+      type: 'website',
+      siteName: 'Perth Pint Prices',
+      locale: 'en_AU',
+      images: [{ url: `${BASE_URL}/articles/perth-happy-hours-by-day-01-5pm-window.png`, width: 1200, height: 630, alt: `${day.label} happy hours in Perth` }],
+    },
+    twitter: { card: 'summary_large_image' },
+  }
+}
+
+function formatPrice(price: number | null | undefined): string {
+  if (price == null) return 'TBC'
+  return Number.isInteger(price) ? `$${price.toFixed(0)}` : `$${price.toFixed(2)}`
+}
+
+function formatTime(value: string | null): string {
+  if (!value) return ''
+  const [hourValue, minuteValue = '0'] = value.split(':')
+  const hour = Number(hourValue)
+  const minute = Number(minuteValue)
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return value
+  const period = hour >= 12 ? 'pm' : 'am'
+  const hour12 = hour > 12 ? hour - 12 : hour === 0 ? 12 : hour
+  return minute > 0 ? `${hour12}:${String(minute).padStart(2, '0')}${period}` : `${hour12}${period}`
+}
+
+function formatWindow(pub: Pub): string {
+  if (pub.happyHourStart && pub.happyHourEnd) {
+    return `${formatTime(pub.happyHourStart)}-${formatTime(pub.happyHourEnd)}`
+  }
+  return formatHappyHourDays(pub.happyHourDays) || pub.happyHour || 'Window TBC'
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return 'date TBC'
+  return new Date(value).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: 'numeric', timeZone: 'Australia/Perth' })
+}
+
+function buildItemList(rows: Pub[], dayLabel: string) {
+  const pricedRows = rows.filter(pub => pub.happyHourPrice !== null)
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: `${dayLabel} happy hours in Perth`,
+    itemListOrder: 'https://schema.org/ItemListOrderAscending',
+    numberOfItems: pricedRows.length,
+    itemListElement: pricedRows.slice(0, 20).map((pub, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      url: `${BASE_URL}${pubUrl(pub)}`,
+      name: `${pub.name} - ${formatPrice(pub.happyHourPrice)} happy hour`,
+    })),
+  }
+}
+
+export default async function HappyHourDayPage({ params }: DayPageProps) {
+  const day = getHappyHourDayBySlug(params.day)
+  if (!day) notFound()
+
+  const pubs = await getPubs()
+  const dayPubs = pubs
+    .filter(pub => pubHasHappyHourOnDay(pub.happyHourDays, day.index))
+    .sort((a, b) => (a.happyHourPrice ?? 999) - (b.happyHourPrice ?? 999))
+  const pricedRows = dayPubs.filter(pub => pub.happyHourPrice !== null)
+  const cheapest = pricedRows[0] ?? null
+  const confirmedDiscounts = pricedRows.length
+  const canonical = `${BASE_URL}/happy-hour/${day.slug}`
+
+  return (
+    <main className="min-h-screen bg-[#FDF8F0]">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(buildItemList(dayPubs, day.label)).replace(/</g, '\\u003c') }}
+      />
+      <BreadcrumbJsonLd items={[
+        { name: 'Home', url: BASE_URL },
+        { name: 'Happy Hour', url: `${BASE_URL}/happy-hour` },
+        { name: day.label, url: canonical },
+      ]} />
+      <SubPageNav breadcrumbs={[{ label: 'Happy Hour', href: '/happy-hour' }, { label: day.label }]} />
+
+      <section className="max-w-container mx-auto px-6 pt-8 pb-12">
+        <div className="grid gap-6 sm:grid-cols-[1fr_260px] sm:items-end">
+          <div>
+            <p className="mb-3 font-mono text-[0.68rem] font-bold uppercase text-gray-mid">Day guide</p>
+            <h1 className="font-display text-[3rem] leading-[1] text-ink sm:text-[4.8rem]">
+              {day.label} happy hours in Perth
+            </h1>
+            <p className="mt-5 max-w-[620px] font-body text-[0.96rem] leading-relaxed text-gray-mid">
+              {cheapest ? <>{day.label} has {dayPubs.length} happy-hour {dayPubs.length === 1 ? 'row' : 'rows'} in the current dataset, with the cheapest confirmed discount at <span className="font-mono font-bold text-ink">{formatPrice(cheapest.happyHourPrice)}</span> from {cheapest.name} in {cheapest.suburb}. Start with the rows, then check the window before anyone calls it a plan.</> : <>We have {dayPubs.length} scheduled {day.label} happy-hour {dayPubs.length === 1 ? 'row' : 'rows'}, but no confirmed discount price for the day yet. The live board still shows what is running right now.</>}
+            </p>
+          </div>
+          <div className="overflow-hidden rounded-card border-3 border-ink bg-white shadow-hard-sm">
+            <Image
+              src="/articles/perth-happy-hours-by-day-01-5pm-window.png"
+              alt={`${day.label} happy-hour pint in Perth`}
+              width={700}
+              height={700}
+              className="aspect-square w-full object-cover"
+              priority
+            />
+          </div>
+        </div>
+
+        <section className="my-8 rounded-card border-3 border-ink bg-ink p-5 text-white shadow-hard-sm">
+          <p className="font-mono text-[0.65rem] font-bold uppercase text-white/55">Answer first</p>
+          <h2 className="mt-2 font-mono text-xl font-extrabold">What is the best {day.label} happy hour in Perth?</h2>
+          <p className="mt-3 font-body text-[0.9rem] leading-relaxed text-white/70">
+            {cheapest ? <>The cheapest checked {day.label} happy-hour discount is {formatPrice(cheapest.happyHourPrice)} at <Link href={pubUrl(cheapest)} className="font-bold text-amber-light hover:underline">{cheapest.name}</Link> in {cheapest.suburb}. The listed window is {formatWindow(cheapest)}, and the row was last checked {formatDate(cheapest.lastVerified ?? cheapest.priceVerifiedAt)}. Treat that as the starting point, not a promise carved into the bar top.</> : <>Use the live happy-hour board for now; this day needs more confirmed discount prices before it deserves a winner.</>}
+          </p>
+        </section>
+
+        <section className="mb-8 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Rows for {day.label}</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{dayPubs.length}</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Pubs with {day.label} in the happy-hour schedule.</p>
+          </div>
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Priced discounts</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{confirmedDiscounts}</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Rows with a specific happy-hour price attached.</p>
+          </div>
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Cheapest listed</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{formatPrice(cheapest?.happyHourPrice)}</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">{cheapest ? `${cheapest.name}, ${cheapest.suburb}` : 'Needs a checked row.'}</p>
+          </div>
+        </section>
+
+        <section className="rounded-card border-3 border-ink bg-white shadow-hard-sm">
+          <div className="flex items-center justify-between gap-4 border-b-3 border-ink bg-off-white px-5 py-4">
+            <div>
+              <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Sorted by price</p>
+              <h2 className="font-mono text-xl font-extrabold text-ink">{day.label} rows</h2>
+            </div>
+            <Clock className="h-5 w-5 text-amber" />
+          </div>
+          <div className="divide-y divide-gray-light">
+            {dayPubs.length > 0 ? dayPubs.slice(0, 30).map((pub, index) => (
+              <Link key={pub.id} href={pubUrl(pub)} className="group grid grid-cols-[2.25rem_1fr_auto] items-center gap-3 px-5 py-4 no-underline hover:bg-off-white">
+                <span className="font-mono text-[0.72rem] font-bold text-gray-mid">{index + 1}</span>
+                <span className="min-w-0">
+                  <span className="block truncate font-mono text-[0.86rem] font-extrabold text-ink group-hover:text-amber">{pub.name}</span>
+                  <span className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[0.68rem] text-gray-mid">
+                    <span>{pub.suburb}</span>
+                    <span>{formatWindow(pub)}</span>
+                    <span>Checked {formatDate(pub.lastVerified ?? pub.priceVerifiedAt)}</span>
+                  </span>
+                </span>
+                <span className="font-mono text-lg font-extrabold text-ink">{formatPrice(pub.happyHourPrice)}</span>
+              </Link>
+            )) : (
+              <div className="px-5 py-8">
+                <p className="font-body text-[0.9rem] leading-relaxed text-gray-mid">No {day.label} rows yet. Perth has chosen mystery over convenience, briefly.</p>
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="mt-8 grid gap-4 sm:grid-cols-2">
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <div className="mb-3 flex items-center gap-2">
+              <GlassWater className="h-4 w-4 text-amber" />
+              <h2 className="font-mono text-lg font-extrabold text-ink">Other days</h2>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              {HAPPY_HOUR_DAYS.filter(other => other.slug !== day.slug).map(other => (
+                <Link key={other.slug} href={`/happy-hour/${other.slug}`} className="rounded-card border border-gray-light px-4 py-3 font-mono text-[0.76rem] font-bold text-ink no-underline hover:border-amber hover:text-amber">
+                  {other.label}
+                </Link>
+              ))}
+            </div>
+          </div>
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <h2 className="font-mono text-lg font-extrabold text-ink">Quick Q&A</h2>
+            <div className="mt-4 space-y-4">
+              <div>
+                <h3 className="font-mono text-[0.82rem] font-extrabold text-ink">Are these live right now?</h3>
+                <p className="mt-1 text-[0.78rem] leading-relaxed text-gray-mid">Not necessarily. This page is the {day.label} planning board. For the current minute, use the live happy-hour page.</p>
+              </div>
+              <div>
+                <h3 className="font-mono text-[0.82rem] font-extrabold text-ink">Why are some windows vague?</h3>
+                <p className="mt-1 text-[0.78rem] leading-relaxed text-gray-mid">Some pubs publish the day but not a neat start and end time. We show the clean window where we have it and leave the fuzzy ones fuzzy.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div className="mt-8 flex flex-wrap gap-3">
+          <Link href="/happy-hour" className="inline-flex items-center gap-1 rounded-pill border-3 border-ink bg-amber px-5 py-3 font-mono text-[0.78rem] font-bold uppercase text-ink no-underline shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover">
+            Live happy hours <ArrowUpRight className="h-3.5 w-3.5" />
+          </Link>
+          <Link href="/articles/perth-happy-hours-by-day" className="inline-flex items-center gap-1 rounded-pill border-3 border-ink bg-white px-5 py-3 font-mono text-[0.78rem] font-bold uppercase text-ink no-underline shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover">
+            Read the guide <ArrowUpRight className="h-3.5 w-3.5" />
+          </Link>
+        </div>
+      </section>
+
+      <Footer />
+    </main>
+  )
+}

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -14,6 +14,7 @@ const lines = [
   `- [Tonight's Best Bets](${BASE_URL}/insights/tonights-best-bets): live happy-hour and value picks for tonight.`,
   `- [Suburb Rankings](${BASE_URL}/insights/suburb-rankings): suburb-by-suburb pint-price comparisons.`,
   `- [Happy Hours](${BASE_URL}/happy-hour): current happy-hour finder for Perth pubs.`,
+  `- [Cheapest Pints](${BASE_URL}/cheapest-pints): live ranked list of the cheapest verified regular pint prices in Perth.`,
   `- [Discover](${BASE_URL}/discover): searchable pub and pint-price directory.`,
   `- [Articles](${BASE_URL}/articles): pub and drinking explainers with PPP data attached.`,
   ...articles.map(article => `- [${article.title}](${BASE_URL}${articleUrl(article.slug)}): ${article.description}`),

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import { MetadataRoute } from 'next'
 import { getAllPubLastModifiedPairs, getIndexablePubSlugPairs, getAllSuburbs } from '@/lib/supabase'
 import { articles, absoluteArticleUrl } from '@/lib/articles'
+import { HAPPY_HOUR_DAYS } from '@/lib/happyHourDays'
 import { BASE_URL, absolutePubUrl, absoluteSuburbUrl, toSuburbSlug } from '@/lib/urls'
 
 // Regenerate hourly so new pubs added to Supabase appear in the sitemap
@@ -52,8 +53,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${BASE_URL}/guides/dad-bar`, lastModified: latestPubModified, changeFrequency: 'weekly', priority: 0.7 },
     { url: `${BASE_URL}/guides/cozy-corners`, lastModified: latestPubModified, changeFrequency: 'weekly', priority: 0.7 },
     { url: `${BASE_URL}/happy-hour`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },
+    { url: `${BASE_URL}/cheapest-pints`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },
     { url: `${BASE_URL}/articles`, lastModified: articles[0]?.updatedAt || FALLBACK_LAST_MODIFIED, changeFrequency: 'weekly', priority: 0.8 },
   ]
+
+  const happyHourDayRoutes: MetadataRoute.Sitemap = HAPPY_HOUR_DAYS.map(day => ({
+    url: `${BASE_URL}/happy-hour/${day.slug}`,
+    lastModified: latestPubModified,
+    changeFrequency: 'daily' as const,
+    priority: 0.7,
+  }))
 
   const articleRoutes: MetadataRoute.Sitemap = articles.map(article => ({
     url: absoluteArticleUrl(article.slug),
@@ -76,5 +85,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: pair.indexabilityTier === 'A' ? 0.6 : 0.5,
   }))
 
-  return [...staticRoutes, ...articleRoutes, ...suburbRoutes, ...pubRoutes]
+  return [...staticRoutes, ...happyHourDayRoutes, ...articleRoutes, ...suburbRoutes, ...pubRoutes]
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 const NAV_LINKS = [
   { href: '/discover', label: 'Discover' },
   { href: '/happy-hour', label: 'Happy Hours' },
+  { href: '/cheapest-pints', label: 'Cheap Pints' },
   { href: '/articles', label: 'Articles' },
   { href: '/suburbs', label: 'Suburbs' },
 ]

--- a/src/lib/happyHourDays.test.ts
+++ b/src/lib/happyHourDays.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { parseHappyHourDayIndexes, pubHasHappyHourOnDay } from './happyHourDays'
+
+test('parseHappyHourDayIndexes expands weekday ranges', () => {
+  assert.deepEqual(parseHappyHourDayIndexes('Mon-Fri'), [1, 2, 3, 4, 5])
+  assert.equal(pubHasHappyHourOnDay('Mon-Fri', 3), true)
+  assert.equal(pubHasHappyHourOnDay('Mon-Fri', 6), false)
+})
+
+test('parseHappyHourDayIndexes expands wrapped ranges', () => {
+  assert.deepEqual(parseHappyHourDayIndexes('Wed-Sun'), [3, 4, 5, 6, 0])
+  assert.equal(pubHasHappyHourOnDay('Wed-Sun', 0), true)
+  assert.equal(pubHasHappyHourOnDay('Wed-Sun', 2), false)
+})
+
+test('parseHappyHourDayIndexes handles publisher dash variants', () => {
+  assert.deepEqual(parseHappyHourDayIndexes('Mon–Fri'), [1, 2, 3, 4, 5])
+})
+
+test('parseHappyHourDayIndexes handles daily and postgres array formats', () => {
+  assert.deepEqual(parseHappyHourDayIndexes('daily'), [0, 1, 2, 3, 4, 5, 6])
+  assert.deepEqual(parseHappyHourDayIndexes('{Mon,Tue,Wed,Thu,Fri}'), [1, 2, 3, 4, 5])
+})
+
+test('parseHappyHourDayIndexes handles weekday and weekend labels', () => {
+  assert.deepEqual(parseHappyHourDayIndexes('Weekdays'), [1, 2, 3, 4, 5])
+  assert.deepEqual(parseHappyHourDayIndexes('Weekends'), [0, 6])
+})

--- a/src/lib/happyHourDays.ts
+++ b/src/lib/happyHourDays.ts
@@ -1,0 +1,71 @@
+export const HAPPY_HOUR_DAYS = [
+  { slug: 'sunday', label: 'Sunday', index: 0 },
+  { slug: 'monday', label: 'Monday', index: 1 },
+  { slug: 'tuesday', label: 'Tuesday', index: 2 },
+  { slug: 'wednesday', label: 'Wednesday', index: 3 },
+  { slug: 'thursday', label: 'Thursday', index: 4 },
+  { slug: 'friday', label: 'Friday', index: 5 },
+  { slug: 'saturday', label: 'Saturday', index: 6 },
+] as const
+
+export type HappyHourDay = typeof HAPPY_HOUR_DAYS[number]
+
+const DAY_MAP: Record<string, number> = {
+  sun: 0,
+  sunday: 0,
+  mon: 1,
+  monday: 1,
+  tue: 2,
+  tuesday: 2,
+  wed: 3,
+  wednesday: 3,
+  thu: 4,
+  thursday: 4,
+  fri: 5,
+  friday: 5,
+  sat: 6,
+  saturday: 6,
+}
+
+export function getHappyHourDayBySlug(slug: string): HappyHourDay | null {
+  return HAPPY_HOUR_DAYS.find(day => day.slug === slug) ?? null
+}
+
+export function parseHappyHourDayIndexes(days: string | null): number[] {
+  if (!days) return []
+  const clean = days.replace(/[{}]/g, '').toLowerCase().trim()
+  if (['7 days', 'daily', 'everyday', 'every day'].includes(clean)) return [0, 1, 2, 3, 4, 5, 6]
+  if (clean === 'weekdays') return [1, 2, 3, 4, 5]
+  if (clean === 'weekends') return [0, 6]
+
+  const parsedDays: number[] = []
+  const parts = clean
+    .split(',')
+    .map(part => part.trim())
+    .filter(Boolean)
+
+  for (const part of parts) {
+    const rangeMatch = part.match(/^(\w{3,})[-–](\w{3,})$/)
+    if (rangeMatch) {
+      const start = DAY_MAP[rangeMatch[1].slice(0, 3)]
+      const end = DAY_MAP[rangeMatch[2].slice(0, 3)]
+      if (start !== undefined && end !== undefined) {
+        let current = start
+        while (current !== (end + 1) % 7) {
+          parsedDays.push(current)
+          current = (current + 1) % 7
+        }
+      }
+      continue
+    }
+
+    const day = DAY_MAP[part] ?? DAY_MAP[part.slice(0, 3)]
+    if (day !== undefined) parsedDays.push(day)
+  }
+
+  return Array.from(new Set(parsedDays))
+}
+
+export function pubHasHappyHourOnDay(days: string | null, dayIndex: number): boolean {
+  return parseHappyHourDayIndexes(days).includes(dayIndex)
+}


### PR DESCRIPTION
## Summary
- add `/cheapest-pints` as a verified regular pint price landing page
- add static `/happy-hour/[day]` pages for all seven weekdays
- add the happy-hour day rail, footer/sitemap/llms links, and shared day parsing tests

Refs #32. This is the first high-intent slice; transport hubs/faceted/student pages remain for follow-up.

## Verification
- `npm test` (254/254)
- `npx tsc --noEmit`
- `git diff --check`
- `npm run lint` (existing warnings only in `SubmitPubForm` and `SunsetSippers`)
- `npm run build`
- `npm run test:e2e` (4/4)
- reviewer sub-agent LGTM
- in-app browser screenshots saved under `/tmp/perth-pint-prices-high-intent-32/`
