### PR TITLE
Add transport-hub pub landing pages

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,12 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Transport-hub landing pages ready for preview (2026-06-03)
+- **Issue #32 second slice / branch `codex/transport-hub-landing-pages-32` / commit `f6c8adf`:** added four direct-proximity pub landing pages: `/pubs-near-perth-station`, `/pubs-near-optus-stadium`, `/pubs-near-rac-arena`, and `/pubs-near-elizabeth-quay`.
+- **Reusable hub system:** added shared transport-hub config, direct-distance ranking, ItemList JSON-LD, canonical metadata with OG/Twitter images, answer-first copy, stats, ranked nearby rows, and cross-links between transport guides. Sitemap, footer, and `/llms.txt` now expose the hub pages.
+- **Data guardrails:** unverified regular prices render as `TBC` and do not affect equal-distance price tie-breaks. Page copy uses direct-proximity/direct-distance wording rather than claiming real walking-route distances.
+- **Verification:** verified `npm test` (**257/257 tests**), `npx tsc --noEmit`, `git diff --check`, `npm run lint` (existing warnings only), `npm run build`, `npm run test:e2e` (**4/4 Playwright tests**), reviewer sub-agent LGTM, and desktop/mobile screenshots for Perth Station + Optus Stadium under `/tmp/perth-pint-prices-transport-hubs-32/`.
+
 ### High-intent landing pages ready for preview (2026-06-03)
 - **Issue #32 first slice / branch `codex/high-intent-landing-pages-32` / commit `68754c5`:** added `/cheapest-pints` as a verified regular-price landing page and `/happy-hour/[day]` static pages for all seven weekdays, with canonical metadata, OG/Twitter tags, Breadcrumb + ItemList JSON-LD, answer-first copy, ranked rows, Q&A blocks, and useful internal links.
 - **Happy-hour day linking:** added a planning-board rail to `/happy-hour`, linked Cheap Pints from the footer, added the new pages to `sitemap.xml`, and exposed `/cheapest-pints` in `/llms.txt`.

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,5 +1,6 @@
 import { BASE_URL } from '@/lib/urls'
 import { articles, articleUrl } from '@/lib/articles'
