### PR TITLE
Receipt-style price card as the pub template (all 857 pubs)

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,12 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Pub page receipt card — site-wide template (2026-06-05)
+- **`feat/pub-receipt-card`:** the pint price card on `/[suburb]/[pub]` is now the "receipt" for every pub — an amber-headed docket (`★ Perth Pint Prices ★` banner + venue name in DM Serif), the hero price, an itemised dotted-leader sheet (Standard pint · Happy hour · Cheaper nearby · Checked · Google rating), amenity stamps, and an in-card report CTA. New self-contained `src/components/PintReceipt.tsx`; the throwaway `_receipt-prototype/` route (A thermal docket / B raffle ticket / C banner card, toggled via a dev-gated `?variant` switcher) was deleted after C won.
+- **Unpriced pubs (most of the 857) handled:** TBC renders cleanly — no false "vs-avg" line, the CTA reads "Know the price?" not "a better price", and the Tier-C "nearest checked price" stub was lifted out of the old card into its own bordered block (verified on The Flaming Galah, Freo → "12 nearby pubs have a checked price — start with Whisper Wine Bar at $9.00").
+- **Page de-dup (the receipt owns this data now):** removed the dark "Quick read" answer-first box (its numbers live in the receipt + the FAQPage schema), the duplicate full-width report button, and the repeated rating/amenity chips below the card (`GoodToKnow` gained a `summaryOnly` prop → editorial blurb only). About + that blurb now share one bordered card instead of floating. Dropped the redundant "Family-friendly in {suburb}" subtitle (the vibe pill already says it).
+- **Verification:** `tsc` clean, **272 tests**, priced + unpriced pubs confirmed in-browser via DOM reads (Chrome screenshot capture wedges on the dev sticky Leaflet map).
+
 ### The Deen suburb correction (2026-06-05)
 - **Data fix (`scripts/fix-deen-suburb.mjs`):** The Deen (pub #7) was tagged `suburb = "North Perth"` but sits at 82 Aberdeen St, **Northbridge** — corrected to Northbridge. Surfaced by the content-review address/suburb audit (the venue is its own Pint-of-the-Day pick, so the wrong tag was visible, and it skewed the Northbridge cluster stats). The pub route looks pubs up by slug and 301-redirects on a suburb mismatch, so **`/north-perth/the-deen` now 308-redirects to `/northbridge/the-deen`** (verified) — no code redirect needed. Script is idempotent + guarded (only touches the row while it is still "North Perth" with a Northbridge address). The wider ~127 address/suburb mismatches stay deferred — most are false positives (CBD naming, border streets).
 

--- a/src/app/[suburb]/[pub]/PubDetailClient.tsx
+++ b/src/app/[suburb]/[pub]/PubDetailClient.tsx
@@ -8,25 +8,22 @@ import WatchlistButton from '@/components/WatchlistButton'
 import PriceHistory from '@/components/PriceHistory'
 import GoodToKnow from '@/components/GoodToKnow'
 import SubmitPubForm from '@/components/SubmitPubForm'
-import { PenLine } from 'lucide-react'
 import { formatHappyHourDays } from '@/lib/happyHourLive'
 import Footer from '@/components/Footer'
 import { pubUrl, suburbUrl } from '@/lib/urls'
 import {
-  answerBlock,
-  bestTime,
   cheaperNearby,
   faqHappyHourAnswer,
   faqNearbyAnswer,
   faqPriceAnswer,
   faqQuestion,
-  pubSubtitle,
   verificationStub,
 } from '@/lib/voiceCopy'
 import { formatDistance } from '@/lib/location'
 import { describePriceSource } from '@/lib/priceProvenance'
 import { trackSiteEvent } from '@/lib/analytics'
-import type { PriceRecencyInfo, PriceRecencyTier } from '@/lib/freshness'
+import type { PriceRecencyInfo } from '@/lib/freshness'
+import PintReceipt, { type PintReceiptData } from '@/components/PintReceipt'
 
 const PubDetailMap = dynamic(() => import('@/components/PubDetailMap'), {
   ssr: false,
@@ -140,12 +137,6 @@ export default function PubDetailClient({
     }
     : null
   const confidenceLabel = pub.priceConfidence === 'low' ? 'Low confidence' : null
-  const recencyBadgeClass: Record<PriceRecencyTier, string> = {
-    fresh: 'text-green bg-green-pale border-green',
-    aging: 'text-amber bg-amber-pale border-amber',
-    stale: 'text-amber bg-amber-pale border-amber',
-    unknown: 'text-gray-mid bg-off-white border-gray-light',
-  }
   const priceMissingCopy = isTierCPage
     ? verificationStub({
       lastAndrewCall: latestAndrewCallAt ? formatLastVerifiedDate(latestAndrewCallAt) : null,
@@ -154,44 +145,10 @@ export default function PubDetailClient({
       nearestPrice: nearestVerifiedPub?.price ?? null,
     })
     : null
-  const reportCtaLabel = isTierCPage ? 'Report the price' : 'Know the price? Report it here'
   const checkedDate = priceVerifiedAt ? formatLastVerifiedDate(priceVerifiedAt) : null
-  const subtitle = pub.vibeTag && pub.vibeTag.toLowerCase() !== 'pub'
-    ? pubSubtitle(pub.suburb, pub.vibeTag)
-    : null
-  const answerCopy = answerBlock({
-    pub: pub.name,
-    suburb: pub.suburb,
-    price: standardPrice,
-    suburbAvg: avgPrice,
-    checkedDate,
-  })
   const happyHourDaysText = formatReadableHappyHourDays(pub.happyHourDays)
   const happyHourStartText = formatHappyHourVoiceTime(pub.happyHourStart)
   const happyHourEndText = formatHappyHourVoiceTime(pub.happyHourEnd)
-  const bestTimeCopy = happyHourDaysText && happyHourStartText && happyHourEndText
-    ? pub.happyHourPrice
-      ? pub.isHappyHourNow
-        ? bestTime({
-          price: standardPrice,
-          hhActiveNow: true,
-          hhLaterToday: false,
-          hhStart: happyHourStartText,
-          hhEnd: happyHourEndText,
-          hhPrice: pub.happyHourPrice,
-          saving: standardPrice !== null ? standardPrice - pub.happyHourPrice : null,
-        })
-        : `Cheapest confirmed window: ${happyHourDaysText} ${happyHourStartText}-${happyHourEndText}, pints down to $${pub.happyHourPrice.toFixed(2)}.`
-      : `Confirmed happy-hour window: ${happyHourDaysText} ${happyHourStartText}-${happyHourEndText}. We still need the discount price.`
-    : bestTime({
-        price: standardPrice,
-        hhActiveNow: false,
-        hhLaterToday: false,
-        hhStart: null,
-        hhEnd: null,
-        hhPrice: pub.happyHourPrice,
-        saving: null,
-      })
   const cheaperNearbyList = currentPrice === null
     ? []
     : nearbyPubs
@@ -206,13 +163,43 @@ export default function PubDetailClient({
   const nearbySummary = nearbyPubs.length > 0 && currentPrice !== null
     ? cheaperNearby(pub.name, cheaperNearbyList, '2km')
     : null
-  const tierCQuickRead = isTierCPage && nearestVerifiedPub?.price !== null && nearestVerifiedPub?.price !== undefined
-    ? `Nearest checked pub: ${nearestVerifiedPub.name} in ${nearestVerifiedPub.suburb}, listed at $${nearestVerifiedPub.price.toFixed(2)}.`
-    : null
-  const quickReadCopy = answerCopy ?? tierCQuickRead
   const nearestCheaper = currentPrice === null
     ? null
     : nearbyPubs.find(nearby => nearby.price !== null && nearby.price < currentPrice)
+
+  // PROTOTYPE — flat data bundle for the receipt-card variants.
+  const receiptAmenities: string[] = []
+  if (pub.outdoorSeating) receiptAmenities.push('Beer garden')
+  if (pub.goodForWatchingSports) receiptAmenities.push('Shows the footy')
+  if (pub.goodForChildren) receiptAmenities.push('Kids welcome')
+  if (pub.allowsDogs) receiptAmenities.push('Dog-friendly')
+  if (pub.liveMusic) receiptAmenities.push('Live music')
+  if (pub.servesFood) receiptAmenities.push('Kitchen')
+  const receiptData: PintReceiptData = {
+    name: pub.name,
+    suburb: pub.suburb,
+    beerType: pub.beerType,
+    price: pub.price,
+    regularPrice: pub.regularPrice,
+    isHappyHourNow: pub.isHappyHourNow,
+    avgPrice,
+    priceDiff,
+    happyHour: (pub.happyHour || pub.happyHourPrice)
+      ? { days: formatReadableHappyHourDays(pub.happyHourDays), time: formatHappyHourTime(pub.happyHourStart, pub.happyHourEnd), price: pub.happyHourPrice }
+      : null,
+    checkedDate,
+    sourcePhrase: priceProvenance?.sourcePhrase ?? null,
+    confidenceLabel,
+    recencyLabel: priceRecency.label,
+    cheaperNearby: nearestCheaper && nearestCheaper.price !== null
+      ? { name: nearestCheaper.name, price: nearestCheaper.price, distance: nearestCheaper.distanceKm != null ? formatDistance(nearestCheaper.distanceKm) : nearestCheaper.suburb }
+      : null,
+    googleRating: pub.googleRating ?? null,
+    googleRatingCount: pub.googleRatingCount ?? null,
+    amenities: receiptAmenities,
+    editorialSummary: pub.googleEditorialSummary ?? null,
+  }
+
   const faqItems: PubFaq[] = [
     {
       question: faqQuestion('price', String(pub.id), pub.name),
@@ -307,9 +294,6 @@ export default function PubDetailClient({
               <span className="font-mono text-[0.6rem] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full border border-gray-light text-gray-mid">{pub.vibeTag}</span>
             )}
           </div>
-          {subtitle && (
-            <p className="mt-3 max-w-[36rem] font-body text-[0.95rem] leading-relaxed text-gray-mid">{subtitle}</p>
-          )}
         </div>
 
         {/* Permanently closed notice — Places business_status */}
@@ -329,141 +313,46 @@ export default function PubDetailClient({
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
           {/* Left column */}
           <div className="space-y-8">
-            {(quickReadCopy || bestTimeCopy || nearbySummary) && (
-              <section className="border-3 border-ink rounded-card bg-ink p-5 text-white shadow-hard-sm">
-                <p className="type-eyebrow text-white/55 mb-2">Quick read</p>
-                {quickReadCopy && (
-                  <p className="font-mono text-[1.05rem] font-extrabold leading-snug tracking-[-0.02em]">{quickReadCopy}</p>
+            {/* Pint price card — the receipt (every pub) */}
+            <PintReceipt data={receiptData} onReport={() => openReportForm('pub_page_cta')} />
+
+            {/* Missing-price stub — point unpriced pubs at the nearest checked price */}
+            {priceMissingCopy && (
+              <div className="border-3 border-ink rounded-card bg-white shadow-hard-sm px-5 py-4">
+                {nearestVerifiedPub ? (
+                  <Link
+                    href={pubUrl({ suburb: nearestVerifiedPub.suburb, slug: nearestVerifiedPub.slug })}
+                    onClick={() => trackSiteEvent('pub_nearby_click', {
+                      source: 'pub_missing_price_stub',
+                      pub_slug: pub.slug,
+                      suburb: pub.suburb,
+                      target_slug: nearestVerifiedPub.slug,
+                      target_suburb: nearestVerifiedPub.suburb,
+                      page_tier: trackingTier,
+                    })}
+                    className="block text-[0.86rem] leading-relaxed text-ink hover:text-amber transition-colors no-underline"
+                  >
+                    {priceMissingCopy}
+                  </Link>
+                ) : (
+                  <p className="text-[0.86rem] leading-relaxed text-ink">{priceMissingCopy}</p>
                 )}
-                <div className="mt-4 space-y-3 border-t border-white/15 pt-4">
-                  {bestTimeCopy && <p className="font-body text-[0.84rem] leading-relaxed text-white/75">{bestTimeCopy}</p>}
-                  {nearbySummary && <p className="font-body text-[0.84rem] leading-relaxed text-white/75">{nearbySummary}</p>}
-                </div>
+              </div>
+            )}
+
+            {/* About this pub — bordered card so the prose sits in the page rhythm.
+                Good-to-know is summary-only; the receipt carries rating + amenities. */}
+            {(pub.description || pub.googleEditorialSummary) && (
+              <section className="border-3 border-ink rounded-card bg-white shadow-hard-sm p-5 space-y-4">
+                {pub.description && (
+                  <div>
+                    <p className="type-eyebrow mb-2">About</p>
+                    <p className="text-[0.85rem] text-gray-mid leading-relaxed">{pub.description}</p>
+                  </div>
+                )}
+                <GoodToKnow pub={pub} summaryOnly />
               </section>
             )}
-
-            {/* Price ticket — "betting slip" receipt treatment (Variant B) */}
-            <div className="border-3 border-ink rounded-card bg-white shadow-hard-sm overflow-hidden">
-              {/* Ticket header bar */}
-              <div className="bg-ink text-white px-5 py-2.5 flex items-center justify-between gap-3">
-                <span className="type-eyebrow text-white/70">Pint price</span>
-                {pub.beerType && <span className="font-mono text-[0.65rem] text-white/55 truncate">{pub.beerType}</span>}
-              </div>
-
-              {/* Big price, centred */}
-              <div className="px-5 pt-6 pb-5 text-center">
-                {pub.isHappyHourNow && pub.regularPrice !== null && pub.regularPrice !== pub.price && (
-                  <div className="text-sm text-gray-mid line-through font-mono">${pub.regularPrice.toFixed(2)}</div>
-                )}
-                <div className="type-price text-[clamp(3.2rem,12vw,4.6rem)] mt-0.5">
-                  {pub.price !== null ? `$${pub.price.toFixed(2)}` : 'TBC'}
-                </div>
-                <div className="flex flex-wrap items-center justify-center gap-2 mt-3">
-                  {pub.effectivePrice && Math.abs(priceDiff) >= 0.05 && (
-                    <span className={`inline-block font-mono text-[0.65rem] font-bold px-2.5 py-1 rounded-full border ${
-                      priceDiff < 0
-                        ? 'bg-green-pale text-green border-green'
-                        : 'bg-red-pale text-red border-red'
-                    }`}>
-                      ${Math.abs(priceDiff).toFixed(2)} {priceDiff < 0 ? 'below' : 'above'} avg
-                    </span>
-                  )}
-                  {pub.isHappyHourNow && (
-                    <span className="inline-flex items-center gap-1.5 font-mono text-[0.6rem] font-bold uppercase tracking-wider text-red bg-red-pale px-2.5 py-1 rounded-full border border-red">
-                      HH{pub.happyHourMinutesRemaining ? ` · ${pub.happyHourMinutesRemaining < 1 ? 'ending soon' : pub.happyHourMinutesRemaining < 60 ? `${pub.happyHourMinutesRemaining}m left` : `${Math.floor(pub.happyHourMinutesRemaining / 60)}h ${pub.happyHourMinutesRemaining % 60 > 0 ? `${pub.happyHourMinutesRemaining % 60}m ` : ''}left`}` : ''}
-                    </span>
-                  )}
-                  {pub.price !== null && (
-                    <span
-                      className={`inline-flex items-center gap-1 font-mono text-[0.65rem] font-bold px-2.5 py-1 rounded-full border ${recencyBadgeClass[priceRecency.tier]}`}
-                      title={pub.lastVerified ? `Last verified ${formatLastVerifiedDate(pub.lastVerified)}` : undefined}
-                    >
-                      {priceRecency.label}
-                    </span>
-                  )}
-                </div>
-                {priceProvenance && (
-                  <p className="mt-3 font-mono text-[0.62rem] leading-relaxed text-gray-mid">
-                    Checked {priceProvenance.sourcePhrase} on <time dateTime={priceProvenance.verifiedAt}>{priceProvenance.verifiedDate}</time>
-                    {confidenceLabel && ` · ${confidenceLabel}`}
-                  </p>
-                )}
-              </div>
-
-              {/* Receipt row — happy hour */}
-              {(pub.happyHour || pub.happyHourPrice) && (
-                <div className={`px-5 py-3.5 border-t-2 border-dashed ${pub.isHappyHourNow ? 'border-red' : 'border-gray-light'}`}>
-                  <div className="flex items-baseline gap-2">
-                    <span className="type-eyebrow whitespace-nowrap">Happy hour</span>
-                    <span className="flex-1 border-b border-dashed border-gray-light translate-y-[-3px]" />
-                    {pub.happyHourPrice && (
-                      <span className={`font-mono text-[0.92rem] font-extrabold ${pub.isHappyHourNow ? 'text-red' : 'text-ink'}`}>${pub.happyHourPrice.toFixed(2)}</span>
-                    )}
-                  </div>
-                  {pub.happyHourDays && pub.happyHourStart && pub.happyHourEnd ? (
-                    <p className="text-[0.78rem] text-gray-mid mt-1 text-right">
-                      {formatReadableHappyHourDays(pub.happyHourDays)} · {formatHappyHourTime(pub.happyHourStart, pub.happyHourEnd)}
-                    </p>
-                  ) : (
-                    <div className="text-[0.78rem] text-gray-mid mt-1 text-right">
-                      {pub.happyHourDays && <p>{formatReadableHappyHourDays(pub.happyHourDays)}</p>}
-                      {pub.happyHourStart && pub.happyHourEnd && (
-                        <p>{formatHappyHourTime(pub.happyHourStart, pub.happyHourEnd)}</p>
-                      )}
-                      {!pub.happyHourPrice && !pub.happyHourStart && pub.happyHour && <p>{pub.happyHour}</p>}
-                    </div>
-                  )}
-                </div>
-              )}
-
-              {/* Tier-C / missing-price verification stub */}
-              {priceMissingCopy && (
-                <div className="px-5 py-4 border-t-2 border-dashed border-gray-light">
-                  {nearestVerifiedPub ? (
-                    <Link
-                      href={pubUrl({ suburb: nearestVerifiedPub.suburb, slug: nearestVerifiedPub.slug })}
-                      onClick={() => trackSiteEvent('pub_nearby_click', {
-                        source: 'pub_missing_price_stub',
-                        pub_slug: pub.slug,
-                        suburb: pub.suburb,
-                        target_slug: nearestVerifiedPub.slug,
-                        target_suburb: nearestVerifiedPub.suburb,
-                        page_tier: trackingTier,
-                      })}
-                      className="block text-[0.86rem] leading-relaxed text-ink hover:text-amber transition-colors no-underline"
-                    >
-                      {priceMissingCopy}
-                    </Link>
-                  ) : (
-                    <p className="text-[0.86rem] leading-relaxed text-ink">{priceMissingCopy}</p>
-                  )}
-                </div>
-              )}
-            </div>
-
-            {/* Report a price — prominent CTA */}
-            <button
-              onClick={() => openReportForm('pub_page_cta')}
-              className={`w-full flex items-center justify-center gap-2 font-mono font-bold uppercase tracking-[0.05em] border-3 border-ink rounded-pill shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all ${
-                isTierCPage
-                  ? 'text-white bg-amber py-4 text-[0.85rem]'
-                  : 'text-amber bg-amber-pale py-3 text-[0.78rem]'
-              }`}
-            >
-              <PenLine className="w-4 h-4" />
-              {reportCtaLabel}
-            </button>
-
-            {/* About */}
-            {pub.description && (
-              <div>
-                <p className="type-eyebrow mb-2">About</p>
-                <p className="text-[0.85rem] text-gray-mid leading-relaxed">{pub.description}</p>
-              </div>
-            )}
-
-            {/* Good to know — sourced Places attributes */}
-            <GoodToKnow pub={pub} />
 
             {/* Price History */}
             <PriceHistory pubId={pub.id} currentPrice={pub.price} />

--- a/src/components/GoodToKnow.tsx
+++ b/src/components/GoodToKnow.tsx
@@ -25,9 +25,9 @@ function formatDate(value: string): string {
   return new Date(value).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: 'numeric' })
 }
 
-export default function GoodToKnow({ pub }: { pub: Pub }) {
-  const chips = CHIPS.filter(({ key }) => pub[key] === true)
-  const hasRating = pub.googleRating != null
+export default function GoodToKnow({ pub, summaryOnly = false }: { pub: Pub; summaryOnly?: boolean }) {
+  const chips = summaryOnly ? [] : CHIPS.filter(({ key }) => pub[key] === true)
+  const hasRating = !summaryOnly && pub.googleRating != null
   const summary = pub.googleEditorialSummary
 
   if (chips.length === 0 && !hasRating && !summary) return null
@@ -65,7 +65,7 @@ export default function GoodToKnow({ pub }: { pub: Pub }) {
         </p>
       )}
 
-      {pub.googleAttrsUpdatedAt && (
+      {pub.googleAttrsUpdatedAt && !summaryOnly && (
         <p className="mt-2 font-mono text-[0.6rem] text-gray-mid">
           Per Google, checked{' '}
           <time dateTime={pub.googleAttrsUpdatedAt}>{formatDate(pub.googleAttrsUpdatedAt)}</time>

--- a/src/components/PintReceipt.tsx
+++ b/src/components/PintReceipt.tsx
@@ -1,0 +1,124 @@
+import { type ReactNode } from 'react'
+import { PenLine } from 'lucide-react'
+
+/**
+ * Data the pint receipt renders. `price` is the happy-hour-aware effective price
+ * shown as the hero; `regularPrice` is the standard pint. Unpriced pubs pass
+ * null prices and render cleanly as "TBC".
+ */
+export interface PintReceiptData {
+  name: string
+  suburb: string
+  beerType: string
+  price: number | null          // effective (HH-aware) price shown as the hero
+  regularPrice: number | null
+  isHappyHourNow: boolean
+  avgPrice: number
+  priceDiff: number             // effective - city avg ; negative = below avg (good)
+  happyHour: { days: string | null; time: string | null; price: number | null } | null
+  checkedDate: string | null
+  sourcePhrase: string | null
+  confidenceLabel: string | null
+  recencyLabel: string
+  cheaperNearby: { name: string; price: number; distance: string } | null
+  googleRating: number | null
+  googleRatingCount: number | null
+  amenities: string[]
+  editorialSummary: string | null
+}
+
+const money = (n: number | null) => (n == null ? 'TBC' : `$${n.toFixed(2)}`)
+
+function vsAvg(d: PintReceiptData) {
+  if (Math.abs(d.priceDiff) < 0.05) return { text: 'on the city average', cls: 'text-gray-mid' }
+  const below = d.priceDiff < 0
+  return { text: `${money(Math.abs(d.priceDiff))} ${below ? 'below' : 'above'} avg`, cls: below ? 'text-green' : 'text-red' }
+}
+
+/** LABEL ········ VALUE — dotted leader line. */
+function Leader({ label, value, valueClass = 'text-ink' }: { label: string; value: ReactNode; valueClass?: string }) {
+  return (
+    <div className="flex items-baseline gap-1.5">
+      <span className="font-mono text-[0.72rem] uppercase tracking-[0.02em] text-gray-mid">{label}</span>
+      <span className="flex-1 border-b border-dotted border-gray-mid/50 translate-y-[-3px]" />
+      <span className={`font-mono text-[0.78rem] font-bold whitespace-nowrap ${valueClass}`}>{value}</span>
+    </div>
+  )
+}
+
+function Stars({ rating }: { rating: number }) {
+  const full = Math.round(rating)
+  return <span className="text-amber tracking-[0.1em]">{'★★★★★'.slice(0, full)}<span className="text-gray-light">{'★★★★★'.slice(full)}</span></span>
+}
+
+/**
+ * Pint price card — the "receipt" on every pub page. An amber-headed docket:
+ * venue banner, the hero price, an itemised sheet (standard pint, happy hour,
+ * cheaper-nearby, checked date, Google rating), amenity stamps, and a report CTA.
+ * Unpriced pubs render "TBC" cleanly — no vs-average line, and the CTA asks for
+ * the price rather than a better one.
+ */
+export default function PintReceipt({ data, onReport }: { data: PintReceiptData; onReport: () => void }) {
+  const v = vsAvg(data)
+  return (
+    <div className="border-3 border-ink rounded-card bg-white shadow-hard-sm overflow-hidden">
+      {/* Banner */}
+      <div className="bg-amber border-b-3 border-ink px-4 py-2.5 text-center text-ink">
+        <p className="font-mono text-[0.55rem] font-bold uppercase tracking-[0.2em]">★ Perth Pint Prices ★</p>
+        <p className="font-display text-[1.2rem] leading-none mt-1">{data.name}</p>
+        <p className="font-mono text-[0.5rem] uppercase tracking-[0.22em] mt-1">{data.suburb}{data.beerType ? ` · ${data.beerType}` : ''}</p>
+      </div>
+
+      {/* Price */}
+      <div className="px-5 py-4 text-center border-b-2 border-dashed border-ink">
+        <p className="font-mono text-[0.55rem] uppercase tracking-[0.2em] text-gray-mid">{data.isHappyHourNow ? 'Pouring now' : 'Pint price'}</p>
+        {data.isHappyHourNow && data.regularPrice != null && data.regularPrice !== data.price && (
+          <p className="font-mono text-[0.8rem] text-gray-mid line-through">{money(data.regularPrice)}</p>
+        )}
+        <p className="type-price text-[clamp(2.8rem,11vw,3.8rem)] leading-none">{money(data.price)}</p>
+        {data.price != null && <p className={`font-mono text-[0.7rem] font-bold ${v.cls}`}>{v.text}</p>}
+      </div>
+
+      {/* Itemised rows */}
+      <div className="px-5 py-3 space-y-1.5">
+        <Leader label="Standard pint" value={money(data.regularPrice)} />
+        {data.happyHour && (
+          <Leader
+            label="Happy hour"
+            value={`${data.happyHour.price ? money(data.happyHour.price) : 'TBC'}${data.happyHour.days ? ` · ${data.happyHour.days}` : ''}${data.happyHour.time ? ` ${data.happyHour.time}` : ''}`}
+            valueClass={data.happyHour.price ? 'text-red' : 'text-gray-mid'}
+          />
+        )}
+        {data.cheaperNearby && (
+          <>
+            <Leader label="Cheaper nearby" value={money(data.cheaperNearby.price)} valueClass="text-green" />
+            <Leader label={data.cheaperNearby.name} value={data.cheaperNearby.distance} valueClass="text-gray-mid" />
+          </>
+        )}
+        {data.checkedDate && <Leader label="Checked" value={`${data.checkedDate}${data.sourcePhrase ? ` · ${data.sourcePhrase}` : ''}`} />}
+        {data.googleRating != null && (
+          <Leader label="Google" value={<><Stars rating={data.googleRating} /> {data.googleRating.toFixed(1)} ({data.googleRatingCount?.toLocaleString()})</>} />
+        )}
+      </div>
+
+      {data.amenities.length > 0 && (
+        <div className="px-5 pb-1 flex flex-wrap gap-1">
+          {data.amenities.map(a => (
+            <span key={a} className="font-mono text-[0.55rem] uppercase tracking-[0.05em] border border-ink/40 px-1.5 py-0.5 text-ink">{a}</span>
+          ))}
+        </div>
+      )}
+
+      {/* Report CTA */}
+      <div className="m-4 mt-3 border-2 border-ink rounded-card bg-amber-pale px-3 py-2.5 flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <p className="font-mono text-[0.5rem] uppercase tracking-[0.12em] text-gray-mid">Help keep prices honest</p>
+          <p className="font-mono text-[0.66rem] font-bold text-ink">{data.price == null ? 'Know the price?' : 'Know a better price?'}</p>
+        </div>
+        <button onClick={onReport} className="shrink-0 flex items-center gap-1.5 font-mono text-[0.6rem] font-bold uppercase tracking-[0.05em] text-white bg-ink border-2 border-ink rounded-pill px-3 py-1.5 hover:bg-amber hover:text-ink transition-colors">
+          <PenLine className="w-3 h-3" /> Report a price
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/tests/e2e/pr-proof.spec.ts
+++ b/tests/e2e/pr-proof.spec.ts
@@ -24,8 +24,10 @@ test('pub page renders price, freshness, map, and nearby prices', async ({ page 
 
   await expect(page.getByRole('heading', { name: 'The Court Hotel' })).toBeVisible()
   await expect(page.getByText(/pint price/i).first()).toBeVisible()
-  await expect(page.getByText(/Checked \d+d ago/i)).toBeVisible()
-  await expect(page.getByText(/Cheaper nearby|Nearby verified prices/i)).toBeVisible()
+  // Freshness: the receipt shows an absolute "Checked <date>" (e.g. "17 Feb 2026")
+  await expect(page.getByText(/Checked/i).first()).toBeVisible()
+  await expect(page.getByText(/\d{1,2} [A-Z][a-z]{2} \d{4}/).first()).toBeVisible()
+  await expect(page.getByText(/Cheaper nearby|Nearby verified prices/i).first()).toBeVisible()
   await expect(page.locator('.leaflet-container')).toBeVisible()
 
   await attachProof(page, testInfo, 'pub-page')


### PR DESCRIPTION
## What

The pint price card on `/[suburb]/[pub]` is now the **receipt** for every pub — an amber-headed docket: `★ Perth Pint Prices ★` banner + venue name (DM Serif), the hero price, an itemised dotted-leader sheet (Standard pint · Happy hour · Cheaper nearby · Checked · Google rating), amenity stamps, and an in-card report CTA.

Chosen from a throwaway `?variant` prototype (A thermal docket / B raffle ticket / C banner card); C won, prototype folder deleted. New self-contained component `src/components/PintReceipt.tsx`.

## Also folded in (the receipt owns this data now)

- **Unpriced pubs (most of the 857):** render `TBC` cleanly — no false vs-average line, CTA reads "Know the price?", and the Tier-C "nearest checked price" stub is preserved as its own bordered block.
- Removed the dark **Quick read** answer-first box (numbers now live in the receipt + the FAQPage schema).
- De-duped: dropped the duplicate full-width report button and the repeated rating/amenity chips below the card (`GoodToKnow` gained a `summaryOnly` prop).
- **About** + the editorial blurb now share one bordered card instead of floating.
- Dropped the redundant "Family-friendly in {suburb}" subtitle (the vibe pill already says it).

## Verification

- `tsc --noEmit` clean · **272 tests** pass
- In-browser (DOM reads — screenshot capture wedges on the dev sticky Leaflet map): **priced** (Guildford Hotel, \$9.00) and **unpriced** (The Flaming Galah, Freo → TBC + "12 nearby pubs have a checked price — start with Whisper Wine Bar at \$9.00")

🤖 Generated with [Claude Code](https://claude.com/claude-code)