### PR TITLE
Suburb page polish: HH-live box, stat-grid gap, nearby-suburbs card

### DIFF
--- a/src/app/[suburb]/SuburbClient.tsx
+++ b/src/app/[suburb]/SuburbClient.tsx
@@ -132,8 +132,13 @@ export default function SuburbClient({ suburb, pubs, nearbySuburbs, perthAvgPric
       {/* Local guide modules — rendered only from checked suburb data */}
       <section className="max-w-container mx-auto px-6 pb-6">
         <div className="grid gap-3 sm:grid-cols-2">
-          {story.cards.map(card => (
-            <article key={card.id} className="min-w-0 border-3 border-ink rounded-card bg-white p-4 shadow-hard-sm">
+          {story.cards.map((card, i) => (
+            <article
+              key={card.id}
+              className={`min-w-0 border-3 border-ink rounded-card bg-white p-4 shadow-hard-sm${
+                i === story.cards.length - 1 && story.cards.length % 2 === 1 ? ' sm:col-span-2' : ''
+              }`}
+            >
               <p className="type-eyebrow mb-1">{card.label}</p>
               <h2 className="font-mono text-[1.05rem] font-extrabold leading-tight text-ink mb-2">{card.title}</h2>
               <p className="text-[0.78rem] leading-relaxed text-gray-mid">{card.body}</p>

--- a/src/app/[suburb]/SuburbClient.tsx
+++ b/src/app/[suburb]/SuburbClient.tsx
@@ -153,20 +153,20 @@ export default function SuburbClient({ suburb, pubs, nearbySuburbs, perthAvgPric
         if (activeHH.length === 0) return null
         return (
           <section className="max-w-container mx-auto px-6 pb-4">
-            <div className="border-3 border-red/30 rounded-card bg-red/5 overflow-hidden">
-              <div className="px-4 py-3 flex items-center gap-2">
+            <div className="border-3 border-ink rounded-card shadow-hard-sm bg-white overflow-hidden">
+              <div className="px-4 py-3 flex items-center gap-2 bg-red-pale border-b-3 border-ink">
                 <span className="w-2 h-2 rounded-full bg-red animate-pulse" />
                 <h2 className="type-card-header text-red">
                   Happy Hour Live Now
                 </h2>
-                <span className="text-[0.7rem] text-gray-mid ml-auto">{activeHH.length} {activeHH.length === 1 ? 'venue' : 'venues'}</span>
+                <span className="font-mono text-[0.62rem] font-bold uppercase tracking-wider text-red/70 ml-auto">{activeHH.length} {activeHH.length === 1 ? 'venue' : 'venues'}</span>
               </div>
-              <div className="divide-y divide-red/10">
+              <div className="divide-y divide-gray-light">
                 {activeHH.map(pub => (
                   <Link
                     key={pub.id}
                     href={`/${suburbSlug}/${pub.slug}`}
-                    className="flex items-center justify-between px-4 py-3 no-underline group hover:bg-red/5 transition-colors"
+                    className="flex items-center justify-between px-4 py-3 no-underline group hover:bg-off-white transition-colors"
                   >
                     <div className="min-w-0 flex-1">
                       <p className="font-mono text-[0.82rem] font-extrabold text-ink group-hover:text-red transition-colors truncate">{pub.name}</p>

--- a/src/app/[suburb]/SuburbClient.tsx
+++ b/src/app/[suburb]/SuburbClient.tsx
@@ -305,27 +305,33 @@ export default function SuburbClient({ suburb, pubs, nearbySuburbs, perthAvgPric
       {/* Nearby Suburbs */}
       {nearbySuburbs.length > 0 && (
         <section className="max-w-container mx-auto px-6 pb-6">
-          <div className="flex flex-wrap gap-2">
-            {nearbySuburbs.map(ns => (
-              <Link
-                key={ns.slug}
-                href={`/${ns.slug}`}
-                className="border-3 border-ink rounded-pill px-4 py-2 shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all no-underline group"
-              >
-                <span className="font-mono text-[0.75rem] font-bold text-ink group-hover:text-amber transition-colors">{ns.name}</span>
-                <span className="text-[0.65rem] text-gray-mid ml-2">
-                  {ns.pubCount} {ns.pubCount === 1 ? 'pub' : 'pubs'}
-                  {ns.cheapestPrice !== 'TBC' && ` · from $${ns.cheapestPrice}`}
-                  {avgNum > 0 && Number(ns.avgPrice) > 0 && (
-                    Number(ns.avgPrice) < avgNum
-                      ? <span className="text-green ml-1">cheaper</span>
-                      : Number(ns.avgPrice) > avgNum
-                        ? <span className="text-red/70 ml-1">pricier</span>
-                        : null
-                  )}
-                </span>
-              </Link>
-            ))}
+          <div className="border-3 border-ink rounded-card bg-white shadow-hard-sm overflow-hidden">
+            <div className="px-4 py-3 border-b border-gray-light flex items-center justify-between gap-3">
+              <h2 className="type-card-header">Nearby suburbs</h2>
+              <span className="font-mono text-[0.62rem] font-bold uppercase tracking-wider text-gray-mid">Compare prices</span>
+            </div>
+            <div className="p-4 flex flex-wrap gap-2">
+              {nearbySuburbs.map(ns => (
+                <Link
+                  key={ns.slug}
+                  href={`/${ns.slug}`}
+                  className="border-2 border-gray-light rounded-pill px-3.5 py-1.5 hover:border-ink hover:bg-off-white transition-all no-underline group"
+                >
+                  <span className="font-mono text-[0.72rem] font-bold text-ink group-hover:text-amber transition-colors">{ns.name}</span>
+                  <span className="text-[0.62rem] text-gray-mid ml-1.5">
+                    {ns.pubCount} {ns.pubCount === 1 ? 'pub' : 'pubs'}
+                    {ns.cheapestPrice !== 'TBC' && ` · from $${ns.cheapestPrice}`}
+                    {avgNum > 0 && Number(ns.avgPrice) > 0 && (
+                      Number(ns.avgPrice) < avgNum
+                        ? <span className="text-green ml-1">cheaper</span>
+                        : Number(ns.avgPrice) > avgNum
+                          ? <span className="text-red/70 ml-1">pricier</span>
+                          : null
+                    )}
+                  </span>
+                </Link>
+              ))}
+            </div>
           </div>
         </section>
       )}

--- a/src/lib/suburbStory.ts
+++ b/src/lib/suburbStory.ts
@@ -165,18 +165,9 @@ export function getSuburbStory(input: SuburbStoryInput): SuburbStory {
     })
   }
 
-  if (suburbAvgPrice !== null && verifiedCount >= 2 && perthAvgPrice > 0) {
-    const delta = suburbAvgPrice - perthAvgPrice
-    const relation = priceWord(delta)
-    cards.push({
-      id: 'average',
-      label: 'Suburb average',
-      title: money(suburbAvgPrice),
-      body: relation === 'about level with'
-        ? `${suburb.name} is about level with Perth's checked average of ${money(perthAvgPrice)}.`
-        : `${suburb.name} sits ${money(Math.abs(delta))} ${relation} Perth's checked average of ${money(perthAvgPrice)}.`,
-    })
-  }
+  // (No 'average' card — the suburb average + Perth comparison is already shown
+  // in the hero stat strip and the answer-first lead, so a card here just
+  // duplicates it and pads the grid to an odd count.)
 
   if (happyHourCount > 0) {
     const activeLine = activeHappyHourCount > 0


### PR DESCRIPTION
The live happy-hour panel on `/[suburb]` used `border-3 border-red/30` + `bg-red/5` with **no shadow** — a washed-out faded-pink box that read as low-quality next to the bold `border-3 border-ink` + `shadow-hard-sm` cards around it (incl. the "All Venues" table directly below it).

Rebuilt with the brand treatment: solid ink border + hard shadow + a saturated `bg-red-pale` header bar (ink bottom-divider, pulse dot, red title + count), white body, `gray-light` row dividers. Now consistent with the rest of the suburb page while keeping the red "live" accent.

Verified live via Chrome MCP on `/perth-cbd` (box currently active). tsc clean, 267 tests, lint clean.