+import { TRANSPORT_HUBS } from '@/lib/transportHubs'
 
 const lines = [
   '# Perth Pint Prices',
@@ -15,6 +16,7 @@ const lines = [
   `- [Suburb Rankings](${BASE_URL}/insights/suburb-rankings): suburb-by-suburb pint-price comparisons.`,
   `- [Happy Hours](${BASE_URL}/happy-hour): current happy-hour finder for Perth pubs.`,
   `- [Cheapest Pints](${BASE_URL}/cheapest-pints): live ranked list of the cheapest verified regular pint prices in Perth.`,
+  ...TRANSPORT_HUBS.map(hub => `- [Pubs near ${hub.name}](${BASE_URL}/${hub.slug}): distance-ranked pub guide with checked pint prices where available.`),
   `- [Discover](${BASE_URL}/discover): searchable pub and pint-price directory.`,
   `- [Articles](${BASE_URL}/articles): pub and drinking explainers with PPP data attached.`,
   ...articles.map(article => `- [${article.title}](${BASE_URL}${articleUrl(article.slug)}): ${article.description}`),

--- a/src/app/pubs-near-elizabeth-quay/page.tsx
+++ b/src/app/pubs-near-elizabeth-quay/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next'
+import TransportHubPage from '@/components/TransportHubPage'
+import { requireTransportHub } from '@/lib/transportHubs'
+import { BASE_URL } from '@/lib/urls'
+
+const hub = requireTransportHub('pubs-near-elizabeth-quay')
+
+export const revalidate = 3600
+
+export const metadata: Metadata = {
+  title: 'Pubs Near Elizabeth Quay',
+  description: 'Pubs near Elizabeth Quay, ranked by direct proximity with verified pint prices where Perth Pint Prices has a checked row.',
+  alternates: { canonical: `${BASE_URL}/${hub.slug}` },
+  openGraph: {
+    title: 'Pubs Near Elizabeth Quay | Perth Pint Prices',
+    description: 'Nearby Elizabeth Quay pubs with direct-distance notes and checked pint prices where available.',
+    url: `${BASE_URL}/${hub.slug}`,
+    type: 'website',
+    siteName: 'Perth Pint Prices',
+    locale: 'en_AU',
+    images: [{ url: `${BASE_URL}/og-image.png`, width: 1200, height: 630, alt: 'Perth Pint Prices' }],
+  },
+  twitter: { card: 'summary_large_image' },
+}
+
+export default function PubsNearElizabethQuayPage() {
+  return <TransportHubPage hub={hub} />
+}

--- a/src/app/pubs-near-optus-stadium/page.tsx
+++ b/src/app/pubs-near-optus-stadium/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next'
+import TransportHubPage from '@/components/TransportHubPage'
+import { requireTransportHub } from '@/lib/transportHubs'
+import { BASE_URL } from '@/lib/urls'
+
+const hub = requireTransportHub('pubs-near-optus-stadium')
+
+export const revalidate = 3600
+
+export const metadata: Metadata = {
+  title: 'Pubs Near Optus Stadium',
+  description: 'Pubs near Optus Stadium, ranked by direct proximity with verified pint prices where Perth Pint Prices has a checked row.',
+  alternates: { canonical: `${BASE_URL}/${hub.slug}` },
+  openGraph: {
+    title: 'Pubs Near Optus Stadium | Perth Pint Prices',
+    description: 'Nearby Optus Stadium pubs with direct-distance notes and checked pint prices where available.',
+    url: `${BASE_URL}/${hub.slug}`,
+    type: 'website',
+    siteName: 'Perth Pint Prices',
+    locale: 'en_AU',
+    images: [{ url: `${BASE_URL}/og-image.png`, width: 1200, height: 630, alt: 'Perth Pint Prices' }],
+  },
+  twitter: { card: 'summary_large_image' },
+}
+
+export default function PubsNearOptusStadiumPage() {
+  return <TransportHubPage hub={hub} />
+}

--- a/src/app/pubs-near-perth-station/page.tsx
+++ b/src/app/pubs-near-perth-station/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next'
+import TransportHubPage from '@/components/TransportHubPage'
+import { requireTransportHub } from '@/lib/transportHubs'
+import { BASE_URL } from '@/lib/urls'
+
+const hub = requireTransportHub('pubs-near-perth-station')
+
+export const revalidate = 3600
+
+export const metadata: Metadata = {
+  title: 'Pubs Near Perth Station',
+  description: 'Pubs near Perth Station, ranked by direct proximity with verified pint prices where Perth Pint Prices has a checked row.',
+  alternates: { canonical: `${BASE_URL}/${hub.slug}` },
+  openGraph: {
+    title: 'Pubs Near Perth Station | Perth Pint Prices',
+    description: 'Nearby Perth Station pubs with direct-distance notes and checked pint prices where available.',
+    url: `${BASE_URL}/${hub.slug}`,
+    type: 'website',
+    siteName: 'Perth Pint Prices',
+    locale: 'en_AU',
+    images: [{ url: `${BASE_URL}/og-image.png`, width: 1200, height: 630, alt: 'Perth Pint Prices' }],
+  },
+  twitter: { card: 'summary_large_image' },
+}
+
+export default function PubsNearPerthStationPage() {
+  return <TransportHubPage hub={hub} />
+}

--- a/src/app/pubs-near-rac-arena/page.tsx
+++ b/src/app/pubs-near-rac-arena/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next'
+import TransportHubPage from '@/components/TransportHubPage'
+import { requireTransportHub } from '@/lib/transportHubs'
+import { BASE_URL } from '@/lib/urls'
+
+const hub = requireTransportHub('pubs-near-rac-arena')
+
+export const revalidate = 3600
+
+export const metadata: Metadata = {
+  title: 'Pubs Near RAC Arena',
+  description: 'Pubs near RAC Arena, ranked by direct proximity with verified pint prices where Perth Pint Prices has a checked row.',
+  alternates: { canonical: `${BASE_URL}/${hub.slug}` },
+  openGraph: {
+    title: 'Pubs Near RAC Arena | Perth Pint Prices',
+    description: 'Nearby RAC Arena pubs with direct-distance notes and checked pint prices where available.',
+    url: `${BASE_URL}/${hub.slug}`,
+    type: 'website',
+    siteName: 'Perth Pint Prices',
+    locale: 'en_AU',
+    images: [{ url: `${BASE_URL}/og-image.png`, width: 1200, height: 630, alt: 'Perth Pint Prices' }],
+  },
+  twitter: { card: 'summary_large_image' },
+}
+
+export default function PubsNearRacArenaPage() {
+  return <TransportHubPage hub={hub} />
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,6 +2,7 @@ import { MetadataRoute } from 'next'
 import { getAllPubLastModifiedPairs, getIndexablePubSlugPairs, getAllSuburbs } from '@/lib/supabase'
 import { articles, absoluteArticleUrl } from '@/lib/articles'
 import { HAPPY_HOUR_DAYS } from '@/lib/happyHourDays'
+import { TRANSPORT_HUBS } from '@/lib/transportHubs'
 import { BASE_URL, absolutePubUrl, absoluteSuburbUrl, toSuburbSlug } from '@/lib/urls'
 
 // Regenerate hourly so new pubs added to Supabase appear in the sitemap
@@ -64,6 +65,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.7,
   }))
 
