### PR TITLE
Semantic typography system + site-wide codemod

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -47,12 +47,12 @@ function LiveHappyHourBanner({ pubs }: { pubs: Pub[] }) {
       <div className="bg-ink border-3 border-ink rounded-pill px-6 py-3 flex items-center gap-3 shadow-hard">
         <div className="flex items-center gap-1.5 flex-shrink-0">
           <span className="w-2 h-2 rounded-full bg-green shadow-[0_0_8px_rgba(45,122,61,0.5)] animate-pulse" />
-          <span className="font-mono font-bold text-[0.72rem] uppercase tracking-[0.05em] text-white">Live</span>
+          <span className="type-eyebrow text-white">Live</span>
         </div>
         <span className="text-white font-medium text-[0.85rem] flex-1 truncate transition-opacity duration-300" key={current.slug}>
           <strong className="text-amber-light font-bold">{current.name}</strong> has ${current.price?.toFixed(2)} pints right now
         </span>
-        <span className="font-mono font-extrabold text-[1.1rem] text-amber-light flex-shrink-0">
+        <span className="type-price text-[1.1rem] text-amber-light flex-shrink-0">
           ${current.price?.toFixed(2)}
         </span>
         {liveHHPubs.length > 1 && (
@@ -77,7 +77,7 @@ function LoadingSkeleton() {
             <div className="absolute -right-[14px] top-[12px] w-[12px] h-[28px] border-3 border-ink border-l-0 rounded-[0_8px_8px_0] bg-white" />
           </div>
         </div>
-        <span className="font-mono text-[0.75rem] font-bold uppercase tracking-[0.1em] text-gray-mid">Loading pubs...</span>
+        <span className="type-eyebrow">Loading pubs...</span>
       </div>
     </main>
   )

--- a/src/app/[suburb]/SuburbClient.tsx
+++ b/src/app/[suburb]/SuburbClient.tsx
@@ -66,7 +66,7 @@ export default function SuburbClient({ suburb, pubs, nearbySuburbs, perthAvgPric
 
       {/* Hero Stats */}
       <section className="max-w-container mx-auto px-6 pt-6 pb-6">
-        <h1 className="font-mono font-extrabold text-[clamp(1.8rem,5vw,2.4rem)] tracking-[-0.03em] text-ink leading-[1.1] mb-2">
+        <h1 className="type-hero mb-2">
           Pints in {suburb.name}
         </h1>
         <p className="text-gray-mid text-[0.85rem] mb-6">
@@ -82,8 +82,8 @@ export default function SuburbClient({ suburb, pubs, nearbySuburbs, perthAvgPric
             { label: 'Happy Hours', value: String(suburb.happyHourCount), accent: false, extra: `of ${suburb.pubCount} venues` },
           ].map((stat) => (
             <div key={stat.label} className={`border-3 border-ink rounded-card px-4 py-4 shadow-hard-sm ${stat.accent ? 'bg-amber' : 'bg-white'}`}>
-              <p className={`font-mono text-[0.6rem] font-bold uppercase tracking-[0.08em] ${stat.accent ? 'text-white/75' : 'text-gray-mid'} mb-1`}>{stat.label}</p>
-              <p className={`font-mono text-[1.5rem] font-extrabold leading-none ${stat.accent ? 'text-white' : 'text-ink'}`}>
+              <p className={`type-eyebrow ${stat.accent ? 'text-white/75' : 'text-gray-mid'} mb-1`}>{stat.label}</p>
+              <p className={`type-price text-[1.5rem] ${stat.accent ? 'text-white' : 'text-ink'}`}>
                 {stat.value}
               </p>
               {stat.link && stat.linkLabel && (
@@ -134,7 +134,7 @@ export default function SuburbClient({ suburb, pubs, nearbySuburbs, perthAvgPric
         <div className="grid gap-3 sm:grid-cols-2">
           {story.cards.map(card => (
             <article key={card.id} className="min-w-0 border-3 border-ink rounded-card bg-white p-4 shadow-hard-sm">
-              <p className="font-mono text-[0.6rem] font-bold uppercase tracking-[0.08em] text-gray-mid mb-1">{card.label}</p>
+              <p className="type-eyebrow mb-1">{card.label}</p>
               <h2 className="font-mono text-[1.05rem] font-extrabold leading-tight text-ink mb-2">{card.title}</h2>
               <p className="text-[0.78rem] leading-relaxed text-gray-mid">{card.body}</p>
               {card.href && card.linkLabel && (
@@ -156,7 +156,7 @@ export default function SuburbClient({ suburb, pubs, nearbySuburbs, perthAvgPric
             <div className="border-3 border-red/30 rounded-card bg-red/5 overflow-hidden">
               <div className="px-4 py-3 flex items-center gap-2">
                 <span className="w-2 h-2 rounded-full bg-red animate-pulse" />
-                <h2 className="font-mono font-extrabold text-[0.85rem] text-red uppercase tracking-[0.05em]">
+                <h2 className="type-card-header text-red">
                   Happy Hour Live Now
                 </h2>
                 <span className="text-[0.7rem] text-gray-mid ml-auto">{activeHH.length} {activeHH.length === 1 ? 'venue' : 'venues'}</span>
@@ -192,7 +192,7 @@ export default function SuburbClient({ suburb, pubs, nearbySuburbs, perthAvgPric
       <section className="max-w-container mx-auto px-6 pb-6">
         <div className="border-3 border-ink rounded-card shadow-hard-sm overflow-hidden">
           <div className="px-4 py-3 border-b border-gray-light">
-            <h2 className="font-mono font-extrabold text-[0.85rem] text-ink uppercase tracking-[0.05em]">All Venues - Cheapest First</h2>
+            <h2 className="type-card-header">All Venues - Cheapest First</h2>
           </div>
 
           {/* Desktop table */}
@@ -330,7 +330,7 @@ export default function SuburbClient({ suburb, pubs, nearbySuburbs, perthAvgPric
         <section className="max-w-container mx-auto px-6 pb-6">
           <div className="border-3 border-ink rounded-card bg-off-white shadow-hard-sm overflow-hidden">
             <div className="px-4 py-3 border-b border-gray-light">
-              <h2 className="font-mono font-extrabold text-[0.85rem] text-ink uppercase tracking-[0.05em]">{suburb.name} pint FAQ</h2>
+              <h2 className="type-card-header">{suburb.name} pint FAQ</h2>
             </div>
             <dl className="divide-y divide-gray-light">
               {story.faqs.map(item => (
@@ -347,7 +347,7 @@ export default function SuburbClient({ suburb, pubs, nearbySuburbs, perthAvgPric
       {/* Footer CTA */}
       <section className="max-w-container mx-auto px-6 pb-8">
         <div className="bg-ink border-3 border-ink rounded-card p-6 text-center shadow-hard-sm">
-          <h2 className="font-mono font-extrabold text-xl text-white mb-2">Know a price in {suburb.name}?</h2>
+          <h2 className="type-section text-white mb-2">Know a price in {suburb.name}?</h2>
           <p className="text-white/60 text-sm mb-4">Help us keep {suburb.name} pint prices accurate.</p>
           <Link
             href="/?submit=1"

--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -160,8 +160,8 @@ function Under10Module({ pubs, articleSlug }: { pubs: Pub[]; articleSlug: string
     <section className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
       <div className="mb-4 flex items-center justify-between gap-4">
         <div>
-          <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Live rows</p>
-          <h2 className="font-mono text-xl font-extrabold text-ink">Verified under $10</h2>
+          <p className="type-eyebrow">Live rows</p>
+          <h2 className="type-section">Verified under $10</h2>
         </div>
         <Beer className="h-5 w-5 text-amber" />
       </div>
@@ -208,8 +208,8 @@ function HappyHoursByDayModule({ pubs, articleSlug }: { pubs: Pub[]; articleSlug
     <section className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
       <div className="mb-4 flex items-center justify-between gap-4">
         <div>
-          <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Planning board</p>
-          <h2 className="font-mono text-xl font-extrabold text-ink">Happy hours by day</h2>
+          <p className="type-eyebrow">Planning board</p>
+          <h2 className="type-section">Happy hours by day</h2>
         </div>
         <Clock className="h-5 w-5 text-amber" />
       </div>
@@ -253,8 +253,8 @@ function GlassSizesModule() {
     <section className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
       <div className="mb-4 flex items-center justify-between gap-4">
         <div>
-          <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Reference</p>
-          <h2 className="font-mono text-xl font-extrabold text-ink">Glass sizes we care about</h2>
+          <p className="type-eyebrow">Reference</p>
+          <h2 className="type-section">Glass sizes we care about</h2>
         </div>
         <GlassWater className="h-5 w-5 text-amber" />
       </div>
@@ -326,7 +326,7 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
               {article.readingMinutes} min
             </span>
           </div>
-          <h1 className="font-display text-[3rem] leading-[1] text-ink sm:text-[5rem]">
+          <h1 className="type-hero-editorial">
             {article.title}
           </h1>
           <p className="mt-5 max-w-[660px] font-body text-[1rem] leading-relaxed text-gray-mid">
@@ -337,13 +337,13 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
         <div className="mb-8 overflow-hidden rounded-card border-3 border-ink bg-white shadow-hard-sm">
           <div className="grid sm:grid-cols-[1fr_210px]">
             <div className="bg-ink p-5 text-white sm:p-6">
-              <p className="font-mono text-[0.68rem] font-bold uppercase text-white/60">Article brief</p>
+              <p className="type-eyebrow text-white/60">Article brief</p>
               <p className="mt-3 max-w-[470px] font-body text-[0.92rem] leading-relaxed text-white/75">
                 Read the note, then use the live rows below to turn it into a useful pub decision.
               </p>
             </div>
             <div className="border-t-3 border-ink bg-amber p-5 sm:border-l-3 sm:border-t-0">
-              <p className="font-mono text-[0.62rem] font-bold uppercase text-ink/70">{article.heroLabel}</p>
+              <p className="type-eyebrow text-ink/70">{article.heroLabel}</p>
               <p className="mt-2 font-mono text-[2rem] font-extrabold leading-none text-ink">{article.heroStat}</p>
               <p className="mt-2 font-body text-[0.78rem] font-bold text-ink/70">{article.heroSubstat}</p>
             </div>
@@ -365,7 +365,7 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
             const inlineImage = sectionImages.get(section.heading)
             return (
               <section key={section.heading}>
-                <h2 className="font-mono text-xl font-extrabold text-ink">{section.heading}</h2>
+                <h2 className="type-section">{section.heading}</h2>
                 <div className="mt-3 space-y-3">
                   {section.body.map(paragraph => (
                     <p key={paragraph} className="font-body text-[0.92rem] leading-relaxed text-gray-mid">

--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -38,10 +38,10 @@ export default function ArticlesPage() {
 
       <section className="max-w-container mx-auto px-6 pt-8 pb-12">
         <div className="mb-10">
-          <p className="font-mono text-[0.68rem] font-bold uppercase text-gray-mid mb-3">
+          <p className="type-eyebrow mb-3">
             Pub notes
           </p>
-          <h1 className="max-w-[700px] font-display text-[3rem] leading-[1] text-ink sm:text-[4.8rem]">
+          <h1 className="max-w-[700px] type-hero-editorial">
             Perth drinking, with the prices left in.
           </h1>
           <p className="font-body text-[0.95rem] leading-relaxed text-gray-mid mt-5 max-w-[590px]">
@@ -73,7 +73,7 @@ export default function ArticlesPage() {
                       {formatArticleDate(featured.publishedAt)}
                     </span>
                   </div>
-                  <p className="mb-3 font-mono text-[0.68rem] font-bold uppercase text-white/60">{featured.category}</p>
+                  <p className="mb-3 type-eyebrow text-white/60">{featured.category}</p>
                   <h2 className="font-display text-[2.4rem] leading-[1] text-white sm:text-[3.6rem]">
                     {featured.title}
                   </h2>
@@ -89,7 +89,7 @@ export default function ArticlesPage() {
                   />
                   <div className="flex flex-1 flex-col justify-between p-6">
                     <div>
-                      <p className="font-mono text-[0.68rem] font-bold uppercase text-ink/70">{featured.heroLabel}</p>
+                      <p className="type-eyebrow text-ink/70">{featured.heroLabel}</p>
                       <p className="mt-3 font-mono text-[2.45rem] font-extrabold leading-none text-ink">{featured.heroStat}</p>
                       <p className="mt-2 font-body text-[0.82rem] font-bold leading-snug text-ink/70">{featured.heroSubstat}</p>
                     </div>
@@ -105,7 +105,7 @@ export default function ArticlesPage() {
 
         <section>
           <div className="mb-5 flex items-center justify-between gap-4 border-b-3 border-ink pb-3">
-            <h2 className="font-mono text-xl font-extrabold text-ink">Latest notes</h2>
+            <h2 className="type-section">Latest notes</h2>
             <BookOpen className="h-5 w-5 text-gray-mid" />
           </div>
           <div className="grid gap-5 sm:grid-cols-2">
@@ -125,7 +125,7 @@ export default function ArticlesPage() {
                 <ArticleImageSlot article={article} size="card" className="aspect-[16/9] border-b-3 border-ink" />
                 <div className="flex flex-1 flex-col p-5">
                   <div className="flex items-start justify-end gap-4">
-                    <span className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">
+                    <span className="type-eyebrow">
                       {formatArticleDate(article.publishedAt)} - {article.readingMinutes} min
                     </span>
                   </div>

--- a/src/app/cheapest-pints/page.tsx
+++ b/src/app/cheapest-pints/page.tsx
@@ -84,8 +84,8 @@ export default async function CheapestPintsPage() {
       <section className="max-w-container mx-auto px-6 pt-8 pb-12">
         <div className="grid gap-6 sm:grid-cols-[1fr_260px] sm:items-end">
           <div>
-            <p className="mb-3 font-mono text-[0.68rem] font-bold uppercase text-gray-mid">Live ranked list</p>
-            <h1 className="font-display text-[3rem] leading-[1] text-ink sm:text-[4.8rem]">
+            <p className="mb-3 type-eyebrow">Live ranked list</p>
+            <h1 className="type-hero-editorial">
               Cheapest pints in Perth
             </h1>
             <p className="mt-5 max-w-[620px] font-body text-[0.96rem] leading-relaxed text-gray-mid">
@@ -106,25 +106,25 @@ export default async function CheapestPintsPage() {
 
         <section className="my-8 grid gap-3 sm:grid-cols-3">
           <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
-            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Cheapest checked</p>
+            <p className="type-eyebrow">Cheapest checked</p>
             <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{formatPrice(cheapest?.regularPrice)}</p>
             <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">{cheapest ? `${cheapest.name}, ${cheapest.suburb}` : 'No verified rows yet.'}</p>
           </div>
           <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
-            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Under $10</p>
+            <p className="type-eyebrow">Under $10</p>
             <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{under10.length}</p>
             <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Verified regular pint rows below the ten-dollar line.</p>
           </div>
           <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
-            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">City average</p>
+            <p className="type-eyebrow">City average</p>
             <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{formatPrice(average)}</p>
             <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">{verified.length} verified pubs across the live dataset.</p>
           </div>
         </section>
 
         <section className="mb-8 rounded-card border-3 border-ink bg-ink p-5 text-white shadow-hard-sm">
-          <p className="font-mono text-[0.65rem] font-bold uppercase text-white/55">Answer first</p>
-          <h2 className="mt-2 font-mono text-xl font-extrabold">Where is the cheapest pint in Perth?</h2>
+          <p className="type-eyebrow text-white/55">Answer first</p>
+          <h2 className="mt-2 type-section text-white">Where is the cheapest pint in Perth?</h2>
           <p className="mt-3 font-body text-[0.9rem] leading-relaxed text-white/70">
             {cheapest ? <>The cheapest verified pint in Perth is {formatPrice(cheapest.regularPrice)} at <Link href={pubUrl(cheapest)} className="font-bold text-amber-light hover:underline">{cheapest.name}</Link> in {cheapest.suburb}, checked {formatDate(cheapest.lastVerified ?? cheapest.priceVerifiedAt)}. The top 24 checked rows currently cover {suburbCount} suburbs, which is why the useful answer is a ranked list rather than one suburb headline.</> : 'We do not have a verified regular pint row to publish yet.'}
           </p>
@@ -133,8 +133,8 @@ export default async function CheapestPintsPage() {
         <section className="rounded-card border-3 border-ink bg-white shadow-hard-sm">
           <div className="flex items-center justify-between gap-4 border-b-3 border-ink bg-off-white px-5 py-4">
             <div>
-              <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Verified regular prices</p>
-              <h2 className="font-mono text-xl font-extrabold text-ink">Cheapest rows</h2>
+              <p className="type-eyebrow">Verified regular prices</p>
+              <h2 className="type-section">Cheapest rows</h2>
             </div>
             <ListChecks className="h-5 w-5 text-amber" />
           </div>
@@ -182,11 +182,11 @@ export default async function CheapestPintsPage() {
             </div>
             <div className="space-y-4">
               <div>
-                <h3 className="font-mono text-[0.82rem] font-extrabold text-ink">Do happy-hour prices count here?</h3>
+                <h3 className="type-card">Do happy-hour prices count here?</h3>
                 <p className="mt-1 text-[0.78rem] leading-relaxed text-gray-mid">No. This page ranks regular pint prices only. Happy hours get their own day pages because a one-hour pint is not the same promise as the normal price.</p>
               </div>
               <div>
-                <h3 className="font-mono text-[0.82rem] font-extrabold text-ink">Why is a pub missing?</h3>
+                <h3 className="type-card">Why is a pub missing?</h3>
                 <p className="mt-1 text-[0.78rem] leading-relaxed text-gray-mid">Usually because the regular pint price is still TBC or stale. We would rather show an honest gap than a tidy guess.</p>
               </div>
             </div>

--- a/src/app/discover/DiscoverClient.tsx
+++ b/src/app/discover/DiscoverClient.tsx
@@ -163,7 +163,7 @@ export default function DiscoverClient() {
         {pintOfTheDay && (
           <section className="mb-10 sm:mb-14">
             <div className="border-3 border-ink rounded-card shadow-hard-sm bg-white py-10 px-6 text-center">
-              <p className="font-mono text-[0.68rem] font-bold uppercase tracking-[0.1em] text-gray-mid mb-2">
+              <p className="type-eyebrow mb-2">
                 <Star className="w-3.5 h-3.5 inline -mt-0.5 mr-1" />Pint of the Day
               </p>
               <div className="flex items-center justify-center gap-2 mb-3 flex-wrap">
@@ -173,7 +173,7 @@ export default function DiscoverClient() {
                 </Link>
                 <span className="text-gray-mid text-sm">{pintOfTheDay.pub.suburb}</span>
               </div>
-              <div className="font-mono text-[2.5rem] font-extrabold text-ink leading-none">
+              <div className="type-price text-[2.5rem]">
                 ${pintOfTheDay.pub.effectivePrice.toFixed(2)}
               </div>
               <p className="text-[0.75rem] text-gray-mid mt-1">{pintOfTheDay.reason}</p>
@@ -254,7 +254,7 @@ export default function DiscoverClient() {
             3. PUB PICKS CAROUSEL
             ════════════════════════════════════════════ */}
         <section className="mb-10 sm:mb-14">
-          <h2 className="font-mono font-extrabold text-xl tracking-[-0.02em] text-ink">Pub Picks</h2>
+          <h2 className="type-section">Pub Picks</h2>
           <p className="text-sm text-gray-mid mt-1 mb-6">Pub lists for every mood</p>
 
           <div className="relative">
@@ -294,7 +294,7 @@ export default function DiscoverClient() {
             ════════════════════════════════════════════ */}
         <section className="mb-10 sm:mb-14">
           <div className="bg-ink border-3 border-ink rounded-card p-6 text-center shadow-hard-sm">
-            <h2 className="font-mono font-extrabold text-xl text-white mb-2">Know a price we&apos;re missing?</h2>
+            <h2 className="type-section text-white mb-2">Know a price we&apos;re missing?</h2>
             <p className="text-white/60 text-sm mb-4">Help Perth drink cheaper.</p>
             <Link
               href="/?submit=1"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,13 +41,14 @@
     background-color: #FDF8F0;
     -webkit-overflow-scrolling: touch;
   }
-  h1 {
+  /* Bare headings default to mono (the dominant brand heading face) as a safety
+     net only. Real styling comes from the .type-* roles below; deliberate serif
+     is opt-in via `font-display` / `.type-hero-editorial`. The old `h2,h3 -> DM
+     Serif + bold` rule was the source of accidental-serif + faux-bold headings
+     (DM Serif Display ships weight 400 only). */
+  h1, h2, h3, h4 {
     font-family: var(--font-jetbrains-mono), 'Courier New', monospace;
     @apply font-extrabold;
-  }
-  h2, h3 {
-    font-family: var(--font-dm-serif), Georgia, serif;
-    @apply font-bold;
   }
 }
 
@@ -57,6 +58,59 @@
   }
   .section-gap-sm {
     @apply py-4 sm:py-6;
+  }
+
+  /* ─── Typography system — one definition per semantic role ───────────────
+     Pins family + size + weight + tracking so components stop re-improvising
+     with arbitrary values. DM Serif Display is 400-only: never bold it. */
+
+  /* Hero on data/app pages (pub, suburb, discover) — the price-board voice */
+  .type-hero {
+    @apply font-mono font-extrabold text-ink;
+    font-size: clamp(1.9rem, 5.5vw, 2.6rem);
+    letter-spacing: -0.03em;
+    line-height: 1.05;
+  }
+  /* Hero on editorial/landing pages — DM Serif at its native 400, one size */
+  .type-hero-editorial {
+    @apply font-display font-normal text-ink;
+    font-size: clamp(2.6rem, 6vw, 4.5rem);
+    letter-spacing: -0.01em;
+    line-height: 1.04;
+  }
+  /* Section heading — "Pub Picks", "Best Sunset Spots" */
+  .type-section {
+    @apply font-mono font-extrabold text-ink text-xl;
+    letter-spacing: -0.02em;
+    line-height: 1.15;
+  }
+  /* Card title */
+  .type-card {
+    @apply font-mono font-extrabold text-ink;
+    font-size: 0.85rem;
+    letter-spacing: -0.01em;
+    line-height: 1.25;
+  }
+  /* Uppercase panel/card-section header — "CHEAPER NEARBY", "ALL VENUES",
+     "{SUBURB} PINT FAQ". Bigger + heavier than an eyebrow label. */
+  .type-card-header {
+    @apply font-mono font-extrabold uppercase text-ink;
+    font-size: 0.85rem;
+    letter-spacing: 0.05em;
+    line-height: 1.2;
+  }
+  /* Eyebrow / uppercase label */
+  .type-eyebrow {
+    @apply font-mono font-bold uppercase text-gray-mid;
+    font-size: 0.68rem;
+    letter-spacing: 0.1em;
+    line-height: 1.2;
+  }
+  /* Big price number (size is contextual — set per use) */
+  .type-price {
+    @apply font-mono font-extrabold text-ink;
+    letter-spacing: -0.03em;
+    line-height: 1;
   }
 }
 

--- a/src/app/happy-hour/HappyHourClient.tsx
+++ b/src/app/happy-hour/HappyHourClient.tsx
@@ -186,7 +186,7 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
       <div className="max-w-container mx-auto px-6 py-8">
         {/* Page heading */}
         <div className="mb-6">
-          <h1 className="font-mono font-extrabold text-[clamp(1.8rem,5vw,2.4rem)] tracking-normal text-ink leading-[1.1]">
+          <h1 className="type-hero">
             Perth happy hours, on now
           </h1>
 
@@ -219,10 +219,10 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
             <div className="border-b border-gray-light bg-off-white px-5 py-4">
               <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
                 <div>
-                  <p className="font-mono text-[0.65rem] font-bold uppercase tracking-[0.05em] text-gray-mid">
+                  <p className="type-eyebrow">
                     {formatPerthTime(clockInstant)} AWST
                   </p>
-                  <h2 className="font-mono text-[1.15rem] font-extrabold leading-tight text-ink">
+                  <h2 className="type-section leading-tight">
                     Tonight&apos;s happy-hour board
                   </h2>
                 </div>
@@ -234,7 +234,7 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
 
             <div className="grid gap-0 sm:grid-cols-3">
               <div className="border-b border-gray-light p-5 sm:border-b-0 sm:border-r">
-                <p className="font-mono text-[0.68rem] font-bold uppercase tracking-[0.05em] text-gray-mid">
+                <p className="type-eyebrow">
                   Live
                 </p>
                 <p className="mt-2 font-mono text-3xl font-extrabold text-ink">
@@ -252,12 +252,12 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
               </div>
 
               <div className="border-b border-gray-light p-5 sm:border-b-0 sm:border-r">
-                <p className="font-mono text-[0.68rem] font-bold uppercase tracking-[0.05em] text-gray-mid">
+                <p className="type-eyebrow">
                   Next
                 </p>
                 {planner.nextDeal ? (
                   <>
-                    <p className="mt-2 font-mono text-[1.45rem] font-extrabold leading-tight text-ink">
+                    <p className="mt-2 type-price text-[1.45rem] leading-tight">
                       {planner.nextDeal.status.countdown ?? 'Later today'}
                     </p>
                     <p className="mt-2 text-[0.78rem] leading-relaxed text-gray-mid">
@@ -266,7 +266,7 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
                   </>
                 ) : planner.laterDeal ? (
                   <>
-                    <p className="mt-2 font-mono text-[1.45rem] font-extrabold leading-tight text-ink">
+                    <p className="mt-2 type-price text-[1.45rem] leading-tight">
                       Later in the week
                     </p>
                     <p className="mt-2 text-[0.78rem] leading-relaxed text-gray-mid">
@@ -281,10 +281,10 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
               </div>
 
               <div className="p-5">
-                <p className="font-mono text-[0.68rem] font-bold uppercase tracking-[0.05em] text-gray-mid">
+                <p className="type-eyebrow">
                   Freshness
                 </p>
-                <p className="mt-2 font-mono text-[1.45rem] font-extrabold leading-tight text-ink">
+                <p className="mt-2 type-price text-[1.45rem] leading-tight">
                   {planner.freshCount}/{happyHourPubs.length}
                 </p>
                 <p className="mt-2 text-[0.78rem] leading-relaxed text-gray-mid">
@@ -298,8 +298,8 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
         <section className="mb-6 rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
           <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
             <div>
-              <p className="font-mono text-[0.65rem] font-bold uppercase tracking-[0.05em] text-gray-mid">Planning board</p>
-              <h2 className="font-mono text-[1.15rem] font-extrabold leading-tight text-ink">Happy hours by day</h2>
+              <p className="type-eyebrow">Planning board</p>
+              <h2 className="type-section leading-tight">Happy hours by day</h2>
             </div>
             <Link href="/articles/perth-happy-hours-by-day" className="font-mono text-[0.72rem] font-bold uppercase text-amber no-underline hover:underline">
               Read the guide →

--- a/src/app/happy-hour/[day]/page.tsx
+++ b/src/app/happy-hour/[day]/page.tsx
@@ -120,8 +120,8 @@ export default async function HappyHourDayPage({ params }: DayPageProps) {
       <section className="max-w-container mx-auto px-6 pt-8 pb-12">
         <div className="grid gap-6 sm:grid-cols-[1fr_260px] sm:items-end">
           <div>
-            <p className="mb-3 font-mono text-[0.68rem] font-bold uppercase text-gray-mid">Day guide</p>
-            <h1 className="font-display text-[3rem] leading-[1] text-ink sm:text-[4.8rem]">
+            <p className="mb-3 type-eyebrow">Day guide</p>
+            <h1 className="type-hero-editorial">
               {day.label} happy hours in Perth
             </h1>
             <p className="mt-5 max-w-[620px] font-body text-[0.96rem] leading-relaxed text-gray-mid">
@@ -141,8 +141,8 @@ export default async function HappyHourDayPage({ params }: DayPageProps) {
         </div>
 
         <section className="my-8 rounded-card border-3 border-ink bg-ink p-5 text-white shadow-hard-sm">
-          <p className="font-mono text-[0.65rem] font-bold uppercase text-white/55">Answer first</p>
-          <h2 className="mt-2 font-mono text-xl font-extrabold">What is the best {day.label} happy hour in Perth?</h2>
+          <p className="type-eyebrow text-white/55">Answer first</p>
+          <h2 className="mt-2 type-section text-white">What is the best {day.label} happy hour in Perth?</h2>
           <p className="mt-3 font-body text-[0.9rem] leading-relaxed text-white/70">
             {cheapest ? <>The cheapest checked {day.label} happy-hour discount is {formatPrice(cheapest.happyHourPrice)} at <Link href={pubUrl(cheapest)} className="font-bold text-amber-light hover:underline">{cheapest.name}</Link> in {cheapest.suburb}. The listed window is {formatWindow(cheapest)}, and the row was last checked {formatDate(cheapest.lastVerified ?? cheapest.priceVerifiedAt)}. Treat that as the starting point, not a promise carved into the bar top.</> : <>Use the live happy-hour board for now; this day needs more confirmed discount prices before it deserves a winner.</>}
           </p>
@@ -150,17 +150,17 @@ export default async function HappyHourDayPage({ params }: DayPageProps) {
 
         <section className="mb-8 grid gap-3 sm:grid-cols-3">
           <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
-            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Rows for {day.label}</p>
+            <p className="type-eyebrow">Rows for {day.label}</p>
             <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{dayPubs.length}</p>
             <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Pubs with {day.label} in the happy-hour schedule.</p>
           </div>
           <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
-            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Priced discounts</p>
+            <p className="type-eyebrow">Priced discounts</p>
             <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{confirmedDiscounts}</p>
             <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Rows with a specific happy-hour price attached.</p>
           </div>
           <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
-            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Cheapest listed</p>
+            <p className="type-eyebrow">Cheapest listed</p>
             <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{formatPrice(cheapest?.happyHourPrice)}</p>
             <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">{cheapest ? `${cheapest.name}, ${cheapest.suburb}` : 'Needs a checked row.'}</p>
           </div>
@@ -169,8 +169,8 @@ export default async function HappyHourDayPage({ params }: DayPageProps) {
         <section className="rounded-card border-3 border-ink bg-white shadow-hard-sm">
           <div className="flex items-center justify-between gap-4 border-b-3 border-ink bg-off-white px-5 py-4">
             <div>
-              <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Sorted by price</p>
-              <h2 className="font-mono text-xl font-extrabold text-ink">{day.label} rows</h2>
+              <p className="type-eyebrow">Sorted by price</p>
+              <h2 className="type-section">{day.label} rows</h2>
             </div>
             <Clock className="h-5 w-5 text-amber" />
           </div>
@@ -214,11 +214,11 @@ export default async function HappyHourDayPage({ params }: DayPageProps) {
             <h2 className="font-mono text-lg font-extrabold text-ink">Quick Q&A</h2>
             <div className="mt-4 space-y-4">
               <div>
-                <h3 className="font-mono text-[0.82rem] font-extrabold text-ink">Are these live right now?</h3>
+                <h3 className="type-card">Are these live right now?</h3>
                 <p className="mt-1 text-[0.78rem] leading-relaxed text-gray-mid">Not necessarily. This page is the {day.label} planning board. For the current minute, use the live happy-hour page.</p>
               </div>
               <div>
-                <h3 className="font-mono text-[0.82rem] font-extrabold text-ink">Why are some windows vague?</h3>
+                <h3 className="type-card">Why are some windows vague?</h3>
                 <p className="mt-1 text-[0.78rem] leading-relaxed text-gray-mid">Some pubs publish the day but not a neat start and end time. We show the clean window where we have it and leave the fuzzy ones fuzzy.</p>
               </div>
             </div>

--- a/src/app/how-much-is-a-pint-in-perth/page.tsx
+++ b/src/app/how-much-is-a-pint-in-perth/page.tsx
@@ -73,8 +73,8 @@ export default async function HowMuchIsAPintInPerthPage() {
       <section className="max-w-container mx-auto px-6 pt-8 pb-12">
         <div className="grid gap-6 sm:grid-cols-[1fr_250px] sm:items-end">
           <div>
-            <p className="mb-3 font-mono text-[0.68rem] font-bold uppercase text-gray-mid">Answer first</p>
-            <h1 className="font-display text-[3rem] leading-[1] text-ink sm:text-[4.55rem]">
+            <p className="mb-3 type-eyebrow">Answer first</p>
+            <h1 className="type-hero-editorial">
               How much is a pint in Perth?
             </h1>
             <p className="mt-5 max-w-[640px] font-body text-[0.98rem] leading-relaxed text-gray-mid">
@@ -95,17 +95,17 @@ export default async function HowMuchIsAPintInPerthPage() {
 
         <section className="my-8 grid gap-3 sm:grid-cols-3">
           <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
-            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Average pint</p>
+            <p className="type-eyebrow">Average pint</p>
             <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{formatAudPrice(stats.averagePrice)}</p>
             <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Verified regular pint prices only.</p>
           </div>
           <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
-            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Median pint</p>
+            <p className="type-eyebrow">Median pint</p>
             <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{formatAudPrice(stats.medianPrice)}</p>
             <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">The middle of the checked-price pack.</p>
           </div>
           <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
-            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Checked range</p>
+            <p className="type-eyebrow">Checked range</p>
             <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{formatAudPrice(stats.minPrice)}-{formatAudPrice(stats.maxPrice)}</p>
             <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">{stats.trackedCount} pubs tracked across {stats.suburbCount} suburbs.</p>
           </div>
@@ -115,8 +115,8 @@ export default async function HowMuchIsAPintInPerthPage() {
           <div className="flex items-start gap-3">
             <CircleDollarSign className="mt-1 h-5 w-5 shrink-0 text-amber-light" />
             <div>
-              <p className="font-mono text-[0.65rem] font-bold uppercase text-white/55">Short version</p>
-              <h2 className="mt-2 font-mono text-xl font-extrabold">What should you budget for one pint?</h2>
+              <p className="type-eyebrow text-white/55">Short version</p>
+              <h2 className="mt-2 type-section text-white">What should you budget for one pint?</h2>
               <p className="mt-3 font-body text-[0.9rem] leading-relaxed text-white/70">
                 Budget roughly {formatAudPrice(stats.averagePrice)} for a standard Perth pint if you are walking into a random checked pub. If you care where the cheap end still lives, start with the live <Link href="/cheapest-pints" className="font-bold text-amber-light hover:underline">cheapest-pints list</Link>; {stats.underTenCount} verified rows currently sit under $10.
               </p>
@@ -127,8 +127,8 @@ export default async function HowMuchIsAPintInPerthPage() {
         <section className="grid gap-5 sm:grid-cols-[1fr_0.85fr]">
           <div className="rounded-card border-3 border-ink bg-white shadow-hard-sm">
             <div className="border-b-3 border-ink bg-off-white px-5 py-4">
-              <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Live rows</p>
-              <h2 className="mt-1 font-mono text-xl font-extrabold text-ink">Cheapest checked pints right now</h2>
+              <p className="type-eyebrow">Live rows</p>
+              <h2 className="mt-1 type-section">Cheapest checked pints right now</h2>
             </div>
             <div className="divide-y divide-gray-light">
               {cheapestRows.map((pub, index) => (
@@ -165,11 +165,11 @@ export default async function HowMuchIsAPintInPerthPage() {
               </div>
               <div className="space-y-4">
                 <div>
-                  <h3 className="font-mono text-[0.82rem] font-extrabold text-ink">Is a happy-hour pint included?</h3>
+                  <h3 className="type-card">Is a happy-hour pint included?</h3>
                   <p className="mt-1 text-[0.78rem] leading-relaxed text-gray-mid">No. The headline number uses regular pint prices only. Happy-hour deals move around by day and hour, so they live on the happy-hour pages.</p>
                 </div>
                 <div>
-                  <h3 className="font-mono text-[0.82rem] font-extrabold text-ink">Why do some pubs show TBC?</h3>
+                  <h3 className="type-card">Why do some pubs show TBC?</h3>
                   <p className="mt-1 text-[0.78rem] leading-relaxed text-gray-mid">Because we have not confirmed a current regular pint price cleanly enough. TBC rows stay out of the average and median.</p>
                 </div>
               </div>
@@ -178,7 +178,7 @@ export default async function HowMuchIsAPintInPerthPage() {
         </section>
 
         <section className="mt-8 rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
-          <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Keep going</p>
+          <p className="type-eyebrow">Keep going</p>
           <div className="mt-3 grid gap-2 sm:grid-cols-2">
             {[
               { href: '/insights/pint-index', label: 'Perth Pint Index' },

--- a/src/app/insights/pint-index/PintIndexPage.tsx
+++ b/src/app/insights/pint-index/PintIndexPage.tsx
@@ -62,10 +62,10 @@ export default function PintIndexPage({ stats }: { stats: PintIndexAnswerStats }
         >
           <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
             <div>
-              <p className="font-mono text-[0.65rem] font-bold uppercase tracking-[0.08em] text-gray-mid mb-2">
+              <p className="type-eyebrow mb-2">
                 Methodology
               </p>
-              <h2 className="font-mono font-extrabold text-xl tracking-[-0.02em] text-ink">
+              <h2 className="type-section">
                 How the Index works
               </h2>
             </div>
@@ -78,7 +78,7 @@ export default function PintIndexPage({ stats }: { stats: PintIndexAnswerStats }
           </div>
           <div className="mt-5 grid gap-4 sm:grid-cols-2">
             <div className="border border-gray-light rounded-card bg-off-white p-4">
-              <h3 className="font-mono text-[0.75rem] font-bold uppercase tracking-[0.06em] text-ink mb-2">
+              <h3 className="type-eyebrow text-ink mb-2">
                 What we count
               </h3>
               <p className="font-body text-[0.85rem] leading-relaxed text-gray-mid">
@@ -86,7 +86,7 @@ export default function PintIndexPage({ stats }: { stats: PintIndexAnswerStats }
               </p>
             </div>
             <div className="border border-gray-light rounded-card bg-off-white p-4">
-              <h3 className="font-mono text-[0.75rem] font-bold uppercase tracking-[0.06em] text-ink mb-2">
+              <h3 className="type-eyebrow text-ink mb-2">
                 How prices are checked
               </h3>
               <p className="font-body text-[0.85rem] leading-relaxed text-gray-mid">

--- a/src/app/student-pints-perth/page.tsx
+++ b/src/app/student-pints-perth/page.tsx
@@ -86,8 +86,8 @@ export default async function StudentPintsPerthPage() {
       <section className="max-w-container mx-auto px-6 pt-8 pb-12">
         <div className="grid gap-6 sm:grid-cols-[1fr_260px] sm:items-end">
           <div>
-            <p className="mb-3 font-mono text-[0.68rem] font-bold uppercase text-gray-mid">Campus budget guide</p>
-            <h1 className="font-display text-[3rem] leading-[1] text-ink sm:text-[4.7rem]">
+            <p className="mb-3 type-eyebrow">Campus budget guide</p>
+            <h1 className="type-hero-editorial">
               Student pints in Perth
             </h1>
             <p className="mt-5 max-w-[620px] font-body text-[0.96rem] leading-relaxed text-gray-mid">
@@ -99,15 +99,15 @@ export default async function StudentPintsPerthPage() {
               <GraduationCap className="h-4 w-4 text-amber" />
               Student list
             </div>
-            <p className="font-mono text-[0.65rem] font-bold uppercase text-ink/55">Cheapest checked</p>
+            <p className="type-eyebrow text-ink/55">Cheapest checked</p>
             <p className="mt-1 font-mono text-5xl font-extrabold text-ink">{formatPrice(cheapest?.regularPrice)}</p>
             <p className="mt-2 text-[0.8rem] leading-relaxed text-ink/70">{cheapest ? `${cheapest.name}, near ${cheapest.campusShortName}` : 'No checked row yet.'}</p>
           </div>
         </div>
 
         <section className="my-8 rounded-card border-3 border-ink bg-ink p-5 text-white shadow-hard-sm">
-          <p className="font-mono text-[0.65rem] font-bold uppercase text-white/55">Answer first</p>
-          <h2 className="mt-2 font-mono text-xl font-extrabold">Where are the cheapest student pints in Perth?</h2>
+          <p className="type-eyebrow text-white/55">Answer first</p>
+          <h2 className="mt-2 type-section text-white">Where are the cheapest student pints in Perth?</h2>
           <p className="mt-3 font-body text-[0.9rem] leading-relaxed text-white/70">
             {cheapest ? <>The cheapest verified student-adjacent pint in this cut is {formatPrice(cheapest.regularPrice)} at <Link href={pubUrl(cheapest)} className="font-bold text-amber-light hover:underline">{cheapest.name}</Link>, about {formatDistance(cheapest.distanceKm)} direct from {cheapest.campusShortName}. UWA and Curtin have closer clusters; Murdoch needs a wider net in the current checked data.</> : <>We do not have a verified sub-$10 student row yet. That would be depressing, so hopefully it is temporary.</>}
           </p>
@@ -115,17 +115,17 @@ export default async function StudentPintsPerthPage() {
 
         <section className="mb-8 grid gap-3 sm:grid-cols-3">
           <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
-            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Campuses covered</p>
+            <p className="type-eyebrow">Campuses covered</p>
             <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{campusCount}/3</p>
             <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Campuses with at least one verified sub-$10 row.</p>
           </div>
           <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
-            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Rows under $10</p>
+            <p className="type-eyebrow">Rows under $10</p>
             <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{allRows.length}</p>
             <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Verified regular pint rows, not happy-hour specials.</p>
           </div>
           <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
-            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Widest net</p>
+            <p className="type-eyebrow">Widest net</p>
             <p className="mt-2 font-mono text-3xl font-extrabold text-ink">8km</p>
             <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Murdoch needs more radius before checked rows appear.</p>
           </div>
@@ -147,15 +147,15 @@ export default async function StudentPintsPerthPage() {
                       {campus.shortName}
                     </div>
                     <div>
-                      <p className="font-mono text-[0.6rem] font-bold uppercase text-gray-mid">Radius</p>
+                      <p className="type-eyebrow">Radius</p>
                       <p className="mt-1 font-mono text-3xl font-extrabold text-ink">{campus.radiusKm}km</p>
                     </div>
                   </div>
                 </div>
                 <div>
                   <div className="border-b border-gray-light bg-off-white px-5 py-4">
-                    <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">{campus.name}</p>
-                    <h2 className="mt-1 font-mono text-xl font-extrabold text-ink">{campus.shortName} cheap pints</h2>
+                    <p className="type-eyebrow">{campus.name}</p>
+                    <h2 className="mt-1 type-section">{campus.shortName} cheap pints</h2>
                     <p className="mt-2 text-[0.78rem] leading-relaxed text-gray-mid">{campus.note}</p>
                   </div>
                   <div className="divide-y divide-gray-light">

--- a/src/app/suburbs/SuburbsClient.tsx
+++ b/src/app/suburbs/SuburbsClient.tsx
@@ -106,7 +106,7 @@ export default function SuburbsClient({ suburbs }: SuburbsClientProps) {
       <div className="max-w-container mx-auto px-6 pb-12">
         {/* Header */}
         <div className="mb-8">
-          <h1 className="font-mono font-extrabold text-[clamp(1.8rem,5vw,2.4rem)] tracking-[-0.03em] text-ink leading-[1.1] mb-2">
+          <h1 className="type-hero mb-2">
             Pint prices by Perth suburb
           </h1>
           <p className="font-body text-[0.9rem] leading-relaxed text-gray-mid">
@@ -135,7 +135,7 @@ export default function SuburbsClient({ suburbs }: SuburbsClientProps) {
                     <Icon className="h-4 w-4" aria-hidden="true" />
                   </div>
                   <div className="min-w-0">
-                    <h3 className="font-mono text-[0.82rem] font-extrabold text-ink">{title}</h3>
+                    <h3 className="type-card">{title}</h3>
                     <p className="mt-1 font-body text-[0.72rem] leading-snug text-gray-mid">{caption}</p>
                   </div>
                 </div>

--- a/src/components/ArticleRail.tsx
+++ b/src/components/ArticleRail.tsx
@@ -28,10 +28,10 @@ export default function ArticleRail({
       <div className="max-w-container mx-auto px-6 py-10">
         <div className="mb-5 flex items-end justify-between gap-4">
           <div>
-            <p className={`mb-2 font-mono text-[0.68rem] font-bold uppercase ${isDark ? 'text-white/45' : 'text-gray-mid'}`}>
+            <p className={`type-eyebrow mb-2 ${isDark ? 'text-white/45' : 'text-gray-mid'}`}>
               {eyebrow}
             </p>
-            <h2 className={`font-mono text-xl font-extrabold ${isDark ? 'text-white' : 'text-ink'}`}>
+            <h2 className={`type-section ${isDark ? 'text-white' : 'text-ink'}`}>
               {title}
             </h2>
             <p className={`mt-2 max-w-[520px] font-body text-[0.88rem] leading-relaxed ${isDark ? 'text-white/60' : 'text-gray-mid'}`}>
@@ -62,7 +62,7 @@ export default function ArticleRail({
               <ArticleImageSlot article={article} size="rail" className="aspect-[16/10] border-b-3 border-ink" />
               <div className="flex flex-1 flex-col p-5">
                 <div className="flex flex-wrap items-center gap-2">
-                  <span className="font-mono text-[0.62rem] font-bold uppercase text-gray-mid">
+                  <span className="type-eyebrow">
                     {formatArticleDate(article.publishedAt)}
                   </span>
                 </div>
@@ -72,7 +72,7 @@ export default function ArticleRail({
                 <p className="mt-3 flex-1 font-body text-[0.82rem] leading-relaxed text-gray-mid">
                   {article.deck}
                 </p>
-                <span className="mt-5 inline-flex items-center gap-1 font-mono text-[0.7rem] font-bold uppercase text-amber">
+                <span className="mt-5 inline-flex items-center gap-1 type-eyebrow text-amber">
                   Read it <ArrowUpRight className="h-3.5 w-3.5" />
                 </span>
               </div>
@@ -84,7 +84,7 @@ export default function ArticleRail({
           href="/articles"
           eventName="article_hub_click"
           eventProperties={{ source }}
-          className={`mt-5 inline-flex items-center gap-1 font-mono text-[0.72rem] font-bold uppercase no-underline hover:underline ${
+          className={`mt-5 inline-flex items-center gap-1 type-eyebrow no-underline hover:underline ${
             isDark ? 'text-amber-light' : 'text-amber'
           }`}
         >

--- a/src/components/BeerWeather.tsx
+++ b/src/components/BeerWeather.tsx
@@ -198,7 +198,7 @@ export default function BeerWeather({ pubs, userLocation }: BeerWeatherProps) {
             </div>
             <div>
               <div className="flex items-center gap-2">
-                <h3 className="font-mono text-[0.85rem] font-extrabold text-ink">Beer Weather</h3>
+                <h3 className="type-card">Beer Weather</h3>
                 {isWindy && (
                   <span className="font-mono text-[0.55rem] font-bold uppercase tracking-[0.05em] px-1.5 py-0.5 rounded-pill border-2 border-gray-light bg-off-white text-gray-mid flex items-center gap-1">
                     <Wind className="w-3 h-3" /> Windy
@@ -255,7 +255,7 @@ export default function BeerWeather({ pubs, userLocation }: BeerWeatherProps) {
 
             {/* Recommended Pubs */}
             <div className="flex items-center justify-between mb-3">
-              <h4 className="font-mono text-[0.7rem] font-bold uppercase tracking-[0.05em] text-ink">
+              <h4 className="type-eyebrow text-ink">
                 Recommended Right Now
               </h4>
               <span className="font-mono text-[0.65rem] text-gray-mid">

--- a/src/components/CrowdReporter.tsx
+++ b/src/components/CrowdReporter.tsx
@@ -43,7 +43,7 @@ export default function CrowdReporter({ pubId, pubName, onClose, onReport }: Cro
         <div className="bg-gradient-to-r from-amber-600 to-amber-700 px-6 py-4">
           <div className="flex items-center justify-between">
             <div>
-              <h3 className="text-white font-bold text-lg">How busy is it?</h3>
+              <h3 className="font-mono text-white font-bold text-lg">How busy is it?</h3>
               <p className="text-white/80 text-sm truncate">{pubName}</p>
             </div>
             <button 

--- a/src/components/DadBar.tsx
+++ b/src/components/DadBar.tsx
@@ -74,7 +74,7 @@ export default function DadBar({ pubs, userLocation }: { pubs: Pub[], userLocati
               <Users className="w-5 h-5 text-ink" />
             </div>
             <div>
-              <h3 className="font-mono text-[0.85rem] font-extrabold text-ink">The Dad Bar</h3>
+              <h3 className="type-card">The Dad Bar</h3>
               <p className="font-body text-[0.75rem] text-gray-mid">Playgrounds for them. Pints for you.</p>
             </div>
           </div>

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -37,7 +37,7 @@ export default function FAQ() {
   return (
     <section className="py-14 px-6 bg-off-white bg-noise relative">
       <div ref={faqRef} className={`max-w-container mx-auto reveal ${faqInView ? 'in-view' : ''}`}>
-        <h2 className="font-mono text-[0.7rem] font-bold uppercase tracking-[0.08em] text-gray-mid mb-6">
+        <h2 className="type-eyebrow mb-6">
           FAQ
         </h2>
         <div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -62,7 +62,7 @@ export default function Footer() {
 
         {/* Beer sizes — compact inline reference */}
         <div className="flex items-center gap-4 mb-8">
-          <span className="font-mono text-[0.6rem] font-bold uppercase tracking-[0.12em] text-white/30">Glass sizes</span>
+          <span className="type-eyebrow text-white/30">Glass sizes</span>
           {GLASS_SIZES.map((size) => (
             <span key={size.name} className="font-mono text-[0.65rem] text-white/50">
               <span className="font-bold text-white/70">{size.name}</span> {size.ml}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -32,14 +32,14 @@ export default function HeroSection({ pubs }: HeroSectionProps) {
           </div>
         </div>
 
-        <h1 className="font-display text-[clamp(2.6rem,8vw,3.6rem)] font-bold leading-[1.05] tracking-[-0.03em] text-ink mb-3 animate-fade-up stagger-2">
+        <h1 className="type-hero-editorial mb-3 animate-fade-up stagger-2">
           Perth&apos;s pints,<br />
           <span className="text-amber italic">sorted.</span>
         </h1>
         <p className="font-body text-[1rem] text-gray-mid font-medium animate-fade-up stagger-3">
           What a pint actually costs, across {venueCount} Perth pubs.
         </p>
-        <p className="font-mono text-[0.65rem] font-bold uppercase tracking-[0.12em] text-gray-mid/60 mt-2 animate-fade-up stagger-4">
+        <p className="type-eyebrow text-gray-mid/60 mt-2 animate-fade-up stagger-4">
           Community-powered · Est. 2026
         </p>
       </section>
@@ -47,22 +47,22 @@ export default function HeroSection({ pubs }: HeroSectionProps) {
       {/* Stat strip */}
       <div className="max-w-container mx-auto px-6 pb-8 flex gap-2.5 justify-center flex-wrap">
         <div className="border-3 border-ink rounded-card px-5 py-3.5 text-center min-w-[100px] bg-white shadow-hard-sm animate-fade-up stagger-5">
-          <span className="font-mono text-[1.6rem] font-extrabold tracking-[-0.02em] block leading-[1.1]">{venueCount}</span>
-          <span className="font-mono text-[0.6rem] font-bold uppercase tracking-[0.08em] text-gray-mid block mt-0.5">Venues</span>
+          <span className="type-price text-[1.6rem] block leading-[1.1]">{venueCount}</span>
+          <span className="type-eyebrow block mt-0.5">Venues</span>
         </div>
         <Link href="/suburbs" className="border-3 border-ink rounded-card px-5 py-3.5 text-center min-w-[100px] bg-white shadow-hard-sm animate-fade-up stagger-6 hover:translate-y-[-2px] transition-transform">
-          <span className="font-mono text-[1.6rem] font-extrabold tracking-[-0.02em] block leading-[1.1]">{suburbCount}</span>
-          <span className="font-mono text-[0.6rem] font-bold uppercase tracking-[0.08em] text-gray-mid block mt-0.5">Suburbs</span>
+          <span className="type-price text-[1.6rem] block leading-[1.1]">{suburbCount}</span>
+          <span className="type-eyebrow block mt-0.5">Suburbs</span>
         </Link>
         {cheapestPub ? (
           <Link href={pubUrl(cheapestPub)} className="border-3 border-ink rounded-card px-5 py-3.5 text-center min-w-[100px] bg-amber shadow-hard-sm animate-fade-up stagger-7 hover:translate-y-[-2px] transition-transform">
-            <span className="font-mono text-[1.6rem] font-extrabold tracking-[-0.02em] block leading-[1.1] text-white">${cheapest}</span>
-            <span className="font-mono text-[0.6rem] font-bold uppercase tracking-[0.08em] text-white/80 block mt-0.5">Cheapest</span>
+            <span className="type-price text-[1.6rem] block leading-[1.1] text-white">${cheapest}</span>
+            <span className="type-eyebrow block mt-0.5 text-white/80">Cheapest</span>
           </Link>
         ) : (
           <div className="border-3 border-ink rounded-card px-5 py-3.5 text-center min-w-[100px] bg-amber shadow-hard-sm animate-fade-up stagger-7">
-            <span className="font-mono text-[1.6rem] font-extrabold tracking-[-0.02em] block leading-[1.1] text-white">TBC</span>
-            <span className="font-mono text-[0.6rem] font-bold uppercase tracking-[0.08em] text-white/80 block mt-0.5">Cheapest</span>
+            <span className="type-price text-[1.6rem] block leading-[1.1] text-white">TBC</span>
+            <span className="type-eyebrow block mt-0.5 text-white/80">Cheapest</span>
           </div>
         )}
       </div>

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -51,7 +51,7 @@ export default function HowItWorks({ venueCount = 0, suburbCount = 0 }: HowItWor
                 className="border-3 border-ink rounded-card bg-off-white shadow-hard-sm p-5"
               >
                 <Icon className="w-8 h-8 text-amber mb-3" strokeWidth={2} />
-                <h3 className="font-mono text-[0.8rem] font-bold tracking-[0.02em] text-ink mb-2">
+                <h3 className="type-card mb-2">
                   {feature.heading}
                 </h3>
                 <p className="font-body text-[0.85rem] text-gray-mid font-medium leading-relaxed">

--- a/src/components/PintIndex.tsx
+++ b/src/components/PintIndex.tsx
@@ -241,7 +241,7 @@ export default function PintIndex() {
 
   const sparkData = snapshots.map(s => s.avg_price);
   const trendIcon = monthChange > 0 ? '\u25b2' : monthChange < 0 ? '\u25bc' : '\u2014';
-  const trendColor = monthChange > 0 ? 'text-coral' : monthChange < 0 ? 'text-amber' : 'text-yellow-500';
+  const trendColor = monthChange > 0 ? 'text-red' : monthChange < 0 ? 'text-amber' : 'text-yellow-500';
 
   return (
     <Card 
@@ -255,7 +255,7 @@ export default function PintIndex() {
           <div className="flex items-center gap-3">
             <div>
               <div className="flex items-center gap-2">
-                <h3 className="text-lg font-semibold font-heading text-ink flex items-center">Perth Pint Index{'\u2122'}</h3>
+                <h3 className="type-card text-lg flex items-center">Perth Pint Index{'\u2122'}</h3>
                 <span className="text-[10px] px-1.5 py-0 border border-gray rounded-pill text-gray-mid">
                   LIVE
                 </span>
@@ -289,10 +289,10 @@ export default function PintIndex() {
                 <div className="text-sm font-bold text-ink mt-1">{current.cheapest_suburb}</div>
                 <div className="text-xs text-amber font-mono">avg ${current.cheapest_suburb_avg.toFixed(2)}/pint</div>
               </div>
-              <div className="bg-coral/10 rounded-xl p-3">
-                <div className="text-[10px] text-coral font-semibold">▲ Priciest Suburb</div>
+              <div className="bg-red/10 rounded-xl p-3">
+                <div className="text-[10px] text-red font-semibold">▲ Priciest Suburb</div>
                 <div className="text-sm font-bold text-ink mt-1">{current.most_expensive_suburb}</div>
-                <div className="text-xs text-coral font-mono">avg ${current.most_expensive_suburb_avg.toFixed(2)}/pint</div>
+                <div className="text-xs text-red font-mono">avg ${current.most_expensive_suburb_avg.toFixed(2)}/pint</div>
               </div>
             </div>
 
@@ -300,7 +300,7 @@ export default function PintIndex() {
             <div className="flex items-center justify-between mt-4 px-1">
               <div>
                 <div className="text-[10px] text-gray-mid font-medium">Overall Change</div>
-                <div className={`text-lg font-bold font-mono ${yearChange > 0 ? 'text-coral' : 'text-amber'}`}>
+                <div className={`text-lg font-bold font-mono ${yearChange > 0 ? 'text-red' : 'text-amber'}`}>
                   {yearChange >= 0 ? '+' : ''}{yearPct.toFixed(1)}%
                 </div>
               </div>

--- a/src/components/PintOfTheDay.tsx
+++ b/src/components/PintOfTheDay.tsx
@@ -95,7 +95,7 @@ export default function PintOfTheDay() {
         <div className="flex items-center gap-2">
           <Beer className="w-5 h-5 text-amber" />
           <div>
-            <h3 className="text-xs font-bold text-amber">Pint of the Day</h3>
+            <h3 className="type-card text-amber">Pint of the Day</h3>
             <p className="text-[10px] text-gray-mid">{new Date(data.date + 'T00:00:00+08:00').toLocaleDateString('en-AU', { weekday: 'long', day: 'numeric', month: 'short' })}</p>
           </div>
         </div>
@@ -111,7 +111,7 @@ export default function PintOfTheDay() {
       <Link href={pubUrl(data.pub)} className="block px-4 sm:px-5 pb-4 sm:pb-5 group">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
-            <h4 className="text-lg font-bold font-heading text-ink group-hover:text-amber transition-colors truncate">{data.pub.name}</h4>
+            <h4 className="type-card text-lg group-hover:text-amber transition-colors truncate">{data.pub.name}</h4>
             <p className="text-xs text-gray-mid mt-0.5">{data.pub.suburb} · {data.pub.address}</p>
             {data.pub.beerType && (
               <p className="text-xs text-gray-mid mt-0.5">{data.pub.beerType}</p>

--- a/src/components/PubCardList.tsx
+++ b/src/components/PubCardList.tsx
@@ -31,8 +31,8 @@ export default function PubCardList({
     <div className="max-w-container mx-auto px-6">
       {/* List header */}
       <div className="flex justify-between py-4 pb-2.5 border-b-3 border-ink">
-        <span className="font-mono text-[0.68rem] font-bold uppercase tracking-[0.1em] text-gray-mid">Pub</span>
-        <span className="font-mono text-[0.68rem] font-bold uppercase tracking-[0.1em] text-gray-mid">Pint</span>
+        <span className="type-eyebrow">Pub</span>
+        <span className="type-eyebrow">Pint</span>
       </div>
 
       {/* Empty state */}
@@ -95,7 +95,7 @@ export default function PubCardList({
 
             {/* Price */}
             <div className="text-right min-w-[70px]">
-              <span className="font-mono text-[1.1rem] font-extrabold text-ink">
+              <span className="type-price text-[1.1rem]">
                 {pub.price !== null ? `$${pub.price.toFixed(2)}` : 'TBC'}
               </span>
             </div>

--- a/src/components/PuntNPints.tsx
+++ b/src/components/PuntNPints.tsx
@@ -119,7 +119,7 @@ export default function PuntNPints({ pubs, userLocation }: PuntNPintsProps) {
       <section>
         <div className="border-3 border-ink rounded-card shadow-hard-sm bg-white overflow-hidden">
           <div className="px-5 py-4 border-b-3 border-ink bg-ink">
-            <h2 className="font-mono text-[0.75rem] font-bold uppercase tracking-[0.08em] text-white">
+            <h2 className="type-card-header text-white">
               Today&apos;s WA Races
             </h2>
           </div>
@@ -177,12 +177,12 @@ export default function PuntNPints({ pubs, userLocation }: PuntNPintsProps) {
 
       {/* ═══ TAB Pubs Section ═══ */}
       <section>
-        <h2 className="font-mono font-extrabold text-xl tracking-[-0.02em] text-ink">Bet & Drink Under One Roof</h2>
+        <h2 className="type-section">Bet & Drink Under One Roof</h2>
         <p className="text-sm text-gray-mid mt-1 mb-5">Pubs with TAB on-site. Punt and pint, sorted by price</p>
 
         <div className="border-3 border-ink rounded-card shadow-hard-sm overflow-hidden">
           <div className="px-4 py-3 border-b border-gray-light bg-off-white">
-            <span className="font-mono text-[0.65rem] font-bold uppercase tracking-[0.08em] text-gray-mid">
+            <span className="type-eyebrow">
               {tabPubs.length} venues with TAB
             </span>
           </div>
@@ -253,12 +253,12 @@ export default function PuntNPints({ pubs, userLocation }: PuntNPintsProps) {
       {/* ═══ Nearby TAB Section ═══ */}
       {nearbyPairs.length > 0 && (
         <section>
-          <h2 className="font-mono font-extrabold text-xl tracking-[-0.02em] text-ink">Cheap Pints Near a TAB</h2>
+          <h2 className="type-section">Cheap Pints Near a TAB</h2>
           <p className="text-sm text-gray-mid mt-1 mb-5">No TAB on-site, but a TABtouch agency within walking distance</p>
 
           <div className="border-3 border-ink rounded-card shadow-hard-sm overflow-hidden">
             <div className="px-4 py-3 border-b border-gray-light bg-off-white">
-              <span className="font-mono text-[0.65rem] font-bold uppercase tracking-[0.08em] text-gray-mid">
+              <span className="type-eyebrow">
                 {nearbyPairs.length} pubs near a TAB
               </span>
             </div>

--- a/src/components/RainyDay.tsx
+++ b/src/components/RainyDay.tsx
@@ -135,7 +135,7 @@ export default function RainyDay({ pubs, userLocation }: RainyDayProps) {
             </div>
             <div>
               <div className="flex items-center gap-2">
-                <h3 className="font-mono text-[0.85rem] font-extrabold text-ink">
+                <h3 className="type-card">
                   {isRaining ? 'Rainy Day Pubs' : 'Cosy Corners'}
                 </h3>
                 {isRaining && weather.rain > 0 && (
@@ -192,7 +192,7 @@ export default function RainyDay({ pubs, userLocation }: RainyDayProps) {
 
             {/* Recommended Pubs */}
             <div className="flex items-center justify-between mb-3">
-              <h4 className="font-mono text-[0.7rem] font-bold uppercase tracking-[0.05em] text-ink">
+              <h4 className="type-eyebrow text-ink">
                 {isRaining ? 'Duck In Here' : 'Cosy Picks'}
               </h4>
               <span className="font-mono text-[0.65rem] text-gray-mid">

--- a/src/components/SocialProof.tsx
+++ b/src/components/SocialProof.tsx
@@ -20,8 +20,8 @@ export default function SocialProof({ avgPrice, venueCount, onSubmitClick }: Soc
         {/* Stat + context */}
         <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-8">
           <div className="inline-flex items-baseline gap-2 border-3 border-ink rounded-pill px-7 py-3 bg-white shadow-hard-sm">
-            <span className="font-mono text-[0.65rem] font-bold uppercase tracking-[0.08em] text-gray-mid">Avg pint</span>
-            <span className="font-mono text-[1.4rem] font-extrabold tracking-[-0.02em] text-ink">${avgPrice}</span>
+            <span className="type-eyebrow">Avg pint</span>
+            <span className="type-price text-[1.4rem]">${avgPrice}</span>
           </div>
           <span className="font-mono text-[0.7rem] text-gray-mid tracking-[0.02em]">
             across {venueCount} Perth venues
@@ -29,7 +29,7 @@ export default function SocialProof({ avgPrice, venueCount, onSubmitClick }: Soc
         </div>
 
         {/* CTA */}
-        <h2 className="text-[clamp(1.5rem,4vw,2rem)] text-ink mb-2">
+        <h2 className="font-mono font-extrabold text-[clamp(1.5rem,4vw,2rem)] text-ink mb-2">
           Know a price we&apos;re missing?
         </h2>
         <p className="font-body text-[0.95rem] text-gray-mid font-medium mb-6">

--- a/src/components/SuburbLeague.tsx
+++ b/src/components/SuburbLeague.tsx
@@ -125,7 +125,7 @@ export default function SuburbLeague({ pubs }: { pubs: Pub[] }) {
             <BarChart3 className="w-5 h-5 text-ink" />
           </div>
           <div>
-            <h3 className="font-mono text-[0.85rem] font-extrabold text-ink">Suburb Rankings</h3>
+            <h3 className="type-card">Suburb Rankings</h3>
             <p className="font-body text-[0.75rem] text-gray-mid">
               {isExpanded
                 ? `${total} suburbs ${sortLabel}. Tap columns to re-sort`

--- a/src/components/SunsetSippers.tsx
+++ b/src/components/SunsetSippers.tsx
@@ -202,7 +202,7 @@ export default function SunsetSippers({ pubs, userLocation }: SunsetSippersProps
       <section>
         <div className="border-3 border-ink rounded-card shadow-hard-sm bg-white overflow-hidden">
           <div className="px-5 py-4 border-b-3 border-ink bg-ink">
-            <h2 className="font-mono text-[0.75rem] font-bold uppercase tracking-[0.08em] text-white">
+            <h2 className="type-card-header text-white">
               Today&apos;s Sunset
             </h2>
           </div>
@@ -269,10 +269,10 @@ export default function SunsetSippers({ pubs, userLocation }: SunsetSippersProps
                     </>
                   )}
                   {/* Labels */}
-                  <text x="8" y={arcCenterY + 16} fontSize="10" fill="#8A8A85" fontFamily="monospace" fontWeight="600">
+                  <text x="8" y={arcCenterY + 16} fontSize="10" fill="#8A8A85" fontFamily="var(--font-jetbrains-mono), monospace" fontWeight="600">
                     {formatTime(sunTimes.sunrise).replace(' ', '')}
                   </text>
-                  <text x={arcWidth - 78} y={arcCenterY + 16} fontSize="10" fill="#D4740A" fontFamily="monospace" fontWeight="600">
+                  <text x={arcWidth - 78} y={arcCenterY + 16} fontSize="10" fill="#D4740A" fontFamily="var(--font-jetbrains-mono), monospace" fontWeight="600">
                     {formatTime(sunTimes.sunset).replace(' ', '')}
                   </text>
                 </svg>
@@ -304,7 +304,7 @@ export default function SunsetSippers({ pubs, userLocation }: SunsetSippersProps
       <section>
         <div className="flex items-baseline justify-between mb-5">
           <div>
-            <h2 className="font-mono font-extrabold text-xl tracking-[-0.02em] text-ink">Best Sunset Spots</h2>
+            <h2 className="type-section">Best Sunset Spots</h2>
             <p className="text-sm text-gray-mid mt-1">{sunsetPubs.length} west-facing pubs for golden hour pints</p>
           </div>
           {cheapestSunset && (

--- a/src/components/TonightsMoves.tsx
+++ b/src/components/TonightsMoves.tsx
@@ -140,7 +140,7 @@ export default function TonightsMoves({ pubs, userLocation }: TonightsMovesProps
             </div>
             <div>
               <div className="flex items-center gap-2">
-                <h3 className="font-mono text-[0.85rem] font-extrabold text-ink">{`Tonight's Best Bets`}</h3>
+                <h3 className="type-card">{`Tonight's Best Bets`}</h3>
                 <span className="font-mono text-[0.6rem] text-gray-mid">{formatPerthTime(clockInstant)} AWST</span>
               </div>
               <p className="font-body text-[0.75rem] text-gray-mid">{summaryText}</p>
@@ -157,7 +157,7 @@ export default function TonightsMoves({ pubs, userLocation }: TonightsMovesProps
             {/* Market Tip */}
             {marketTip && (
               <div className="p-3 rounded-card bg-amber-pale border-2 border-amber/30">
-                <h4 className="font-mono text-[0.65rem] font-bold uppercase tracking-[0.05em] text-amber mb-1 flex items-center gap-1">
+                <h4 className="type-eyebrow text-amber mb-1 flex items-center gap-1">
                   <Star className="w-3 h-3" /> Market Tip
                 </h4>
                 <div className="flex items-center justify-between">
@@ -184,7 +184,7 @@ export default function TonightsMoves({ pubs, userLocation }: TonightsMovesProps
 
             {/* Best Buys */}
             <div>
-              <h4 className="font-mono text-[0.7rem] font-bold uppercase tracking-[0.05em] text-ink mb-2 flex items-center gap-1">
+              <h4 className="type-eyebrow text-ink mb-2 flex items-center gap-1">
                 <TrendingDown className="w-3.5 h-3.5" /> Best Buys
               </h4>
               <div className="space-y-0">
@@ -206,7 +206,7 @@ export default function TonightsMoves({ pubs, userLocation }: TonightsMovesProps
             {/* Active Deals */}
             {activeDeals.length > 0 && (
               <div>
-                <h4 className="font-mono text-[0.7rem] font-bold uppercase tracking-[0.05em] text-ink mb-2 flex items-center gap-1">
+                <h4 className="type-eyebrow text-ink mb-2 flex items-center gap-1">
                   <PartyPopper className="w-3.5 h-3.5" /> Happy Hour Now ({activeDeals.length})
                 </h4>
                 <div className="space-y-0">
@@ -234,7 +234,7 @@ export default function TonightsMoves({ pubs, userLocation }: TonightsMovesProps
             {/* Upcoming Deals */}
             {upcomingDeals.length > 0 && (
               <div>
-                <h4 className="font-mono text-[0.7rem] font-bold uppercase tracking-[0.05em] text-ink mb-2 flex items-center gap-1">
+                <h4 className="type-eyebrow text-ink mb-2 flex items-center gap-1">
                   <Clock className="w-3.5 h-3.5" /> Starting Soon
                 </h4>
                 <div className="space-y-0">
@@ -262,7 +262,7 @@ export default function TonightsMoves({ pubs, userLocation }: TonightsMovesProps
             {/* Hot Suburb */}
             {hotSuburb && (
               <div className="bg-off-white rounded-card p-3 text-center">
-                <h4 className="font-mono text-[0.65rem] font-bold uppercase tracking-[0.05em] text-gray-mid mb-1 flex items-center justify-center gap-1">
+                <h4 className="type-eyebrow mb-1 flex items-center justify-center gap-1">
                   <Flame className="w-3 h-3" /> Hot Suburb
                 </h4>
                 <p className="font-mono text-sm font-extrabold text-ink">{hotSuburb.name}</p>

--- a/src/components/TransportHubPage.tsx
+++ b/src/components/TransportHubPage.tsx
@@ -77,8 +77,8 @@ export default async function TransportHubPage({ hub }: TransportHubPageProps) {
       <section className="max-w-container mx-auto px-6 pt-8 pb-12">
         <div className="grid gap-6 sm:grid-cols-[1fr_260px] sm:items-end">
           <div>
-            <p className="mb-3 font-mono text-[0.68rem] font-bold uppercase text-gray-mid">Transport pub guide</p>
-            <h1 className="font-display text-[3rem] leading-[1] text-ink sm:text-[4.7rem]">
+            <p className="mb-3 type-eyebrow">Transport pub guide</p>
+            <h1 className="type-hero-editorial">
               Pubs near {hub.name}
             </h1>
             <p className="mt-5 max-w-[620px] font-body text-[0.96rem] leading-relaxed text-gray-mid">
@@ -97,7 +97,7 @@ export default async function TransportHubPage({ hub }: TransportHubPageProps) {
                 {hub.shortName}
               </div>
               <div>
-                <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Search radius</p>
+                <p className="type-eyebrow">Search radius</p>
                 <p className="mt-1 font-mono text-4xl font-extrabold text-ink">{hub.radiusKm.toFixed(1)}km</p>
               </div>
             </div>
@@ -105,8 +105,8 @@ export default async function TransportHubPage({ hub }: TransportHubPageProps) {
         </div>
 
         <section className="my-8 rounded-card border-3 border-ink bg-ink p-5 text-white shadow-hard-sm">
-          <p className="font-mono text-[0.65rem] font-bold uppercase text-white/55">Answer first</p>
-          <h2 className="mt-2 font-mono text-xl font-extrabold">What is the best pub near {hub.name}?</h2>
+          <p className="type-eyebrow text-white/55">Answer first</p>
+          <h2 className="mt-2 type-section text-white">What is the best pub near {hub.name}?</h2>
           <p className="mt-3 font-body text-[0.9rem] leading-relaxed text-white/70">
             {closest ? <>The closest pub in the current dataset is <Link href={pubUrl(closest)} className="font-bold text-amber-light hover:underline">{closest.name}</Link> in {closest.suburb}, about {formatDistance(closest.distanceKm)} direct from {hub.shortName}. {cheapest ? <>The cheapest verified regular pint nearby is {formatPrice(cheapest.regularPrice)} at {cheapest.name}.</> : <>We do not have a verified regular pint price for this hub yet.</>} {hub.answerNote}</> : <>We do not have enough nearby pub data for this hub yet.</>}
           </p>
@@ -114,17 +114,17 @@ export default async function TransportHubPage({ hub }: TransportHubPageProps) {
 
         <section className="mb-8 grid gap-3 sm:grid-cols-3">
           <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
-            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Nearby pubs</p>
+            <p className="type-eyebrow">Nearby pubs</p>
             <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{nearbyPubs.length}</p>
             <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Within {hub.radiusKm.toFixed(1)}km direct of {hub.shortName}.</p>
           </div>
           <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
-            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Closest</p>
+            <p className="type-eyebrow">Closest</p>
             <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{closest ? formatDistance(closest.distanceKm) : 'TBC'}</p>
             <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">{closest ? `${closest.name}, ${closest.suburb}` : 'Needs nearby rows.'}</p>
           </div>
           <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
-            <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Cheapest checked</p>
+            <p className="type-eyebrow">Cheapest checked</p>
             <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{formatPrice(cheapest?.regularPrice)}</p>
             <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">{cheapest ? `${cheapest.name}, ${cheapest.suburb}` : 'No verified price yet.'}</p>
           </div>
@@ -133,8 +133,8 @@ export default async function TransportHubPage({ hub }: TransportHubPageProps) {
         <section className="rounded-card border-3 border-ink bg-white shadow-hard-sm">
           <div className="flex items-center justify-between gap-4 border-b-3 border-ink bg-off-white px-5 py-4">
             <div>
-              <p className="font-mono text-[0.65rem] font-bold uppercase text-gray-mid">Sorted by direct distance</p>
-              <h2 className="font-mono text-xl font-extrabold text-ink">Nearby rows</h2>
+              <p className="type-eyebrow">Sorted by direct distance</p>
+              <h2 className="type-section">Nearby rows</h2>
             </div>
             <MapPin className="h-5 w-5 text-amber" />
           </div>

--- a/src/components/VenueIntel.tsx
+++ b/src/components/VenueIntel.tsx
@@ -128,7 +128,7 @@ export default function VenueIntel({ pubs, userLocation }: VenueIntelProps) {
               <BarChart3 className="w-5 h-5 text-ink" />
             </div>
             <div>
-              <h3 className="font-mono text-[0.85rem] font-extrabold text-ink">Venue Breakdown</h3>
+              <h3 className="type-card">Venue Breakdown</h3>
               <p className="font-body text-[0.75rem] text-gray-mid">{summaryText}</p>
             </div>
           </div>
@@ -141,7 +141,7 @@ export default function VenueIntel({ pubs, userLocation }: VenueIntelProps) {
           <div className="mt-3 pt-3 border-t border-gray-light space-y-4" onClick={(e) => e.stopPropagation()}>
             {/* Price Distribution */}
             <div>
-              <h4 className="font-mono text-[0.7rem] font-bold uppercase tracking-[0.05em] text-ink mb-2 flex items-center gap-1">
+              <h4 className="type-eyebrow text-ink mb-2 flex items-center gap-1">
                 <BarChart3 className="w-3.5 h-3.5" /> Price Distribution
               </h4>
               <div className="p-3 rounded-card bg-off-white">
@@ -164,7 +164,7 @@ export default function VenueIntel({ pubs, userLocation }: VenueIntelProps) {
 
             {/* Median */}
             <div className="bg-amber-pale rounded-card p-4 text-center border-2 border-amber/30">
-              <p className="font-mono text-[0.65rem] text-gray-mid uppercase tracking-[0.05em]">Median Pint Price in Perth</p>
+              <p className="type-eyebrow">Median Pint Price in Perth</p>
               <p className="font-mono text-xl font-extrabold text-ink mt-1">${percentileData.median.toFixed(2)}</p>
               <p className="font-mono text-[0.6rem] text-gray-mid mt-1">{percentileData.percentile}% of venues are cheaper than the median</p>
             </div>
@@ -172,7 +172,7 @@ export default function VenueIntel({ pubs, userLocation }: VenueIntelProps) {
             {/* Under/Over valued */}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
-                <h4 className="font-mono text-[0.7rem] font-bold uppercase tracking-[0.05em] text-ink mb-2 flex items-center gap-1">
+                <h4 className="type-eyebrow text-ink mb-2 flex items-center gap-1">
                   <TrendingDown className="w-3.5 h-3.5" /> Undervalued
                 </h4>
                 <div className="space-y-0">
@@ -192,7 +192,7 @@ export default function VenueIntel({ pubs, userLocation }: VenueIntelProps) {
               </div>
 
               <div>
-                <h4 className="font-mono text-[0.7rem] font-bold uppercase tracking-[0.05em] text-red mb-2 flex items-center gap-1">
+                <h4 className="type-eyebrow text-red mb-2 flex items-center gap-1">
                   <TrendingUp className="w-3.5 h-3.5" /> Overvalued
                 </h4>
                 <div className="space-y-0">
@@ -215,7 +215,7 @@ export default function VenueIntel({ pubs, userLocation }: VenueIntelProps) {
             {/* Cheapest / Priciest suburbs */}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
-                <h4 className="font-mono text-[0.7rem] font-bold uppercase tracking-[0.05em] text-ink mb-2 flex items-center gap-1">
+                <h4 className="type-eyebrow text-ink mb-2 flex items-center gap-1">
                   <span className="w-2 h-2 rounded-full bg-green" /> Cheapest Suburbs
                 </h4>
                 <div className="space-y-0">
@@ -235,7 +235,7 @@ export default function VenueIntel({ pubs, userLocation }: VenueIntelProps) {
               </div>
 
               <div>
-                <h4 className="font-mono text-[0.7rem] font-bold uppercase tracking-[0.05em] text-red mb-2 flex items-center gap-1">
+                <h4 className="type-eyebrow text-red mb-2 flex items-center gap-1">
                   <span className="w-2 h-2 rounded-full bg-red" /> Priciest Suburbs
                 </h4>
                 <div className="space-y-0">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,10 +21,10 @@ const config: Config = {
         display: ['var(--font-dm-serif)', 'Georgia', 'serif'],
         body: ['var(--font-plus-jakarta)', 'system-ui', 'sans-serif'],
         mono: ['var(--font-jetbrains-mono)', '"Courier New"', 'monospace'],
-        // Backward compat aliases
+        // Backward-compat aliases. (Removed `heading` — it pointed at the body
+        // sans despite its name; migrate to .type-card / explicit font-mono.)
         sans: ['var(--font-plus-jakarta)', 'system-ui', 'sans-serif'],
         serif: ['var(--font-dm-serif)', 'Georgia', 'serif'],
-        heading: ['var(--font-plus-jakarta)', 'system-ui', 'sans-serif'],
       },
       colors: {
         // Arvo Bold palette


### PR DESCRIPTION
Fixes the typography inconsistencies surfaced in the audit by adding the missing **semantic layer between tokens and JSX** — so components stop re-improvising hero/section/card/eyebrow styles with arbitrary values, and three font families stop colliding on the same heading level.

## The system (`globals.css` `@layer components`)
One definition per role — family + size + weight + tracking pinned:
- `type-hero` (mono, app/data pages) · `type-hero-editorial` (DM Serif **400**, editorial/landing — one size)
- `type-section` (mono section heading) · `type-card` (card title) · `type-card-header` (uppercase panel header)
- `type-eyebrow` (uppercase label) · `type-price` (price number, size inline)

## Root-cause fixes
- **Faux-bold + accidental serif:** the base `h2,h3 → DM Serif + bold` rule (DM Serif ships weight 400 only) is replaced with `h1–h4 → mono`; deliberate serif is now opt-in via `font-display`. Zero `font-display`+bold combos remain.
- **Hero drift:** the 4 editorial heroes (`4.55/4.7/4.8/5rem`) + the homepage one-off unify to a single `type-hero-editorial`.
- **`font-heading` footgun removed** (it aliased the body sans despite its name) — the two usages migrated to mono.
- **Bugs:** undefined `text-coral`/`bg-coral` → `red`; SVG `fontFamily="monospace"` → the brand mono var.
- **Decision-page CTA:** the "Know a price we're missing?" CTA was serif in SocialProof but mono elsewhere (audit #4) — now consistently mono.

## Peer-reviewed
The 30-file codemod was reviewed by **3 parallel agents** (regressions / spec-adherence / coverage-and-over-reach). Their findings were folded back in — notably:
- they caught uppercase **panel headers** being wrongly collapsed into `type-eyebrow` (shrinking them) → added the `type-card-header` role
- two prominent card titles (Pint Index, Pint of the Day) had shrunk `text-lg→0.85rem` → restored
- a base-rule fallout on the SocialProof CTA → made explicit

## Verified
- `npx tsc --noEmit` clean · `npm test` **267/267** · `npm run lint` clean
- Desktop + mobile **screenshot QA** across home / suburb / cheapest-pints / discover / pint-index / articles — no regressions (the base-rule swap leaves all *visible* bare headings correct; the only bare ones are `sr-only`)

## Out of scope (intentional)
- `src/app/[suburb]/[pub]/*` and `src/app/prototype/*` — the pub-page **Variant B redesign** lands as a separate PR on top of this system.
- `admin/*` (internal tool) and inline list-price spans — documented as deliberate boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)