### PR TITLE
Add answer-first Perth pint cost page

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,13 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Answer-first pint-cost page ready for preview (2026-06-03)
+- **Issue #27 / branch `codex/answer-first-pint-prices-27`:** added `/how-much-is-a-pint-in-perth` for the zero-click "how much is a pint in Perth" cluster. The page answers in the first screen with the live checked average, median, range, cheapest verified pint, glass-size notes, visible Q&A, and internal links into Cheapest Pints, Happy Hours, Pint Index, and the proper-pint explainer.
+- **Pint Index answer block:** added a "Perth beer prices" answer-first card to `/insights/pint-index`, backed by the same verified regular-price stats. The mobile Pint Index methodology wrapper was tightened to remove an 8px horizontal overflow found during screenshot QA.
+- **Shared stats helper:** added `src/lib/pintPriceStats.ts` with tests so average, median, range, under-$10 count, and verified-row filtering stay consistent across answer pages.
+- **SEO wiring:** added canonical metadata, OG/Twitter image, Breadcrumb + ItemList JSON-LD, and sitemap/footer/`/llms.txt` entries.
+- **Verification:** verified `npm test` (**263/263 tests**), `npx tsc --noEmit`, `git diff --check`, `npm run lint` (existing warnings only), `npm run build`, `npm run test:e2e` (**4/4 Playwright tests**), reviewer sub-agent LGTM, and clean desktop/mobile screenshots for `/how-much-is-a-pint-in-perth` + `/insights/pint-index` under `/tmp/perth-pint-prices-answer-first-27/`. The repeated local build flake (`/_document` not found) only occurred while a dev/e2e server was touching `.next`; the solo build passed.
+
 ### Student-pints landing page ready for preview (2026-06-03)
 - **Issue #32 third slice / branch `codex/student-pints-landing-page-32` / commit `8ec3168`:** added `/student-pints-perth`, a verified under-$10 regular-pint page for UWA, Curtin, and Murdoch.
 - **Campus ranking:** added shared student-pint ranking helpers and tests. Campus sections use verified regular prices only, direct-distance radii, and campus-specific notes; Murdoch deliberately uses a wider 8km radius because the current checked data has no useful sub-$10 cluster inside 4-6km.

