### PR TITLE
Noindex permanently-closed venues + closed banner

### DIFF
--- a/src/app/[suburb]/[pub]/PubDetailClient.tsx
+++ b/src/app/[suburb]/[pub]/PubDetailClient.tsx
@@ -313,6 +313,19 @@ export default function PubDetailClient({
           )}
         </div>
 
+        {/* Permanently closed notice — Places business_status */}
+        {pub.businessStatus === 'CLOSED_PERMANENTLY' && (
+          <div className="border-3 border-ink rounded-card bg-red-pale p-4 shadow-hard-sm">
+            <p className="font-mono text-[0.72rem] font-extrabold uppercase tracking-[0.05em] text-red">Permanently closed</p>
+            <p className="mt-1 font-body text-[0.85rem] leading-relaxed text-ink">
+              Google lists {pub.name} as permanently closed.{' '}
+              <Link href={suburbUrl(pub.suburb)} className="font-bold text-red no-underline hover:underline">
+                See other {pub.suburb} pubs →
+              </Link>
+            </p>
+          </div>
+        )}
+
         {/* Two-column layout */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
           {/* Left column */}

--- a/src/app/[suburb]/[pub]/page.tsx
+++ b/src/app/[suburb]/[pub]/page.tsx
@@ -60,6 +60,7 @@ function getPubPageIndexability(pub: Pub) {
     cozyPub: pub.cozyPub,
     sunsetSpot: pub.sunsetSpot,
     website: pub.website,
+    businessStatus: pub.businessStatus,
   })
 }
 

--- a/src/lib/pubIndexability.test.ts
+++ b/src/lib/pubIndexability.test.ts
@@ -69,6 +69,19 @@ describe('getPubIndexability', () => {
     assert.equal(stale.dataScore, 2)
   })
 
+  it('noindexes permanently-closed venues but keeps their data tier for rendering', () => {
+    const result = getPubIndexability({
+      price: 11.5,
+      priceVerified: true,
+      lastVerified: '2026-05-31T00:00:00.000Z',
+      now: NOW,
+      businessStatus: 'CLOSED_PERMANENTLY',
+    })
+
+    assert.equal(result.isIndexable, false) // out of index + sitemap
+    assert.equal(result.tier, 'A') // tier preserved so the page doesn't show a "no price" stub
+  })
+
   it('indexes happy-hour pubs without a regular price', () => {
     const result = getPubIndexability({
       price: null,

--- a/src/lib/pubIndexability.ts
+++ b/src/lib/pubIndexability.ts
@@ -18,6 +18,7 @@ export interface PubIndexabilityInput {
   cozyPub?: boolean | null
   sunsetSpot?: boolean | null
   website?: string | null
+  businessStatus?: string | null
   now?: Date
 }
 
@@ -36,6 +37,11 @@ function hasText(value: string | null | undefined): boolean {
 }
 
 export function getPubIndexability(pub: PubIndexabilityInput): PubIndexability {
+  // Permanently-closed venues (Places business_status) are forced out of indexing
+  // and the sitemap below — but keep their data-driven tier so on-page rendering
+  // (e.g. the Tier-C "no price yet" stub) stays correct for closed-but-priced pubs.
+  const closed = pub.businessStatus === 'CLOSED_PERMANENTLY'
+
   const hasPrice = hasPositiveNumber(pub.price)
   const priceRecency = getPriceRecency(pub.lastVerified, pub.now)
   const hasCurrentRecency = priceRecency.tier === 'fresh' || priceRecency.tier === 'aging'
@@ -66,13 +72,12 @@ export function getPubIndexability(pub: PubIndexabilityInput): PubIndexability {
     Math.min(attributeCount, 2),
   ].reduce((sum, score) => sum + score, 0)
 
-  if (hasVerifiedPrice || (hasHappyHour && attributeCount > 0)) {
-    return { dataScore, tier: 'A', isIndexable: true }
-  }
+  const base: PubIndexability =
+    hasVerifiedPrice || (hasHappyHour && attributeCount > 0)
+      ? { dataScore, tier: 'A', isIndexable: true }
+      : hasPrice || hasHappyHour
+        ? { dataScore, tier: 'B', isIndexable: true }
+        : { dataScore, tier: 'C', isIndexable: false }
 
-  if (hasPrice || hasHappyHour) {
-    return { dataScore, tier: 'B', isIndexable: true }
-  }
-
-  return { dataScore, tier: 'C', isIndexable: false }
+  return closed ? { ...base, isIndexable: false } : base
 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -297,7 +297,7 @@ export async function getAllPubLastModifiedPairs(): Promise<PubLastModifiedPair[
 export async function getIndexablePubSlugPairs(): Promise<IndexablePubSlugPair[]> {
   const { data, error } = await supabase
     .from('pubs')
-    .select('slug, suburb, price, price_verified, last_verified, last_updated, updated_at, happy_hour, happy_hour_price, happy_hour_days, happy_hour_start, happy_hour_end, beer_type, vibe_tag, has_tab, kid_friendly, cozy_pub, sunset_spot, website')
+    .select('slug, suburb, price, price_verified, last_verified, last_updated, updated_at, happy_hour, happy_hour_price, happy_hour_days, happy_hour_start, happy_hour_end, beer_type, vibe_tag, has_tab, kid_friendly, cozy_pub, sunset_spot, website, business_status')
     .order('slug')
 
   if (error || !data) return []
@@ -323,6 +323,7 @@ export async function getIndexablePubSlugPairs(): Promise<IndexablePubSlugPair[]
         cozyPub: row.cozy_pub,
         sunsetSpot: row.sunset_spot,
         website: row.website || null,
+        businessStatus: row.business_status || null,
       })
 
       return {


### PR DESCRIPTION
Follow-up to the Places attribute backfill (#151) and the address-audit pass. Uses the new `business_status` column to handle permanently-closed venues.

## What it does
- **`getPubIndexability`** now forces `CLOSED_PERMANENTLY` venues to `isIndexable: false` → robots `noindex` + excluded from the sitemap (`getIndexablePubSlugPairs` already filters on `isIndexable`).
- **Decoupled from tier:** the closed override only flips `isIndexable`; the data-driven A/B/C tier is preserved, so a closed-but-priced pub keeps rendering its real price instead of the Tier-C "no verified price yet" stub.
- **Closed banner** on the pub page: "Google lists {pub} as permanently closed" + a link to the suburb for alternatives.
- Wired `business_status` through `page.tsx` (per-page robots) and `getIndexablePubSlugPairs` (sitemap).

Catches the ~8 currently-closed venues (Folly Rooftop, Parley Bar, Hangout on Preston, Bar Therapy, Tiger Lil's, etc.) and **auto-handles future closures** on each monthly Places sweep.

## Also done outside this PR (data-only, already live)
- Fixed the Running With Thieves address + **22 other genuine address errors** surfaced by the audit (auto-corrected to the matched place_id's Google address; unit/formatting noise skipped; 3 ambiguous wrong-match candidates held for manual review).

## Verified
- `npx tsc --noEmit` clean
- `npm test` — **267/267** (new case: closed → not indexable, tier preserved)
- `npm run lint` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)