+  const transportHubRoutes: MetadataRoute.Sitemap = TRANSPORT_HUBS.map(hub => ({
+    url: `${BASE_URL}/${hub.slug}`,
+    lastModified: latestPubModified,
+    changeFrequency: 'weekly' as const,
+    priority: 0.7,
+  }))
+
   const articleRoutes: MetadataRoute.Sitemap = articles.map(article => ({
     url: absoluteArticleUrl(article.slug),
     lastModified: article.updatedAt,
@@ -85,5 +93,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: pair.indexabilityTier === 'A' ? 0.6 : 0.5,
   }))
 
-  return [...staticRoutes, ...happyHourDayRoutes, ...articleRoutes, ...suburbRoutes, ...pubRoutes]
+  return [...staticRoutes, ...happyHourDayRoutes, ...transportHubRoutes, ...articleRoutes, ...suburbRoutes, ...pubRoutes]
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,6 +4,7 @@ const NAV_LINKS = [
   { href: '/discover', label: 'Discover' },
   { href: '/happy-hour', label: 'Happy Hours' },
   { href: '/cheapest-pints', label: 'Cheap Pints' },
+  { href: '/pubs-near-perth-station', label: 'Near Station' },
   { href: '/articles', label: 'Articles' },
   { href: '/suburbs', label: 'Suburbs' },
 ]

