### PR TITLE
submit form: keep <img> for blob previews + fix object-URL leak

### DIFF
--- a/src/components/SubmitPubForm.tsx
+++ b/src/components/SubmitPubForm.tsx
@@ -191,7 +191,7 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
     // Scan menu reset
     setScanStep('upload');
     setMenuImages([]);
-    setMenuPreviews([]);
+    clearMenuPreviews();
     setScanning(false);
     setExtractedItems([]);
     setScanError('');
@@ -308,7 +308,19 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
 
   function removeMenuImage(index: number) {
     setMenuImages(prev => prev.filter((_, i) => i !== index));
-    setMenuPreviews(prev => prev.filter((_, i) => i !== index));
+    setMenuPreviews(prev => {
+      const removed = prev[index];
+      if (removed) URL.revokeObjectURL(removed);
+      return prev.filter((_, i) => i !== index);
+    });
+  }
+
+  // Revoke all preview object URLs before clearing, so we don't leak blob: handles.
+  function clearMenuPreviews() {
+    setMenuPreviews(prev => {
+      prev.forEach(url => URL.revokeObjectURL(url));
+      return [];
+    });
   }
 
   async function handleScanMenu() {
@@ -846,6 +858,7 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
                         <div className="grid grid-cols-3 gap-2 mb-3">
                           {menuPreviews.map((preview, i) => (
                             <div key={i} className="relative">
+                              {/* eslint-disable-next-line @next/next/no-img-element -- local object-URL preview of the user's own upload; next/image can't optimize a client-side blob: URL */}
                               <img
                                 src={preview}
                                 alt={`Menu photo ${i + 1}`}
@@ -926,7 +939,7 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
                         <p className="font-mono text-xs text-gray-mid">Try a clearer photo, or use Report Price to add manually.</p>
                         <button
                           type="button"
-                          onClick={() => { setScanStep('upload'); setMenuImages([]); setMenuPreviews([]); }}
+                          onClick={() => { setScanStep('upload'); setMenuImages([]); clearMenuPreviews(); }}
                           className="mt-3 px-4 py-2 font-mono text-xs font-bold text-ink border-2 border-ink rounded-pill hover:bg-off-white transition-all"
                         >
                           Try Again

--- a/src/components/SubmitPubForm.tsx
+++ b/src/components/SubmitPubForm.tsx
@@ -103,6 +103,18 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
     return () => document.removeEventListener('keydown', handleKey);
   }, [isOpen, onClose]);
 
+  // When the modal closes by any path (including Escape/backdrop, which bypass
+  // resetForm), revoke and drop any outstanding menu-photo preview blob URLs so
+  // they don't leak. Returns the same array when already empty to avoid an
+  // extra render. setMenuPreviews is a stable setter, so deps stay [isOpen].
+  useEffect(() => {
+    if (isOpen) return;
+    setMenuPreviews(prev => {
+      prev.forEach(url => URL.revokeObjectURL(url));
+      return prev.length ? [] : prev;
+    });
+  }, [isOpen]);
+
   // Close dropdown on outside click
   useEffect(() => {
     if (!showDropdown) return;

--- a/src/components/SubmitPubForm.tsx
+++ b/src/components/SubmitPubForm.tsx
@@ -103,17 +103,19 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
     return () => document.removeEventListener('keydown', handleKey);
   }, [isOpen, onClose]);
 
-  // When the modal closes by any path (including Escape/backdrop, which bypass
-  // resetForm), revoke and drop any outstanding menu-photo preview blob URLs so
-  // they don't leak. Returns the same array when already empty to avoid an
-  // extra render. setMenuPreviews is a stable setter, so deps stay [isOpen].
+  // When the modal closes by a path that skips resetForm — Escape (which calls
+  // onClose directly) or a parent toggling isOpen — revoke the outstanding menu
+  // preview blob URLs and clear BOTH menu arrays together, so they never desync
+  // (a stale menuImages with no previews would leave the scan step armed but
+  // showing nothing) and no blob handle leaks. The close button and backdrop
+  // already run resetForm. Revoking in the effect body (not inside a state
+  // updater) keeps the updaters pure; length guards avoid extra renders.
   useEffect(() => {
     if (isOpen) return;
-    setMenuPreviews(prev => {
-      prev.forEach(url => URL.revokeObjectURL(url));
-      return prev.length ? [] : prev;
-    });
-  }, [isOpen]);
+    menuPreviews.forEach(url => URL.revokeObjectURL(url));
+    if (menuPreviews.length) setMenuPreviews([]);
+    if (menuImages.length) setMenuImages([]);
+  }, [isOpen, menuPreviews, menuImages]);
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -319,20 +321,17 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
   }
 
   function removeMenuImage(index: number) {
+    const removed = menuPreviews[index];
+    if (removed) URL.revokeObjectURL(removed);
     setMenuImages(prev => prev.filter((_, i) => i !== index));
-    setMenuPreviews(prev => {
-      const removed = prev[index];
-      if (removed) URL.revokeObjectURL(removed);
-      return prev.filter((_, i) => i !== index);
-    });
+    setMenuPreviews(prev => prev.filter((_, i) => i !== index));
   }
 
   // Revoke all preview object URLs before clearing, so we don't leak blob: handles.
+  // Revoke in the handler body (not inside the state updater) to keep updaters pure.
   function clearMenuPreviews() {
-    setMenuPreviews(prev => {
-      prev.forEach(url => URL.revokeObjectURL(url));
-      return [];
-    });
+    menuPreviews.forEach(url => URL.revokeObjectURL(url));
+    setMenuPreviews([]);
   }
 
   async function handleScanMenu() {


### PR DESCRIPTION
Independent of the blog PR (#148). Branched off `main`.

## Context
`next lint` flagged `src/components/SubmitPubForm.tsx` for using a raw `<img>` (`@next/next/no-img-element`). On inspection that's a **false positive**: the element is a preview thumbnail of a menu photo the user just selected, whose `src` is a `URL.createObjectURL()` **blob: URL**.

- `next/image` optimization runs server-side and **cannot** fetch/optimize a client-only `blob:` URL.
- The thumbnail is never the LCP and carries no network/bandwidth cost (it's the user's own local file).

So `<img>` is the correct element. Fix = suppress the rule on that line with a justifying comment, **not** force `next/image` where it doesn't apply.

## Real issue found alongside it
Those object URLs were created but **never `URL.revokeObjectURL()`'d** — a blob-handle leak as previews are removed/reset within a session. Fixed:
- `removeMenuImage` now revokes the removed URL.
- New `clearMenuPreviews()` revokes all URLs before clearing; used by both reset paths (`resetForm` and the "Try Again" button).

## Deliberately not done
- **Unmount cleanup:** closing the form without navigating away won't revoke remaining previews. A full page navigation frees them automatically, so this is a minor residual edge. Can add a `useEffect` unmount revoke if you want it airtight.
- Did **not** swap to `next/image` (see above — would be wrong for blob URLs).

## Checks
- `npx tsc --noEmit` → exit 0
- `npm run lint` → exit 0 (the `no-img-element` warning on this file is gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)