--- a/src/app/how-much-is-a-pint-in-perth/page.tsx
+++ b/src/app/how-much-is-a-pint-in-perth/page.tsx
@@ -1,0 +1,200 @@
+import type { Metadata } from 'next'
+import Image from 'next/image'
+import Link from 'next/link'
+import { ArrowUpRight, Beer, CircleDollarSign, Ruler } from 'lucide-react'
+import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
+import Footer from '@/components/Footer'
+import SubPageNav from '@/components/SubPageNav'
+import { formatAudPrice, getPintPriceStats } from '@/lib/pintPriceStats'
+import { getPubs } from '@/lib/supabase'
+import { BASE_URL, pubUrl } from '@/lib/urls'
+import type { Pub } from '@/types/pub'
+
+const canonical = `${BASE_URL}/how-much-is-a-pint-in-perth`
+const description = 'How much a pint costs in Perth right now, using verified regular pint prices from Perth Pint Prices with the current average, median, range, and glass-size notes.'
+
+export const revalidate = 3600
+
+export const metadata: Metadata = {
+  title: 'How Much Is a Pint in Perth?',
+  description,
+  alternates: { canonical },
+  openGraph: {
+    title: 'How Much Is a Pint in Perth? | Perth Pint Prices',
+    description,
+    url: canonical,
+    type: 'website',
+    siteName: 'Perth Pint Prices',
+    locale: 'en_AU',
+    images: [{ url: `${BASE_URL}/articles/pints-under-10-perth-01-fremantle-6-pint.png`, width: 1200, height: 630, alt: 'A pint on a Perth pub table' }],
+  },
+  twitter: { card: 'summary_large_image' },
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return 'date TBC'
+  return new Date(value).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: 'numeric', timeZone: 'Australia/Perth' })
+}
+
+function buildItemList(rows: Pub[]) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: 'Checked Perth pint prices',
+    itemListOrder: 'https://schema.org/ItemListOrderAscending',
+    numberOfItems: rows.length,
+    itemListElement: rows.slice(0, 12).map((pub, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      url: `${BASE_URL}${pubUrl(pub)}`,
+      name: `${pub.name} - ${formatAudPrice(pub.regularPrice)} pint`,
+    })),
+  }
+}
+
+export default async function HowMuchIsAPintInPerthPage() {
+  const pubs = await getPubs()
+  const stats = getPintPriceStats(pubs)
+  const cheapestRows = stats.verifiedPubs.slice(0, 8)
+  const cheapest = stats.cheapestPub
+
+  return (
+    <main className="min-h-screen bg-[#FDF8F0]">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(buildItemList(cheapestRows)).replace(/</g, '\\u003c') }}
+      />
+      <BreadcrumbJsonLd items={[
+        { name: 'Home', url: BASE_URL },
+        { name: 'How much is a pint in Perth?', url: canonical },
+      ]} />
+      <SubPageNav breadcrumbs={[{ label: 'Pint cost' }]} />
+
+      <section className="max-w-container mx-auto px-6 pt-8 pb-12">
+        <div className="grid gap-6 sm:grid-cols-[1fr_250px] sm:items-end">
+          <div>
+            <p className="mb-3 font-mono text-[0.68rem] font-bold uppercase text-gray-mid">Answer first</p>
+            <h1 className="font-display text-[3rem] leading-[1] text-ink sm:text-[4.55rem]">
+              How much is a pint in Perth?
+            </h1>
+            <p className="mt-5 max-w-[640px] font-body text-[0.98rem] leading-relaxed text-gray-mid">
+              A pint in Perth costs about <span className="font-mono font-bold text-ink">{formatAudPrice(stats.averagePrice)}</span> on average across {stats.verifiedCount} verified regular pint prices in the current Perth Pint Prices dataset. The median is <span className="font-mono font-bold text-ink">{formatAudPrice(stats.medianPrice)}</span>, and the cheapest checked pint is {cheapest ? <><span className="font-mono font-bold text-ink">{formatAudPrice(cheapest.regularPrice)}</span> at {cheapest.name} in {cheapest.suburb}</> : 'still TBC'}.
+            </p>
+          </div>
+          <div className="overflow-hidden rounded-card border-3 border-ink bg-white shadow-hard-sm">
+            <Image
+              src="/articles/pints-under-10-perth-01-fremantle-6-pint.png"
+              alt="A checked Perth pint"
+              width={700}
+              height={700}
+              className="aspect-square w-full object-cover"
+              priority
+            />
+          </div>
+        </div>
+
+        <section className="my-8 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Average pint</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{formatAudPrice(stats.averagePrice)}</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Verified regular pint prices only.</p>
+          </div>
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Median pint</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{formatAudPrice(stats.medianPrice)}</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">The middle of the checked-price pack.</p>
+          </div>
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Checked range</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{formatAudPrice(stats.minPrice)}-{formatAudPrice(stats.maxPrice)}</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">{stats.trackedCount} pubs tracked across {stats.suburbCount} suburbs.</p>
+          </div>
+        </section>
+
+        <section className="mb-8 rounded-card border-3 border-ink bg-ink p-5 text-white shadow-hard-sm">
+          <div className="flex items-start gap-3">
+            <CircleDollarSign className="mt-1 h-5 w-5 shrink-0 text-amber-light" />
+            <div>
+              <p className="font-mono text-[0.65rem] font-bold uppercase text-white/55">Short version</p>
+              <h2 className="mt-2 font-mono text-xl font-extrabold">What should you budget for one pint?</h2>
+              <p className="mt-3 font-body text-[0.9rem] leading-relaxed text-white/70">
+                Budget roughly {formatAudPrice(stats.averagePrice)} for a standard Perth pint if you are walking into a random checked pub. If you care where the cheap end still lives, start with the live <Link href="/cheapest-pints" className="font-bold text-amber-light hover:underline">cheapest-pints list</Link>; {stats.underTenCount} verified rows currently sit under $10.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-5 sm:grid-cols-[1fr_0.85fr]">
+          <div className="rounded-card border-3 border-ink bg-white shadow-hard-sm">
+            <div className="border-b-3 border-ink bg-off-white px-5 py-4">
+              <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Live rows</p>
+              <h2 className="mt-1 font-mono text-xl font-extrabold text-ink">Cheapest checked pints right now</h2>
+            </div>
+            <div className="divide-y divide-gray-light">
+              {cheapestRows.map((pub, index) => (
+                <Link key={pub.id} href={pubUrl(pub)} className="group grid grid-cols-[2rem_1fr_auto] items-center gap-3 px-5 py-4 no-underline hover:bg-off-white">
+                  <span className="font-mono text-[0.72rem] font-bold text-gray-mid">{index + 1}</span>
+                  <span className="min-w-0">
+                    <span className="block truncate font-mono text-[0.86rem] font-extrabold text-ink group-hover:text-amber">{pub.name}</span>
+                    <span className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[0.68rem] text-gray-mid">
+                      <span>{pub.suburb}</span>
+                      <span>Checked {formatDate(pub.lastVerified ?? pub.priceVerifiedAt)}</span>
+                    </span>
+                  </span>
+                  <span className="font-mono text-lg font-extrabold text-ink">{formatAudPrice(pub.regularPrice)}</span>
+                </Link>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid gap-5">
+            <section className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+              <div className="mb-3 flex items-center gap-2">
+                <Ruler className="h-4 w-4 text-amber" />
+                <h2 className="font-mono text-lg font-extrabold text-ink">What is a pint?</h2>
+              </div>
+              <p className="font-body text-[0.85rem] leading-relaxed text-gray-mid">
+                On this site, a pint means 570ml. A schooner is 425ml and a middy is 285ml. If a venue only confirms a schooner or middy, we keep that glass size with the pub and do not inflate it into a pint number.
+              </p>
+            </section>
+
+            <section className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+              <div className="mb-3 flex items-center gap-2">
+                <Beer className="h-4 w-4 text-amber" />
+                <h2 className="font-mono text-lg font-extrabold text-ink">Quick Q&A</h2>
+              </div>
+              <div className="space-y-4">
+                <div>
+                  <h3 className="font-mono text-[0.82rem] font-extrabold text-ink">Is a happy-hour pint included?</h3>
+                  <p className="mt-1 text-[0.78rem] leading-relaxed text-gray-mid">No. The headline number uses regular pint prices only. Happy-hour deals move around by day and hour, so they live on the happy-hour pages.</p>
+                </div>
+                <div>
+                  <h3 className="font-mono text-[0.82rem] font-extrabold text-ink">Why do some pubs show TBC?</h3>
+                  <p className="mt-1 text-[0.78rem] leading-relaxed text-gray-mid">Because we have not confirmed a current regular pint price cleanly enough. TBC rows stay out of the average and median.</p>
+                </div>
+              </div>
+            </section>
+          </div>
+        </section>
+
+        <section className="mt-8 rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+          <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Keep going</p>
+          <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            {[
+              { href: '/insights/pint-index', label: 'Perth Pint Index' },
+              { href: '/cheapest-pints', label: 'Cheapest pints in Perth' },
+              { href: '/happy-hour', label: 'Happy hours running now' },
+              { href: '/articles/proper-pint-schooner-middy-perth', label: 'Pint, schooner, middy explainer' },
+            ].map(link => (
+              <Link key={link.href} href={link.href} className="flex items-center justify-between rounded-card border border-gray-light px-4 py-3 font-mono text-[0.76rem] font-bold text-ink no-underline hover:border-amber hover:text-amber">
+                {link.label}<ArrowUpRight className="h-3.5 w-3.5" />
+              </Link>
+            ))}
+          </div>
+        </section>
+      </section>
+
+      <Footer />
+    </main>
+  )
+}

--- a/src/app/insights/pint-index/PintIndexPage.tsx
+++ b/src/app/insights/pint-index/PintIndexPage.tsx
@@ -1,11 +1,26 @@
 'use client'
 
+import Link from 'next/link'
+import { ArrowUpRight, CircleDollarSign } from 'lucide-react'
 import SubPageNav from '@/components/SubPageNav'
 import PintIndex from '@/components/PintIndex'
 import Footer from '@/components/Footer'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 
-export default function PintIndexPage() {
+interface PintIndexAnswerStats {
+  averagePrice: string
+  medianPrice: string
+  verifiedCount: number
+  trackedCount: number
+  suburbCount: number
+  underTenCount: number
+  cheapestName: string | null
+  cheapestSuburb: string | null
+  cheapestPrice: string
+  cheapestUrl: string | null
+}
+
+export default function PintIndexPage({ stats }: { stats: PintIndexAnswerStats }) {
   return (
     <main className="min-h-screen overflow-x-hidden bg-[#FDF8F0]">
       <SubPageNav breadcrumbs={[
@@ -14,14 +29,33 @@ export default function PintIndexPage() {
       ]} />
       <h1 className="sr-only">Perth Pint Index</h1>
       <div className="mx-auto w-[calc(100vw-3rem)] max-w-container py-8 sm:py-12">
+        <section className="mb-5 rounded-card border-3 border-ink bg-ink p-5 text-white shadow-hard-sm">
+          <div className="flex items-start gap-3">
+            <CircleDollarSign className="mt-1 h-5 w-5 shrink-0 text-amber-light" />
+            <div>
+              <p className="font-mono text-[0.65rem] font-bold uppercase tracking-[0.08em] text-white/55">
+                Answer first
+              </p>
+              <h2 className="mt-2 font-mono text-xl font-extrabold text-white">
+                What are Perth beer prices right now?
+              </h2>
+              <p className="mt-3 font-body text-[0.9rem] leading-relaxed text-white/70">
+                Perth&apos;s checked pint average is {stats.averagePrice}, with a {stats.medianPrice} median across {stats.verifiedCount} verified regular pint rows. {stats.cheapestName && stats.cheapestUrl ? <>The cheapest checked pint is <Link href={stats.cheapestUrl} className="font-bold text-amber-light hover:underline">{stats.cheapestPrice} at {stats.cheapestName}</Link> in {stats.cheapestSuburb}.</> : 'The cheapest checked pint is still TBC.'} We track {stats.trackedCount} pubs across {stats.suburbCount} suburbs; {stats.underTenCount} verified rows currently sit under $10.
+              </p>
+              <Link
+                href="/how-much-is-a-pint-in-perth"
+                className="mt-4 inline-flex items-center gap-2 font-mono text-[0.72rem] font-bold uppercase tracking-[0.05em] text-amber-light no-underline hover:text-white"
+              >
+                Read the plain-English price answer <ArrowUpRight className="h-3.5 w-3.5" />
+              </Link>
+            </div>
+          </div>
+        </section>
         <div className="overflow-x-auto">
           <ErrorBoundary><PintIndex /></ErrorBoundary>
         </div>
       </div>
-      <div
-        className="relative left-1/2 -translate-x-1/2 px-6 pb-8 sm:pb-12"
-        style={{ width: '100vw', boxSizing: 'border-box' }}
-      >
+      <div className="mx-auto w-[calc(100vw-3rem)] max-w-container pb-8 sm:pb-12">
         <section
           className="mx-auto w-full max-w-container border-3 border-ink rounded-card bg-white p-5 sm:p-6 shadow-hard-sm"
           style={{ boxSizing: 'border-box' }}

--- a/src/app/insights/pint-index/page.tsx
+++ b/src/app/insights/pint-index/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from 'next'
 import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
 import { buildArticleJsonLd } from '@/lib/articleJsonLd'
-import { getAllPubLastModifiedPairs } from '@/lib/supabase'
+import { formatAudPrice, getPintPriceStats } from '@/lib/pintPriceStats'
+import { getAllPubLastModifiedPairs, getPubs } from '@/lib/supabase'
+import { pubUrl } from '@/lib/urls'
 import PintIndexPage from './PintIndexPage'
 
 const canonical = 'https://perthpintprices.com/insights/pint-index'
@@ -39,7 +41,12 @@ function latestModifiedDate(values: Array<{ lastModified: string | null }>): str
 }
 
 export default async function Page() {
-  const latestPubModified = latestModifiedDate(await getAllPubLastModifiedPairs())
+  const [pubDates, pubs] = await Promise.all([
+    getAllPubLastModifiedPairs(),
+    getPubs(),
+  ])
+  const latestPubModified = latestModifiedDate(pubDates)
+  const stats = getPintPriceStats(pubs)
   const articleJsonLd = buildArticleJsonLd({
     url: canonical,
     headline: 'Perth Pint Index: Live Beer Price Tracker',
@@ -66,7 +73,18 @@ export default async function Page() {
         <a href="/discover">Discover</a>
         <a href="/happy-hour">Happy Hours</a>
       </div>
-      <PintIndexPage />
+      <PintIndexPage stats={{
+        averagePrice: formatAudPrice(stats.averagePrice),
+        medianPrice: formatAudPrice(stats.medianPrice),
+        verifiedCount: stats.verifiedCount,
+        trackedCount: stats.trackedCount,
+        suburbCount: stats.suburbCount,
+        underTenCount: stats.underTenCount,
+        cheapestName: stats.cheapestPub?.name ?? null,
+        cheapestSuburb: stats.cheapestPub?.suburb ?? null,
+        cheapestPrice: formatAudPrice(stats.cheapestPub?.regularPrice),
+        cheapestUrl: stats.cheapestPub ? pubUrl(stats.cheapestPub) : null,
+      }} />
     </>
   )
 }

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -16,6 +16,7 @@ const lines = [
   `- [Suburb Rankings](${BASE_URL}/insights/suburb-rankings): suburb-by-suburb pint-price comparisons.`,
   `- [Happy Hours](${BASE_URL}/happy-hour): current happy-hour finder for Perth pubs.`,
   `- [Cheapest Pints](${BASE_URL}/cheapest-pints): live ranked list of the cheapest verified regular pint prices in Perth.`,
+  `- [How Much Is a Pint in Perth?](${BASE_URL}/how-much-is-a-pint-in-perth): answer-first Perth pint cost, average, median, range, and glass-size notes.`,
   `- [Student Pints Perth](${BASE_URL}/student-pints-perth): verified sub-$10 regular pint rows near UWA, Curtin, and Murdoch.`,
   ...TRANSPORT_HUBS.map(hub => `- [Pubs near ${hub.name}](${BASE_URL}/${hub.slug}): distance-ranked pub guide with checked pint prices where available.`),
   `- [Discover](${BASE_URL}/discover): searchable pub and pint-price directory.`,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -55,6 +55,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${BASE_URL}/guides/cozy-corners`, lastModified: latestPubModified, changeFrequency: 'weekly', priority: 0.7 },
     { url: `${BASE_URL}/happy-hour`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },
     { url: `${BASE_URL}/cheapest-pints`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },
+    { url: `${BASE_URL}/how-much-is-a-pint-in-perth`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },
     { url: `${BASE_URL}/student-pints-perth`, lastModified: latestPubModified, changeFrequency: 'weekly', priority: 0.7 },
     { url: `${BASE_URL}/articles`, lastModified: articles[0]?.updatedAt || FALLBACK_LAST_MODIFIED, changeFrequency: 'weekly', priority: 0.8 },
   ]

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,6 +4,7 @@ const NAV_LINKS = [
   { href: '/discover', label: 'Discover' },
   { href: '/happy-hour', label: 'Happy Hours' },
   { href: '/cheapest-pints', label: 'Cheap Pints' },
+  { href: '/how-much-is-a-pint-in-perth', label: 'Pint Cost' },
   { href: '/student-pints-perth', label: 'Student Pints' },
   { href: '/pubs-near-perth-station', label: 'Near Station' },
   { href: '/articles', label: 'Articles' },

--- a/src/components/PintIndex.tsx
+++ b/src/components/PintIndex.tsx
@@ -321,7 +321,7 @@ export default function PintIndex() {
             {/* Mobile sparkline */}
             <div className="sm:hidden mt-4" onClick={e => e.stopPropagation()}>
               <div className="text-[10px] text-gray-mid mb-1">Price trend {'\u00B7'} tap to explore</div>
-              <Sparkline data={sparkData} snapshots={snapshots} width={320} height={50} />
+              <Sparkline data={sparkData} snapshots={snapshots} width={280} height={50} />
             </div>
 
             <p className="text-[10px] text-gray-mid mt-3 text-center flex items-center justify-center gap-1">

--- a/src/lib/pintPriceStats.test.ts
+++ b/src/lib/pintPriceStats.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { formatAudPrice, getPintPriceStats, getVerifiedRegularPubs } from './pintPriceStats'
+import type { Pub } from '@/types/pub'
+
+function pub(overrides: Partial<Pub>): Pub {
+  return {
+    id: 1,
+    slug: 'test-pub',
+    name: 'Test Pub',
+    address: '',
+    suburb: 'Perth',
+    lat: -31.95,
+    lng: 115.86,
+    price: null,
+    beerType: '',
+    happyHour: null,
+    website: null,
+    description: null,
+    priceSource: null,
+    priceVerifiedAt: null,
+    priceConfidence: null,
+    priceVerified: true,
+    hasTab: false,
+    kidFriendly: false,
+    happyHourPrice: null,
+    happyHourDays: null,
+    happyHourStart: null,
+    happyHourEnd: null,
+    lastVerified: null,
+    regularPrice: 9,
+    isHappyHourNow: false,
+    happyHourLabel: null,
+    happyHourMinutesRemaining: null,
+    imageUrl: null,
+    vibeTag: null,
+    cozyPub: false,
+    effectivePrice: null,
+    ...overrides,
+  }
+}
+
+test('getVerifiedRegularPubs keeps only verified regular pint rows sorted by price', () => {
+  const rows = getVerifiedRegularPubs([
+    pub({ id: 1, name: 'Nine', regularPrice: 9 }),
+    pub({ id: 2, name: 'TBC', regularPrice: null }),
+    pub({ id: 3, name: 'Unverified Seven', regularPrice: 7, priceVerified: false }),
+    pub({ id: 4, name: 'Eight', regularPrice: 8 }),
+  ])
+
+  assert.deepEqual(rows.map(row => row.name), ['Eight', 'Nine'])
+})
+
+test('getPintPriceStats calculates average, median, range, and under-ten count', () => {
+  const stats = getPintPriceStats([
+    pub({ id: 1, suburb: 'Perth', regularPrice: 8 }),
+    pub({ id: 2, suburb: 'Northbridge', regularPrice: 9.5 }),
+    pub({ id: 3, suburb: 'Fremantle', regularPrice: 10.5 }),
+    pub({ id: 4, suburb: 'Fremantle', regularPrice: 12 }),
+    pub({ id: 5, suburb: 'Perth', regularPrice: null }),
+  ])
+
+  assert.equal(stats.trackedCount, 5)
+  assert.equal(stats.verifiedCount, 4)
+  assert.equal(stats.suburbCount, 3)
+  assert.equal(stats.averagePrice, 10)
+  assert.equal(stats.medianPrice, 10)
+  assert.equal(stats.minPrice, 8)
+  assert.equal(stats.maxPrice, 12)
+  assert.equal(stats.underTenCount, 2)
+  assert.equal(stats.cheapestPub?.name, 'Test Pub')
+})
+
+test('formatAudPrice keeps whole dollars compact and cents explicit', () => {
+  assert.equal(formatAudPrice(null), 'TBC')
+  assert.equal(formatAudPrice(9), '$9')
+  assert.equal(formatAudPrice(9.5), '$9.50')
+})

--- a/src/lib/pintPriceStats.ts
+++ b/src/lib/pintPriceStats.ts
@@ -1,0 +1,54 @@
+import type { Pub } from '@/types/pub'
+
+export interface PintPriceStats {
+  trackedCount: number
+  verifiedCount: number
+  suburbCount: number
+  averagePrice: number | null
+  medianPrice: number | null
+  minPrice: number | null
+  maxPrice: number | null
+  underTenCount: number
+  cheapestPub: Pub | null
+  verifiedPubs: Pub[]
+}
+
+export function getVerifiedRegularPubs(pubs: Pub[]): Pub[] {
+  return pubs
+    .filter(pub => pub.priceVerified && pub.regularPrice !== null)
+    .sort((a, b) => (a.regularPrice ?? Number.MAX_VALUE) - (b.regularPrice ?? Number.MAX_VALUE))
+}
+
+function getMedian(prices: number[]): number | null {
+  if (prices.length === 0) return null
+
+  const midpoint = Math.floor(prices.length / 2)
+  if (prices.length % 2 === 1) return prices[midpoint]
+
+  return (prices[midpoint - 1] + prices[midpoint]) / 2
+}
+
+export function getPintPriceStats(pubs: Pub[]): PintPriceStats {
+  const verifiedPubs = getVerifiedRegularPubs(pubs)
+  const prices = verifiedPubs.map(pub => pub.regularPrice as number)
+
+  return {
+    trackedCount: pubs.length,
+    verifiedCount: verifiedPubs.length,
+    suburbCount: new Set(pubs.map(pub => pub.suburb).filter(Boolean)).size,
+    averagePrice: prices.length > 0
+      ? prices.reduce((sum, price) => sum + price, 0) / prices.length
+      : null,
+    medianPrice: getMedian(prices),
+    minPrice: prices[0] ?? null,
+    maxPrice: prices.at(-1) ?? null,
+    underTenCount: verifiedPubs.filter(pub => (pub.regularPrice ?? Number.MAX_VALUE) < 10).length,
+    cheapestPub: verifiedPubs[0] ?? null,
+    verifiedPubs,
+  }
+}
+
+export function formatAudPrice(price: number | null | undefined): string {
+  if (price == null) return 'TBC'
+  return Number.isInteger(price) ? `$${price.toFixed(0)}` : `$${price.toFixed(2)}`
+}


### PR DESCRIPTION
## Summary
- Add `/how-much-is-a-pint-in-perth` for the zero-click pint-cost query cluster, with live checked average, median, range, cheapest verified pint, visible Q&A, glass-size notes, and internal links.
- Add a reusable `pintPriceStats` helper + tests so verified regular-price calculations stay consistent.
- Add an answer-first "Perth beer prices" card to Pint Index and remove a mobile overflow in the methodology wrapper.
- Wire the new route into sitemap, footer, and `/llms.txt`.

Refs #27

## Verification
- `npm test` — 263/263 passing
- `npx tsc --noEmit`
- `git diff --check`
- `npm run lint` — passes with existing SubmitPubForm/SunsetSippers warnings only
- `npm run build` — passes; route table includes `/how-much-is-a-pint-in-perth`
- `npm run test:e2e` — 4/4 passing
- Reviewer sub-agent LGTM, no changes made

## Visual evidence
- `/tmp/perth-pint-prices-answer-first-27/how-much-desktop-clean.png`
- `/tmp/perth-pint-prices-answer-first-27/how-much-mobile-clean.png`
- `/tmp/perth-pint-prices-answer-first-27/pint-index-desktop-clean.png`
- `/tmp/perth-pint-prices-answer-first-27/pint-index-mobile-clean.png`

Note: local `npm run build` flaked when a dev/e2e server was touching `.next` at the same time (`/_document` not found). A solo build passed cleanly.