--- a/src/components/TransportHubPage.tsx
+++ b/src/components/TransportHubPage.tsx
@@ -1,0 +1,187 @@
+import Link from 'next/link'
+import { ArrowUpRight, Clock, MapPin, TrainFront } from 'lucide-react'
+import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
+import Footer from '@/components/Footer'
+import SubPageNav from '@/components/SubPageNav'
+import { getMapTileUrl } from '@/lib/mapTile'
+import { getPubs } from '@/lib/supabase'
+import { rankPubsForTransportHub, TRANSPORT_HUBS, type TransportHub, type TransportHubPub } from '@/lib/transportHubs'
+import { BASE_URL, pubUrl } from '@/lib/urls'
+
+type TransportHubPageProps = {
+  hub: TransportHub
+}
+
+function formatPrice(price: number | null | undefined): string {
+  if (price == null) return 'TBC'
+  return Number.isInteger(price) ? `$${price.toFixed(0)}` : `$${price.toFixed(2)}`
+}
+
+function formatDistance(km: number): string {
+  if (km < 1) return `${Math.round(km * 1000)}m`
+  return `${km.toFixed(1)}km`
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return 'date TBC'
+  return new Date(value).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: 'numeric', timeZone: 'Australia/Perth' })
+}
+
+function formatVerifiedPrice(pub: TransportHubPub): string {
+  return pub.priceVerified ? formatPrice(pub.regularPrice) : 'TBC'
+}
+
+function formatVerifiedDate(pub: TransportHubPub): string {
+  return pub.priceVerified ? `Checked ${formatDate(pub.lastVerified ?? pub.priceVerifiedAt)}` : 'Price TBC'
+}
+
+function buildItemList(rows: TransportHubPub[], hub: TransportHub) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: `Pubs ${hub.nearbyLabel}`,
+    itemListOrder: 'https://schema.org/ItemListOrderAscending',
+    numberOfItems: rows.length,
+    itemListElement: rows.slice(0, 20).map((pub, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      url: `${BASE_URL}${pubUrl(pub)}`,
+      name: `${pub.name} - ${formatDistance(pub.distanceKm)} from ${hub.shortName}`,
+    })),
+  }
+}
+
+export default async function TransportHubPage({ hub }: TransportHubPageProps) {
+  const pubs = await getPubs()
+  const nearbyPubs = rankPubsForTransportHub(pubs, hub)
+  const pricedRows = nearbyPubs.filter(pub => pub.priceVerified && pub.regularPrice !== null)
+  const cheapest = pricedRows
+    .slice()
+    .sort((a, b) => (a.regularPrice ?? Number.MAX_VALUE) - (b.regularPrice ?? Number.MAX_VALUE))[0] ?? null
+  const closest = nearbyPubs[0] ?? null
+  const canonical = `${BASE_URL}/${hub.slug}`
+  const otherHubs = TRANSPORT_HUBS.filter(other => other.slug !== hub.slug)
+
+  return (
+    <main className="min-h-screen bg-[#FDF8F0]">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(buildItemList(nearbyPubs, hub)).replace(/</g, '\\u003c') }}
+      />
+      <BreadcrumbJsonLd items={[
+        { name: 'Home', url: BASE_URL },
+        { name: hub.name, url: canonical },
+      ]} />
+      <SubPageNav breadcrumbs={[{ label: hub.shortName }]} />
+
+      <section className="max-w-container mx-auto px-6 pt-8 pb-12">
+        <div className="grid gap-6 sm:grid-cols-[1fr_260px] sm:items-end">
+          <div>
+            <p className="mb-3 font-mono text-[0.68rem] font-bold uppercase text-gray-mid">Transport pub guide</p>
+            <h1 className="font-display text-[3rem] leading-[1] text-ink sm:text-[4.7rem]">
+              Pubs near {hub.name}
+            </h1>
+            <p className="mt-5 max-w-[620px] font-body text-[0.96rem] leading-relaxed text-gray-mid">
+              {hub.intro}
+            </p>
+          </div>
+          <div className="relative min-h-[260px] overflow-hidden rounded-card border-3 border-ink bg-white shadow-hard-sm">
+            <div
+              className="absolute inset-0 bg-cover bg-center opacity-75"
+              style={{ backgroundImage: `url(${getMapTileUrl(hub.lat, hub.lng, 15)})` }}
+            />
+            <div className="absolute inset-0 bg-gradient-to-b from-white/25 to-amber-pale/95" />
+            <div className="relative flex h-full min-h-[260px] flex-col justify-between p-5">
+              <div className="inline-flex w-fit items-center gap-2 rounded-pill border-3 border-ink bg-white px-4 py-2 font-mono text-[0.72rem] font-bold uppercase text-ink shadow-hard-sm">
+                <TrainFront className="h-4 w-4 text-amber" />
+                {hub.shortName}
+              </div>
+              <div>
+                <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Search radius</p>
+                <p className="mt-1 font-mono text-4xl font-extrabold text-ink">{hub.radiusKm.toFixed(1)}km</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <section className="my-8 rounded-card border-3 border-ink bg-ink p-5 text-white shadow-hard-sm">
+          <p className="font-mono text-[0.65rem] font-bold uppercase text-white/55">Answer first</p>
+          <h2 className="mt-2 font-mono text-xl font-extrabold">What is the best pub near {hub.name}?</h2>
+          <p className="mt-3 font-body text-[0.9rem] leading-relaxed text-white/70">
+            {closest ? <>The closest pub in the current dataset is <Link href={pubUrl(closest)} className="font-bold text-amber-light hover:underline">{closest.name}</Link> in {closest.suburb}, about {formatDistance(closest.distanceKm)} direct from {hub.shortName}. {cheapest ? <>The cheapest verified regular pint nearby is {formatPrice(cheapest.regularPrice)} at {cheapest.name}.</> : <>We do not have a verified regular pint price for this hub yet.</>} {hub.answerNote}</> : <>We do not have enough nearby pub data for this hub yet.</>}
+          </p>
+        </section>
+
+        <section className="mb-8 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Nearby pubs</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{nearbyPubs.length}</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Within {hub.radiusKm.toFixed(1)}km direct of {hub.shortName}.</p>
+          </div>
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Closest</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{closest ? formatDistance(closest.distanceKm) : 'TBC'}</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">{closest ? `${closest.name}, ${closest.suburb}` : 'Needs nearby rows.'}</p>
+          </div>
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Cheapest checked</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{formatPrice(cheapest?.regularPrice)}</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">{cheapest ? `${cheapest.name}, ${cheapest.suburb}` : 'No verified price yet.'}</p>
+          </div>
+        </section>
+
+        <section className="rounded-card border-3 border-ink bg-white shadow-hard-sm">
+          <div className="flex items-center justify-between gap-4 border-b-3 border-ink bg-off-white px-5 py-4">
+            <div>
+              <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Sorted by direct distance</p>
+              <h2 className="font-mono text-xl font-extrabold text-ink">Nearby rows</h2>
+            </div>
+            <MapPin className="h-5 w-5 text-amber" />
+          </div>
+          <div className="divide-y divide-gray-light">
+            {nearbyPubs.length > 0 ? nearbyPubs.map((pub, index) => (
+              <Link key={pub.id} href={pubUrl(pub)} className="group grid grid-cols-[2.25rem_1fr_auto] items-center gap-3 px-5 py-4 no-underline hover:bg-off-white">
+                <span className="font-mono text-[0.72rem] font-bold text-gray-mid">{index + 1}</span>
+                <span className="min-w-0">
+                  <span className="block truncate font-mono text-[0.86rem] font-extrabold text-ink group-hover:text-amber">{pub.name}</span>
+                  <span className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[0.68rem] text-gray-mid">
+                    <span>{pub.suburb}</span>
+                    <span>{formatDistance(pub.distanceKm)}</span>
+                    <span>{formatVerifiedDate(pub)}</span>
+                  </span>
+                </span>
+                <span className="font-mono text-lg font-extrabold text-ink">{formatVerifiedPrice(pub)}</span>
+              </Link>
+            )) : (
+              <div className="px-5 py-8">
+                <p className="font-body text-[0.9rem] leading-relaxed text-gray-mid">No nearby rows yet. Annoying, but more honest than a fake shortlist.</p>
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="mt-8 grid gap-4 sm:grid-cols-2">
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <div className="mb-3 flex items-center gap-2">
+              <Clock className="h-4 w-4 text-amber" />
+              <h2 className="font-mono text-lg font-extrabold text-ink">Before you choose</h2>
+            </div>
+            <p className="font-body text-[0.82rem] leading-relaxed text-gray-mid">{hub.timingNote}</p>
+          </div>
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <h2 className="font-mono text-lg font-extrabold text-ink">Other transport guides</h2>
+            <div className="mt-4 grid gap-2">
+              {otherHubs.map(other => (
+                <Link key={other.slug} href={`/${other.slug}`} className="flex items-center justify-between rounded-card border border-gray-light px-4 py-3 font-mono text-[0.76rem] font-bold text-ink no-underline hover:border-amber hover:text-amber">
+                  {other.name}<ArrowUpRight className="h-3.5 w-3.5" />
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      </section>
+
+      <Footer />
+    </main>
+  )
+}

--- a/src/lib/transportHubs.test.ts
+++ b/src/lib/transportHubs.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { rankPubsForTransportHub, TRANSPORT_HUBS } from './transportHubs'
+import type { Pub } from '@/types/pub'
+
+function pub(overrides: Partial<Pub>): Pub {
+  return {
+    id: 1,
+    slug: 'test-pub',
+    name: 'Test Pub',
+    address: '',
+    suburb: 'Perth',
+    lat: -31.9514,
+    lng: 115.8605,
+    price: null,
+    beerType: '',
+    happyHour: null,
+    website: null,
+    description: null,
+    priceSource: null,
+    priceVerifiedAt: null,
+    priceConfidence: null,
+    priceVerified: true,
+    hasTab: false,
+    kidFriendly: false,
+    happyHourPrice: null,
+    happyHourDays: null,
+    happyHourStart: null,
+    happyHourEnd: null,
+    lastVerified: null,
+    regularPrice: null,
+    isHappyHourNow: false,
+    happyHourLabel: null,
+    happyHourMinutesRemaining: null,
+    imageUrl: null,
+    vibeTag: null,
+    cozyPub: false,
+    effectivePrice: null,
+    ...overrides,
+  }
+}
+
+test('rankPubsForTransportHub keeps pubs inside the hub radius sorted by direct distance', () => {
+  const hub = TRANSPORT_HUBS[0]
+  const rows = rankPubsForTransportHub([
+    pub({ id: 1, name: 'Closest', lat: hub.lat, lng: hub.lng }),
+    pub({ id: 2, name: 'Nearby', lat: hub.lat + 0.004, lng: hub.lng }),
+    pub({ id: 3, name: 'Too Far', lat: hub.lat + 0.05, lng: hub.lng }),
+  ], hub)
+
+  assert.deepEqual(rows.map(row => row.name), ['Closest', 'Nearby'])
+})
+
+test('rankPubsForTransportHub uses price only as a tie breaker', () => {
+  const hub = TRANSPORT_HUBS[0]
+  const rows = rankPubsForTransportHub([
+    pub({ id: 1, name: 'Higher Price', regularPrice: 12 }),
+    pub({ id: 2, name: 'Lower Price', regularPrice: 8 }),
+  ], hub)
+
+  assert.deepEqual(rows.map(row => row.name), ['Lower Price', 'Higher Price'])
+})
+
+test('rankPubsForTransportHub ignores unverified prices for tie breaking', () => {
+  const hub = TRANSPORT_HUBS[0]
+  const rows = rankPubsForTransportHub([
+    pub({ id: 1, name: 'Verified Price', regularPrice: 12, priceVerified: true }),
+    pub({ id: 2, name: 'Unverified Price', regularPrice: 6, priceVerified: false }),
+  ], hub)
+
+  assert.deepEqual(rows.map(row => row.name), ['Verified Price', 'Unverified Price'])
+})

--- a/src/lib/transportHubs.ts
+++ b/src/lib/transportHubs.ts
@@ -1,0 +1,101 @@
+import type { Pub } from '@/types/pub'
+import { haversineDistanceKm } from '@/lib/location'
+
+export type TransportHub = {
+  slug: string
+  name: string
+  shortName: string
+  nearbyLabel: string
+  lat: number
+  lng: number
+  radiusKm: number
+  intro: string
+  answerNote: string
+  timingNote: string
+}
+
+export type TransportHubPub = Pub & {
+  distanceKm: number
+}
+
+export const TRANSPORT_HUBS = [
+  {
+    slug: 'pubs-near-perth-station',
+    name: 'Perth Station',
+    shortName: 'Perth Station',
+    nearbyLabel: 'near Perth Station',
+    lat: -31.9514,
+    lng: 115.8605,
+    radiusKm: 1.1,
+    intro: 'Perth Station is the practical pub filter: close enough for one more, central enough that nobody has to perform a suburb argument on the footpath. This page ranks nearby pubs by direct proximity first, then shows the verified pint price where we have one.',
+    answerNote: 'Best for pre-train pints, after-work meetups, and the “I am not crossing the city for this” sort of plan.',
+    timingNote: 'Allow more time on event nights and Friday peaks; the nearest dot is not always the quickest bar order.',
+  },
+  {
+    slug: 'pubs-near-optus-stadium',
+    name: 'Optus Stadium',
+    shortName: 'Optus Stadium',
+    nearbyLabel: 'near Optus Stadium',
+    lat: -31.951,
+    lng: 115.889,
+    radiusKm: 1.8,
+    intro: 'Optus Stadium creates a very specific drinking problem: everyone wants somewhere close, nobody wants to discover the crowd at the same time. This page keeps the search boring in the useful way: nearby pubs first, checked prices where we have them, and enough suburb context to pick before the bounce-down rush.',
+    answerNote: 'Best for pre-game and post-game plans around Burswood, East Perth, and the river crossings.',
+    timingNote: 'On stadium nights, choose earlier than feels necessary. The crowd has also seen the fixture.',
+  },
+  {
+    slug: 'pubs-near-rac-arena',
+    name: 'RAC Arena',
+    shortName: 'RAC Arena',
+    nearbyLabel: 'near RAC Arena',
+    lat: -31.9483,
+    lng: 115.8524,
+    radiusKm: 1.1,
+    intro: 'RAC Arena nights need a pub that works before doors, after the encore, or during the part where someone claims they know a shortcut. The list below keeps it tight around the arena and shows the regular pint price where the row has been checked.',
+    answerNote: 'Best for concerts, basketball nights, and CBD plans where the meeting point needs to survive group chat.',
+    timingNote: 'The useful window is usually before doors or twenty minutes after the first crowd wave leaves.',
+  },
+  {
+    slug: 'pubs-near-elizabeth-quay',
+    name: 'Elizabeth Quay',
+    shortName: 'Elizabeth Quay',
+    nearbyLabel: 'near Elizabeth Quay',
+    lat: -31.9586,
+    lng: 115.8582,
+    radiusKm: 1.1,
+    intro: 'Elizabeth Quay is lovely until the plan becomes "somewhere nearby" and everyone starts rotating on the spot. This page turns the riverfront pub search into a ranked list: nearest useful venues first, verified regular pint prices where we have them, and enough detail to avoid wandering uphill for no reason.',
+    answerNote: 'Best for riverfront meetups, ferry-adjacent plans, and CBD drinks that do not need a spreadsheet.',
+    timingNote: 'Expect the waterfront to move slowly in good weather. That is not a complaint, just physics with better lighting.',
+  },
+] as const satisfies readonly TransportHub[]
+
+export type TransportHubSlug = typeof TRANSPORT_HUBS[number]['slug']
+
+export function getTransportHub(slug: string): TransportHub | null {
+  return TRANSPORT_HUBS.find(hub => hub.slug === slug) ?? null
+}
+
+export function requireTransportHub(slug: TransportHubSlug): TransportHub {
+  const hub = getTransportHub(slug)
+  if (!hub) throw new Error(`Missing transport hub: ${slug}`)
+  return hub
+}
+
+function verifiedRegularPrice(pub: Pub): number {
+  return pub.priceVerified && pub.regularPrice !== null ? pub.regularPrice : Number.MAX_VALUE
+}
+
+export function rankPubsForTransportHub(pubs: Pub[], hub: TransportHub, limit: number = 24): TransportHubPub[] {
+  return pubs
+    .filter(pub => Number.isFinite(pub.lat) && Number.isFinite(pub.lng) && !(pub.lat === 0 && pub.lng === 0))
+    .map(pub => ({
+      ...pub,
+      distanceKm: haversineDistanceKm(hub.lat, hub.lng, pub.lat, pub.lng),
+    }))
+    .filter(pub => pub.distanceKm <= hub.radiusKm)
+    .sort((a, b) => {
+      if (a.distanceKm !== b.distanceKm) return a.distanceKm - b.distanceKm
+      return verifiedRegularPrice(a) - verifiedRegularPrice(b)
+    })
+    .slice(0, limit)
+}


### PR DESCRIPTION
## Summary
- add four transport-hub landing pages: Perth Station, Optus Stadium, RAC Arena, and Elizabeth Quay
- rank nearby pubs by direct proximity and show verified regular pint prices only
- wire hub pages into sitemap, footer, and `/llms.txt`

Refs #32. This is the transport-hub slice; student/faceted suburb pages remain for follow-up.

## Verification
- `npm test` (257/257)
- `npx tsc --noEmit`
- `git diff --check`
- `npm run lint` (existing warnings only in `SubmitPubForm` and `SunsetSippers`)
- `npm run build`
- `npm run test:e2e` (4/4)
- reviewer sub-agent LGTM
- desktop/mobile screenshots saved under `/tmp/perth-pint-prices-transport-hubs-32/`

## Notes
- These pages intentionally say direct proximity/direct distance, not walking distance, because ranking uses pub coordinates rather than route data.
- Unverified regular prices render as `TBC` and do not affect equal-distance price tie-breaks.
