### PR TITLE
SEO: stop linking to redirecting URLs (sitemap + breadcrumbs) + canonical push deep-link

### DIFF
--- a/src/app/api/cron/price-check/route.ts
+++ b/src/app/api/cron/price-check/route.ts
@@ -1,5 +1,6 @@
 import { serviceClient } from '@/lib/supabaseGateway'
 import { NextRequest, NextResponse } from 'next/server'
+import { pubUrl } from '@/lib/urls'
 
 interface PriceChange {
   slug: string
@@ -103,7 +104,7 @@ export async function GET(request: NextRequest) {
             body: JSON.stringify({
               title: `Price Drop at ${drop.name}`,
               body: `$${drop.oldPrice.toFixed(2)} → $${drop.newPrice.toFixed(2)} (-$${drop.diff.toFixed(2)}) in ${drop.suburb}`,
-              url: `/pub/${drop.slug}`,
+              url: pubUrl(drop),
               tag: `price-drop-${drop.slug}`,
               targetSlugs: [drop.slug],
               renotify: true,

--- a/src/app/guides/beer-weather/BeerWeatherPage.tsx
+++ b/src/app/guides/beer-weather/BeerWeatherPage.tsx
@@ -6,7 +6,7 @@ import BeerWeather from '@/components/BeerWeather'
 export default function BeerWeatherPage() {
   return (
     <FeaturePageShell title="Beer Weather Perth" breadcrumbs={[
-      { label: 'Guides', href: '/guides' },
+      { label: 'Discover', href: '/discover' },
       { label: 'Beer Weather' },
     ]}>
       {({ pubs, userLocation }) => (

--- a/src/app/guides/cozy-corners/CozyCornersPage.tsx
+++ b/src/app/guides/cozy-corners/CozyCornersPage.tsx
@@ -6,7 +6,7 @@ import RainyDay from '@/components/RainyDay'
 export default function CozyCornersPage() {
   return (
     <FeaturePageShell title="Cosy Corners Perth" breadcrumbs={[
-      { label: 'Guides', href: '/guides' },
+      { label: 'Discover', href: '/discover' },
       { label: 'Cosy Corners' },
     ]}>
       {({ pubs, userLocation }) => (

--- a/src/app/guides/dad-bar/DadBarPage.tsx
+++ b/src/app/guides/dad-bar/DadBarPage.tsx
@@ -6,7 +6,7 @@ import DadBar from '@/components/DadBar'
 export default function DadBarPage() {
   return (
     <FeaturePageShell title="Classic Perth Pubs for Dads" breadcrumbs={[
-      { label: 'Guides', href: '/guides' },
+      { label: 'Discover', href: '/discover' },
       { label: 'The Dad Bar' },
     ]}>
       {({ pubs, userLocation }) => (

--- a/src/app/guides/punt-and-pints/PuntAndPintsPage.tsx
+++ b/src/app/guides/punt-and-pints/PuntAndPintsPage.tsx
@@ -6,7 +6,7 @@ import PuntNPints from '@/components/PuntNPints'
 export default function PuntAndPintsPage() {
   return (
     <FeaturePageShell title="Perth Pubs with TAB Facilities" breadcrumbs={[
-      { label: 'Guides', href: '/guides' },
+      { label: 'Discover', href: '/discover' },
       { label: 'Punt & Pints' },
     ]}>
       {({ pubs, userLocation }) => (

--- a/src/app/guides/sunset-sippers/SunsetSippersPage.tsx
+++ b/src/app/guides/sunset-sippers/SunsetSippersPage.tsx
@@ -6,7 +6,7 @@ import SunsetSippers from '@/components/SunsetSippers'
 export default function SunsetSippersPage() {
   return (
     <FeaturePageShell title="Sunset Sippers Perth" breadcrumbs={[
-      { label: 'Guides', href: '/guides' },
+      { label: 'Discover', href: '/discover' },
       { label: 'Sunset Sippers' },
     ]}>
       {({ pubs, userLocation }) => (

--- a/src/app/insights/pint-index/PintIndexPage.tsx
+++ b/src/app/insights/pint-index/PintIndexPage.tsx
@@ -24,7 +24,7 @@ export default function PintIndexPage({ stats }: { stats: PintIndexAnswerStats }
   return (
     <main className="min-h-screen overflow-x-hidden bg-[#FDF8F0]">
       <SubPageNav breadcrumbs={[
-        { label: 'Insights', href: '/insights' },
+        { label: 'Discover', href: '/discover' },
         { label: 'Perth Pint Index™' },
       ]} />
       <h1 className="sr-only">Perth Pint Index</h1>

--- a/src/app/insights/pint-of-the-day/PintOfTheDayPage.tsx
+++ b/src/app/insights/pint-of-the-day/PintOfTheDayPage.tsx
@@ -9,7 +9,7 @@ export default function PintOfTheDayPage() {
   return (
     <main className="min-h-screen bg-[#FDF8F0]">
       <SubPageNav breadcrumbs={[
-        { label: 'Insights', href: '/insights' },
+        { label: 'Discover', href: '/discover' },
         { label: 'Pint of the Day' },
       ]} />
       <h1 className="sr-only">Perth Pint of the Day</h1>

--- a/src/app/insights/suburb-rankings/SuburbRankingsPage.tsx
+++ b/src/app/insights/suburb-rankings/SuburbRankingsPage.tsx
@@ -6,7 +6,7 @@ import SuburbLeague from '@/components/SuburbLeague'
 export default function SuburbRankingsPage() {
   return (
     <FeaturePageShell title="Perth Suburb Pint Rankings" breadcrumbs={[
-      { label: 'Insights', href: '/insights' },
+      { label: 'Discover', href: '/discover' },
       { label: 'Suburb Rankings' },
     ]}>
       {({ pubs }) => (

--- a/src/app/insights/tonights-best-bets/TonightsBestBetsPage.tsx
+++ b/src/app/insights/tonights-best-bets/TonightsBestBetsPage.tsx
@@ -6,7 +6,7 @@ import TonightsMoves from '@/components/TonightsMoves'
 export default function TonightsBestBetsPage() {
   return (
     <FeaturePageShell title="Tonight's Best Pints in Perth" breadcrumbs={[
-      { label: 'Insights', href: '/insights' },
+      { label: 'Discover', href: '/discover' },
       { label: "Tonight's Best Bets" },
     ]}>
       {({ pubs, userLocation }) => (

--- a/src/app/insights/venue-breakdown/VenueBreakdownPage.tsx
+++ b/src/app/insights/venue-breakdown/VenueBreakdownPage.tsx
@@ -6,7 +6,7 @@ import VenueIntel from '@/components/VenueIntel'
 export default function VenueBreakdownPage() {
   return (
     <FeaturePageShell title="Perth Pub Prices by Bracket" breadcrumbs={[
-      { label: 'Insights', href: '/insights' },
+      { label: 'Discover', href: '/discover' },
       { label: 'Venue Breakdown' },
     ]}>
       {({ pubs, userLocation }) => (

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -41,8 +41,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const staticRoutes: MetadataRoute.Sitemap = [
     { url: BASE_URL, lastModified: latestPubModified, changeFrequency: 'daily', priority: 1.0 },
     { url: `${BASE_URL}/discover`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.9 },
-    { url: `${BASE_URL}/insights`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.9 },
-    { url: `${BASE_URL}/guides`, lastModified: latestPubModified, changeFrequency: 'weekly', priority: 0.9 },
     { url: `${BASE_URL}/insights/pint-of-the-day`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },
     { url: `${BASE_URL}/insights/pint-index`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },
     { url: `${BASE_URL}/insights/tonights-best-bets`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },


### PR DESCRIPTION
URL-hygiene fixes surfaced by a Google Search Console audit of `sc-domain:perthpintprices.com`, plus a follow-up caught during sub-agent peer review.

## Changes

**1. Sitemap redirect errors** — `/guides` and `/insights` 308-redirect to `/discover`, but were listed in `sitemap.ts` as canonical priority-0.9 URLs. That produced the 2 "Redirect error" entries in GSC. Removed them; `/discover` and the real `/guides/*` + `/insights/*` sub-pages stay. Verified live: of 419 sitemap URLs, those were the only 2 not returning 200.

**2. Push-notification deep-link** — price-drop pushes linked to the deprecated `/pub/{slug}` format (forces a 301 hop when tapped). Switched to `pubUrl()` → canonical `/{suburb}/{slug}`. Service-worker consumer takes a relative path, so click-through is unaffected.

**3. Breadcrumbs → `/discover`** *(found in peer review)* — 10 guide/insight sub-pages had breadcrumb crumbs (`{ label: 'Guides'|'Insights', href: '/guides'|'/insights' }`) pointing at the redirecting hubs, rendered as both visible links and `BreadcrumbList` JSON-LD. Relabelled to `Discover` → `/discover` (the hub those routes redirect to). Same "don't link to a redirect" class as change 1.

## Deliberately NOT changed (already correct)
Canonicalisation (www→apex + legacy 301s), thin-page `noindex` (Tier-C system), and Tier-C sitemap exclusion are already implemented and were left untouched.

## After merge
Production deploy refreshes the sitemap, then hit "Validate Fix" on the GSC Redirect-error report. The 9 "Not found (404)" URLs are genuinely-deleted pubs (SQL-confirmed) — left as 404 by design.

## Review
Peer-reviewed by 3 independent sub-agents (sitemap correctness, push-URL correctness, adversarial regression sweep) → unanimous SHIP. No tests assert on the removed sitemap URLs or push format; no other live `/pub/` consumers in production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)