### PR TITLE
Add student pints landing page

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,12 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Student-pints landing page ready for preview (2026-06-03)
+- **Issue #32 third slice / branch `codex/student-pints-landing-page-32` / commit `8ec3168`:** added `/student-pints-perth`, a verified under-$10 regular-pint page for UWA, Curtin, and Murdoch.
+- **Campus ranking:** added shared student-pint ranking helpers and tests. Campus sections use verified regular prices only, direct-distance radii, and campus-specific notes; Murdoch deliberately uses a wider 8km radius because the current checked data has no useful sub-$10 cluster inside 4-6km.
+- **SEO wiring:** added canonical metadata, OG/Twitter image, Breadcrumb + ItemList JSON-LD, useful internal links, and sitemap/footer/`/llms.txt` entries.
+- **Verification:** verified `npm test` (**260/260 tests**), `npx tsc --noEmit`, `git diff --check`, `npm run lint` (existing warnings only), `npm run build`, `npm run test:e2e` (**4/4 Playwright tests**), reviewer sub-agent LGTM, and desktop/mobile screenshots under `/tmp/perth-pint-prices-student-pints-32/`.
+
 ### Transport-hub landing pages ready for preview (2026-06-03)
 - **Issue #32 second slice / branch `codex/transport-hub-landing-pages-32` / commit `f6c8adf`:** added four direct-proximity pub landing pages: `/pubs-near-perth-station`, `/pubs-near-optus-stadium`, `/pubs-near-rac-arena`, and `/pubs-near-elizabeth-quay`.
 - **Reusable hub system:** added shared transport-hub config, direct-distance ranking, ItemList JSON-LD, canonical metadata with OG/Twitter images, answer-first copy, stats, ranked nearby rows, and cross-links between transport guides. Sitemap, footer, and `/llms.txt` now expose the hub pages.

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -16,6 +16,7 @@ const lines = [
   `- [Suburb Rankings](${BASE_URL}/insights/suburb-rankings): suburb-by-suburb pint-price comparisons.`,
   `- [Happy Hours](${BASE_URL}/happy-hour): current happy-hour finder for Perth pubs.`,
   `- [Cheapest Pints](${BASE_URL}/cheapest-pints): live ranked list of the cheapest verified regular pint prices in Perth.`,
+  `- [Student Pints Perth](${BASE_URL}/student-pints-perth): verified sub-$10 regular pint rows near UWA, Curtin, and Murdoch.`,
   ...TRANSPORT_HUBS.map(hub => `- [Pubs near ${hub.name}](${BASE_URL}/${hub.slug}): distance-ranked pub guide with checked pint prices where available.`),
   `- [Discover](${BASE_URL}/discover): searchable pub and pint-price directory.`,
   `- [Articles](${BASE_URL}/articles): pub and drinking explainers with PPP data attached.`,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -55,6 +55,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${BASE_URL}/guides/cozy-corners`, lastModified: latestPubModified, changeFrequency: 'weekly', priority: 0.7 },
     { url: `${BASE_URL}/happy-hour`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },
     { url: `${BASE_URL}/cheapest-pints`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },
+    { url: `${BASE_URL}/student-pints-perth`, lastModified: latestPubModified, changeFrequency: 'weekly', priority: 0.7 },
     { url: `${BASE_URL}/articles`, lastModified: articles[0]?.updatedAt || FALLBACK_LAST_MODIFIED, changeFrequency: 'weekly', priority: 0.8 },
   ]
 

--- a/src/app/student-pints-perth/page.tsx
+++ b/src/app/student-pints-perth/page.tsx
@@ -1,0 +1,210 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowUpRight, GraduationCap, MapPin, PiggyBank } from 'lucide-react'
+import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
+import Footer from '@/components/Footer'
+import SubPageNav from '@/components/SubPageNav'
+import { getMapTileUrl } from '@/lib/mapTile'
+import { getPubs } from '@/lib/supabase'
+import { rankStudentPints, rankStudentPintsForCampus, STUDENT_CAMPUSES, type StudentPintPub } from '@/lib/studentPints'
+import { BASE_URL, pubUrl } from '@/lib/urls'
+
+const canonical = `${BASE_URL}/student-pints-perth`
+const description = 'Student pints in Perth near UWA, Curtin and Murdoch, using verified sub-$10 regular pint prices where Perth Pint Prices has checked rows.'
+
+export const revalidate = 3600
+
+export const metadata: Metadata = {
+  title: 'Student Pints Perth',
+  description,
+  alternates: { canonical },
+  openGraph: {
+    title: 'Student Pints Perth | Perth Pint Prices',
+    description,
+    url: canonical,
+    type: 'website',
+    siteName: 'Perth Pint Prices',
+    locale: 'en_AU',
+    images: [{ url: `${BASE_URL}/og-image.png`, width: 1200, height: 630, alt: 'Perth Pint Prices' }],
+  },
+  twitter: { card: 'summary_large_image' },
+}
+
+function formatPrice(price: number | null | undefined): string {
+  if (price == null) return 'TBC'
+  return Number.isInteger(price) ? `$${price.toFixed(0)}` : `$${price.toFixed(2)}`
+}
+
+function formatDistance(km: number): string {
+  if (km < 1) return `${Math.round(km * 1000)}m`
+  return `${km.toFixed(1)}km`
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return 'date TBC'
+  return new Date(value).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: 'numeric', timeZone: 'Australia/Perth' })
+}
+
+function buildItemList(rows: StudentPintPub[]) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: 'Student pints in Perth',
+    itemListOrder: 'https://schema.org/ItemListOrderAscending',
+    numberOfItems: rows.length,
+    itemListElement: rows.slice(0, 20).map((pub, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      url: `${BASE_URL}${pubUrl(pub)}`,
+      name: `${pub.name} - ${formatPrice(pub.regularPrice)} near ${pub.campusShortName}`,
+    })),
+  }
+}
+
+export default async function StudentPintsPerthPage() {
+  const pubs = await getPubs()
+  const campusRows = STUDENT_CAMPUSES.map(campus => ({
+    campus,
+    rows: rankStudentPintsForCampus(pubs, campus),
+  }))
+  const allRows = rankStudentPints(pubs)
+  const cheapest = allRows[0] ?? null
+  const campusCount = campusRows.filter(group => group.rows.length > 0).length
+
+  return (
+    <main className="min-h-screen bg-[#FDF8F0]">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(buildItemList(allRows)).replace(/</g, '\\u003c') }}
+      />
+      <BreadcrumbJsonLd items={[
+        { name: 'Home', url: BASE_URL },
+        { name: 'Student pints', url: canonical },
+      ]} />
+      <SubPageNav breadcrumbs={[{ label: 'Student pints' }]} />
+
+      <section className="max-w-container mx-auto px-6 pt-8 pb-12">
+        <div className="grid gap-6 sm:grid-cols-[1fr_260px] sm:items-end">
+          <div>
+            <p className="mb-3 font-mono text-[0.68rem] font-bold uppercase text-gray-mid">Campus budget guide</p>
+            <h1 className="font-display text-[3rem] leading-[1] text-ink sm:text-[4.7rem]">
+              Student pints in Perth
+            </h1>
+            <p className="mt-5 max-w-[620px] font-body text-[0.96rem] leading-relaxed text-gray-mid">
+              Cheap pints near UWA, Curtin and Murdoch, with the boring but important rule up front: only verified regular pint prices under $10 make the list. Happy-hour chaos can have its own lecture theatre.
+            </p>
+          </div>
+          <div className="rounded-card border-3 border-ink bg-amber p-5 shadow-hard-sm">
+            <div className="mb-8 inline-flex items-center gap-2 rounded-pill border-3 border-ink bg-white px-4 py-2 font-mono text-[0.72rem] font-bold uppercase text-ink shadow-hard-sm">
+              <GraduationCap className="h-4 w-4 text-amber" />
+              Student list
+            </div>
+            <p className="font-mono text-[0.65rem] font-bold uppercase text-ink/55">Cheapest checked</p>
+            <p className="mt-1 font-mono text-5xl font-extrabold text-ink">{formatPrice(cheapest?.regularPrice)}</p>
+            <p className="mt-2 text-[0.8rem] leading-relaxed text-ink/70">{cheapest ? `${cheapest.name}, near ${cheapest.campusShortName}` : 'No checked row yet.'}</p>
+          </div>
+        </div>
+
+        <section className="my-8 rounded-card border-3 border-ink bg-ink p-5 text-white shadow-hard-sm">
+          <p className="font-mono text-[0.65rem] font-bold uppercase text-white/55">Answer first</p>
+          <h2 className="mt-2 font-mono text-xl font-extrabold">Where are the cheapest student pints in Perth?</h2>
+          <p className="mt-3 font-body text-[0.9rem] leading-relaxed text-white/70">
+            {cheapest ? <>The cheapest verified student-adjacent pint in this cut is {formatPrice(cheapest.regularPrice)} at <Link href={pubUrl(cheapest)} className="font-bold text-amber-light hover:underline">{cheapest.name}</Link>, about {formatDistance(cheapest.distanceKm)} direct from {cheapest.campusShortName}. UWA and Curtin have closer clusters; Murdoch needs a wider net in the current checked data.</> : <>We do not have a verified sub-$10 student row yet. That would be depressing, so hopefully it is temporary.</>}
+          </p>
+        </section>
+
+        <section className="mb-8 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Campuses covered</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{campusCount}/3</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Campuses with at least one verified sub-$10 row.</p>
+          </div>
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Rows under $10</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{allRows.length}</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Verified regular pint rows, not happy-hour specials.</p>
+          </div>
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Widest net</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">8km</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Murdoch needs more radius before checked rows appear.</p>
+          </div>
+        </section>
+
+        <section className="grid gap-5">
+          {campusRows.map(({ campus, rows }) => (
+            <div key={campus.slug} className="rounded-card border-3 border-ink bg-white shadow-hard-sm">
+              <div className="grid gap-0 sm:grid-cols-[220px_1fr]">
+                <div className="relative min-h-[170px] overflow-hidden border-b-3 border-ink sm:border-b-0 sm:border-r-3">
+                  <div
+                    className="absolute inset-0 bg-cover bg-center opacity-75"
+                    style={{ backgroundImage: `url(${getMapTileUrl(campus.lat, campus.lng, 15)})` }}
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-b from-white/30 to-amber-pale/95" />
+                  <div className="relative flex h-full min-h-[170px] flex-col justify-between p-4">
+                    <div className="inline-flex w-fit items-center gap-2 rounded-pill border-3 border-ink bg-white px-3 py-2 font-mono text-[0.68rem] font-bold uppercase text-ink shadow-hard-sm">
+                      <MapPin className="h-3.5 w-3.5 text-amber" />
+                      {campus.shortName}
+                    </div>
+                    <div>
+                      <p className="font-mono text-[0.6rem] font-bold uppercase text-gray-mid">Radius</p>
+                      <p className="mt-1 font-mono text-3xl font-extrabold text-ink">{campus.radiusKm}km</p>
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div className="border-b border-gray-light bg-off-white px-5 py-4">
+                    <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">{campus.name}</p>
+                    <h2 className="mt-1 font-mono text-xl font-extrabold text-ink">{campus.shortName} cheap pints</h2>
+                    <p className="mt-2 text-[0.78rem] leading-relaxed text-gray-mid">{campus.note}</p>
+                  </div>
+                  <div className="divide-y divide-gray-light">
+                    {rows.length > 0 ? rows.map((pub, index) => (
+                      <Link key={`${campus.slug}-${pub.id}`} href={pubUrl(pub)} className="group grid grid-cols-[2rem_1fr_auto] items-center gap-3 px-5 py-4 no-underline hover:bg-off-white">
+                        <span className="font-mono text-[0.72rem] font-bold text-gray-mid">{index + 1}</span>
+                        <span className="min-w-0">
+                          <span className="block truncate font-mono text-[0.86rem] font-extrabold text-ink group-hover:text-amber">{pub.name}</span>
+                          <span className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[0.68rem] text-gray-mid">
+                            <span>{pub.suburb}</span>
+                            <span>{formatDistance(pub.distanceKm)} direct</span>
+                            <span>Checked {formatDate(pub.lastVerified ?? pub.priceVerifiedAt)}</span>
+                          </span>
+                        </span>
+                        <span className="font-mono text-lg font-extrabold text-ink">{formatPrice(pub.regularPrice)}</span>
+                      </Link>
+                    )) : (
+                      <div className="px-5 py-6">
+                        <p className="font-body text-[0.85rem] leading-relaxed text-gray-mid">No verified sub-$10 regular pint rows inside this campus radius yet.</p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </section>
+
+        <section className="mt-8 rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+          <div className="mb-3 flex items-center gap-2">
+            <PiggyBank className="h-4 w-4 text-amber" />
+            <h2 className="font-mono text-lg font-extrabold text-ink">Useful next clicks</h2>
+          </div>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {[
+              { href: '/cheapest-pints', label: 'Cheapest pints in Perth' },
+              { href: '/happy-hour', label: 'Happy hours running now' },
+              { href: '/pubs-near-perth-station', label: 'Pubs near Perth Station' },
+              { href: '/articles/pints-under-10-perth', label: 'Under-$10 guide' },
+            ].map(link => (
+              <Link key={link.href} href={link.href} className="flex items-center justify-between rounded-card border border-gray-light px-4 py-3 font-mono text-[0.76rem] font-bold text-ink no-underline hover:border-amber hover:text-amber">
+                {link.label}<ArrowUpRight className="h-3.5 w-3.5" />
+              </Link>
+            ))}
+          </div>
+        </section>
+      </section>
+
+      <Footer />
+    </main>
+  )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,6 +4,7 @@ const NAV_LINKS = [
   { href: '/discover', label: 'Discover' },
   { href: '/happy-hour', label: 'Happy Hours' },
   { href: '/cheapest-pints', label: 'Cheap Pints' },
+  { href: '/student-pints-perth', label: 'Student Pints' },
   { href: '/pubs-near-perth-station', label: 'Near Station' },
   { href: '/articles', label: 'Articles' },
   { href: '/suburbs', label: 'Suburbs' },

--- a/src/lib/studentPints.test.ts
+++ b/src/lib/studentPints.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { rankStudentPints, rankStudentPintsForCampus, STUDENT_CAMPUSES } from './studentPints'
+import type { Pub } from '@/types/pub'
+
+function pub(overrides: Partial<Pub>): Pub {
+  return {
+    id: 1,
+    slug: 'test-pub',
+    name: 'Test Pub',
+    address: '',
+    suburb: 'Perth',
+    lat: -31.9805,
+    lng: 115.8197,
+    price: null,
+    beerType: '',
+    happyHour: null,
+    website: null,
+    description: null,
+    priceSource: null,
+    priceVerifiedAt: null,
+    priceConfidence: null,
+    priceVerified: true,
+    hasTab: false,
+    kidFriendly: false,
+    happyHourPrice: null,
+    happyHourDays: null,
+    happyHourStart: null,
+    happyHourEnd: null,
+    lastVerified: null,
+    regularPrice: 8,
+    isHappyHourNow: false,
+    happyHourLabel: null,
+    happyHourMinutesRemaining: null,
+    imageUrl: null,
+    vibeTag: null,
+    cozyPub: false,
+    effectivePrice: null,
+    ...overrides,
+  }
+}
+
+test('rankStudentPintsForCampus keeps only verified sub-$10 rows inside the campus radius', () => {
+  const campus = STUDENT_CAMPUSES[0]
+  const rows = rankStudentPintsForCampus([
+    pub({ id: 1, name: 'Good Row', regularPrice: 8, lat: campus.lat, lng: campus.lng }),
+    pub({ id: 2, name: 'Ten Dollar Row', regularPrice: 10, lat: campus.lat, lng: campus.lng }),
+    pub({ id: 3, name: 'Unverified Row', regularPrice: 7, priceVerified: false, lat: campus.lat, lng: campus.lng }),
+    pub({ id: 4, name: 'Far Row', regularPrice: 7, lat: campus.lat + 0.2, lng: campus.lng }),
+  ], campus)
+
+  assert.deepEqual(rows.map(row => row.name), ['Good Row'])
+})
+
+test('rankStudentPintsForCampus sorts by price before direct distance', () => {
+  const campus = STUDENT_CAMPUSES[0]
+  const rows = rankStudentPintsForCampus([
+    pub({ id: 1, name: 'Closer Nine', regularPrice: 9, lat: campus.lat, lng: campus.lng }),
+    pub({ id: 2, name: 'Further Seven', regularPrice: 7, lat: campus.lat + 0.01, lng: campus.lng }),
+  ], campus)
+
+  assert.deepEqual(rows.map(row => row.name), ['Further Seven', 'Closer Nine'])
+})
+
+test('rankStudentPints sorts combined campus rows by cheapest price', () => {
+  const [uwa, curtin] = STUDENT_CAMPUSES
+  const rows = rankStudentPints([
+    pub({ id: 1, name: 'UWA Eight', regularPrice: 8, lat: uwa.lat, lng: uwa.lng }),
+    pub({ id: 2, name: 'Curtin Seven', regularPrice: 7, lat: curtin.lat, lng: curtin.lng }),
+  ])
+
+  assert.deepEqual(rows.map(row => row.name), ['Curtin Seven', 'UWA Eight'])
+})

--- a/src/lib/studentPints.ts
+++ b/src/lib/studentPints.ts
@@ -1,0 +1,77 @@
+import type { Pub } from '@/types/pub'
+import { haversineDistanceKm } from '@/lib/location'
+
+export type StudentCampus = {
+  slug: string
+  name: string
+  shortName: string
+  lat: number
+  lng: number
+  radiusKm: number
+  note: string
+}
+
+export type StudentPintPub = Pub & {
+  campusSlug: string
+  campusName: string
+  campusShortName: string
+  distanceKm: number
+}
+
+export const STUDENT_CAMPUSES = [
+  {
+    slug: 'uwa',
+    name: 'University of Western Australia',
+    shortName: 'UWA',
+    lat: -31.9805,
+    lng: 115.8197,
+    radiusKm: 4,
+    note: 'Crawley and Subiaco do most of the useful work here. Close is nice, but checked price still wins.',
+  },
+  {
+    slug: 'curtin',
+    name: 'Curtin University',
+    shortName: 'Curtin',
+    lat: -32.0063,
+    lng: 115.8949,
+    radiusKm: 4,
+    note: 'Bentley, Vic Park, East Vic Park and Como give Curtin the strongest nearby cheap-pint cluster.',
+  },
+  {
+    slug: 'murdoch',
+    name: 'Murdoch University',
+    shortName: 'Murdoch',
+    lat: -32.0662,
+    lng: 115.8358,
+    radiusKm: 8,
+    note: 'Murdoch needs a wider net in the current verified data. Treat these as nearby-ish options, not a between-lectures sprint.',
+  },
+] as const satisfies readonly StudentCampus[]
+
+export function rankStudentPintsForCampus(pubs: Pub[], campus: StudentCampus, limit: number = 8): StudentPintPub[] {
+  return pubs
+    .filter(pub => pub.priceVerified && pub.regularPrice !== null && pub.regularPrice < 10)
+    .filter(pub => Number.isFinite(pub.lat) && Number.isFinite(pub.lng) && !(pub.lat === 0 && pub.lng === 0))
+    .map(pub => ({
+      ...pub,
+      campusSlug: campus.slug,
+      campusName: campus.name,
+      campusShortName: campus.shortName,
+      distanceKm: haversineDistanceKm(campus.lat, campus.lng, pub.lat, pub.lng),
+    }))
+    .filter(pub => pub.distanceKm <= campus.radiusKm)
+    .sort((a, b) => {
+      if (a.regularPrice !== b.regularPrice) return (a.regularPrice ?? Number.MAX_VALUE) - (b.regularPrice ?? Number.MAX_VALUE)
+      return a.distanceKm - b.distanceKm
+    })
+    .slice(0, limit)
+}
+
+export function rankStudentPints(pubs: Pub[]): StudentPintPub[] {
+  return STUDENT_CAMPUSES
+    .flatMap(campus => rankStudentPintsForCampus(pubs, campus, Number.MAX_SAFE_INTEGER))
+    .sort((a, b) => {
+      if (a.regularPrice !== b.regularPrice) return (a.regularPrice ?? Number.MAX_VALUE) - (b.regularPrice ?? Number.MAX_VALUE)
+      return a.distanceKm - b.distanceKm
+    })
+}


### PR DESCRIPTION
## Summary
- add `/student-pints-perth` for verified under-$10 regular pint rows near UWA, Curtin, and Murdoch
- add shared student-pint ranking helpers and tests
- wire the page into sitemap, footer, and `/llms.txt`

Refs #32. This is the student-pints slice; faceted suburb pages remain for follow-up.

## Verification
- `npm test` (260/260)
- `npx tsc --noEmit`
- `git diff --check`
- `npm run lint` (existing warnings only in `SubmitPubForm` and `SunsetSippers`)
- `npm run build`
- `npm run test:e2e` (4/4)
- reviewer sub-agent LGTM
- desktop/mobile screenshots saved under `/tmp/perth-pint-prices-student-pints-32/`

## Notes
- Uses verified `regularPrice` only; no happy-hour prices are mixed into the student-pint claims.
- Distances are direct distances from campus coordinates, not walking-route distances.
- Murdoch uses an 8km radius because the current verified data has no sub-$10 rows inside 4-6km.
