### PR TITLE
SEO: exact price schema + answer-first line + happy-hour titles for pub pages

### DIFF
--- a/.claude/seo-content.config.md
+++ b/.claude/seo-content.config.md
@@ -1,0 +1,105 @@
+# seo-content — project config
+
+Written by the `seo-content` skill's `init`. Read by every mode. Keep it committed — it's the project's SEO contract.
+
+```yaml
+project:
+  name: Perth Pint Prices
+  framework: Next.js 14 (App Router)
+  render_mode: hybrid          # SSG for Tier-A pubs (generateStaticParams) + ISR (revalidate 3600) + dynamicParams for Tier-B; all server-rendered HTML → crawlable ✓ (verified via curl)
+  language: en-AU
+  primary_domain: https://perthpintprices.com
+
+data_layer:
+  provider: ahrefs-mcp
+  ahrefs_project_id:           # BLANK — confirm which Ahrefs project maps to perthpintprices.com
+  csv_path:
+  notes: >
+    Ahrefs MCP connected. Money values are USD cents (÷100). Per-pub queries
+    ("[pub] pint price") are long-tail with ~no individual volume — their value is
+    aggregate + AI/answer citations (the SERP is wide open; nobody answers the price).
+    Use Ahrefs for the higher-volume suburb/discover money pages, not the pub template.
+
+keywords:
+  store: docs/seo/keywords.md  # BLANK/not-yet-created — proposed location
+  published_index: >
+    Supabase `pubs` table (857 rows) → /[suburb]/[pub]; suburbs → /[suburb];
+    indexable set in /sitemap.xml. A keyword is "covered" if a matching pub/suburb page exists.
+
+content:
+  blog:
+    location: src/app/articles/[slug]/ , src/app/guides/* , src/app/insights/*
+    format: data-driven tsx (article objects in code — NOT markdown/MDX)
+    index_page: /discover  (the /articles, /guides, /insights hubs 308-redirect here)
+    frontmatter: n/a (articles are typed objects, not files)
+    output: brief
+    writer_handoff: none dedicated — run the `humanizer` skill on new user-facing copy
+  programmatic:
+    exists: true
+    route_pattern: /[suburb]/[pub]  (+ /[suburb] aggregate pages)
+    data_source: Supabase `pubs` table (857 pubs)
+    template_file: >
+      src/app/[suburb]/[pub]/PubDetailClient.tsx (+ page.tsx metadata/JSON-LD,
+      src/lib/pubJsonLd.ts, src/lib/voiceCopy.ts, src/lib/pubIndexability.ts)
+    matrix: pub × suburb (one page per real venue; suburb pages aggregate)
+    output: audit                # audit/optimize only — never generate parallel duplicates
+    ceiling: 857 (1 per real venue; thin/dataless pubs gated to noindex by pubIndexability tier C)
+
+voice:
+  source: docs/brand-voice-brief.md (+ content-pack-v1.md §7) — the "PPP dry register"
+  reference_files: docs/   (voiceCopy.ts holds the rendered per-state strings)
+
+images:
+  provider: pexels             # key not yet wired (pending: rotate + add PEXELS_API_KEY)
+  api_key_env: PEXELS_API_KEY
+
+onpage:
+  targets: internal_links 3-5  # pub pages already emit sr-only crawler links + nearby + breadcrumb
+
+technical:
+  sitemap: /sitemap.xml        # generated; lists indexable (Tier A/B) pubs, excludes Tier C noindex + permanently-closed
+  robots: /robots.txt
+  lighthouse_target: 100
+  schema: >
+    BarOrPub (LocalBusiness) with Offer/MenuItem (exact pint + happy-hour price),
+    FAQPage, BreadcrumbList, WebPage, OpeningHoursSpecification,
+    LocationFeatureSpecification, PostalAddress, GeoCoordinates
+
+deploy:
+  platform: vercel
+  repo: github.com/iamjohnnymac/perthpintprices
+  branch_flow: >
+    PR to main via gh; GitHub Actions "Typecheck, lint, build" (incl. Playwright
+    pr-proof e2e) is the gate — Vercel passing is NOT enough; Vercel auto-deploys main.
+
+search_console:
+  property:                    # BLANK — confirm (likely sc-domain:perthpintprices.com; GSC data already used in docs/seo-action-plan.md)
+  sitemap_submitted: unknown
+
+cadence:
+  blog_per_day_start: 1
+  blog_ramp:                   # data-driven articles, not a daily blog cadence
+  service_ceiling: 857         # no net-new programmatic generation — audit/optimize the existing template only
+
+guardrails:
+  url_slug_freeze: true        # pub/suburb slugs are canonical + 308-redirected; never change existing URLs
+  notes: >
+    Run `humanizer` on new user-facing copy. Verify pub pages via DOM reads — Chrome
+    screenshots wedge on the sticky Leaflet map (see memory). tsc + full test suite +
+    the pr-proof e2e must pass before merge.
+
+integrations:
+  writer: humanizer skill (copy de-AI-ing)
+  editor: /code-review , /simplify
+  voice_ci: humanizer (manual)
+```
+
+## Blanks to confirm
+- `data_layer.ahrefs_project_id` — which Ahrefs project is perthpintprices.com.
+- `search_console.property` — likely `sc-domain:perthpintprices.com` (GSC + GA4 data already referenced in `docs/seo-action-plan.md`).
+- `keywords.store` — proposed `docs/seo/keywords.md`; not created yet.
+
+## Notes
+- **Render mode is crawlable** (server-rendered HTML) — the usual ranking-killer is not an issue here.
+- **Pub pages are `output: audit`** — they're generated from the `pubs` table; optimize the template, never generate duplicates. Thin pubs are gated to `noindex` by `src/lib/pubIndexability.ts` (Tier C), so there's no thin-content ceiling risk.
+- The real "money" pages for keyword work are the **suburb / discover / insight** pages (e.g. "cheap pints {suburb}", "happy hour perth") — that's where an Ahrefs `keywords` pass pays off next.

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,15 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Pub page SEO: price schema + answer-first + happy-hour titles (2026-06-05)
+- **`feat/pub-page-seo`:** an SEO audit (via the `seo-content` skill) of the post-receipt pub template found the pages under-optimised for a wide-open SERP — searching "how much is a pint at [pub]" returns TripAdvisor / booking sites, none of which answer the price. Three fixes, hitting every priced/HH pub at once:
+  - **Exact price in structured data** (`pubJsonLd.ts`): added `makesOffer` → `Offer`/`MenuItem` with the real pint price (+ happy-hour price) in AUD — previously the price was only a coarse `priceRange: "$$"`. Now machine-readable for rich results + AI answers.
+  - **Answer-first line + FAQPage** (`PubDetailClient.tsx`): a plain, un-boxed one-line answer under the H1 — "A pint at {pub} is ${price}, last checked {date}." — restoring the extractable answer the removed Quick-read box used to carry; plus `FAQPage` JSON-LD emitted from the price/HH/nearby Q&A (visible-FAQ gate lowered 3→2 so it renders + matches the schema). FAQ now uses the real **suburb** average (was the city average, mislabelled).
+  - **Happy-hour titles** (`page.tsx` + `voiceCopy.ts`): HH-only pubs (no standard price) now title "$6.00 happy-hour pints" / meta "pours a $6 pint during happy hour…" instead of the flaky "Price TBC" (old title keyed off the time-dependent effective price, so it flipped in/out of HH).
+- **Already good, left alone:** SSR/crawlable render, tiered indexability (dataless pubs `noindex`), self-canonicals, breadcrumb + LocalBusiness schema, internal linking; `aggregateRating` correctly omitted (can't claim Google's stars as first-party).
+- **Deferred (#4, next):** thin per-page content depth — the bigger lever is the suburb/discover/insight "money" pages feeding link equity down; an Ahrefs keyword pass goes there. Added `.claude/seo-content.config.md`.
+- **Verification:** `tsc` clean, 272 tests, signals confirmed in rendered HTML (Offers, answer line, FAQPage, HH titles) on priced + HH-only pubs.
+
 ### Pub page receipt card — site-wide template (2026-06-05)
 - **`feat/pub-receipt-card`:** the pint price card on `/[suburb]/[pub]` is now the "receipt" for every pub — an amber-headed docket (`★ Perth Pint Prices ★` banner + venue name in DM Serif), the hero price, an itemised dotted-leader sheet (Standard pint · Happy hour · Cheaper nearby · Checked · Google rating), amenity stamps, and an in-card report CTA. New self-contained `src/components/PintReceipt.tsx`; the throwaway `_receipt-prototype/` route (A thermal docket / B raffle ticket / C banner card, toggled via a dev-gated `?variant` switcher) was deleted after C won.
 - **Unpriced pubs (most of the 857) handled:** TBC renders cleanly — no false "vs-avg" line, the CTA reads "Know the price?" not "a better price", and the Tier-C "nearest checked price" stub was lifted out of the old card into its own bordered block (verified on The Flaming Galah, Freo → "12 nearby pubs have a checked price — start with Whisper Wine Bar at $9.00").

--- a/src/app/[suburb]/[pub]/PubDetailClient.tsx
+++ b/src/app/[suburb]/[pub]/PubDetailClient.tsx
@@ -75,6 +75,7 @@ interface PubDetailClientProps {
   priceRecency: PriceRecencyInfo
   nearbyPubs: Pub[]
   avgPrice: number
+  suburbAvgPrice: number | null
   isTierCPage: boolean
   latestAndrewCallAt: string | null
   nearestVerifiedPub: Pub | null
@@ -86,6 +87,7 @@ export default function PubDetailClient({
   priceRecency,
   nearbyPubs,
   avgPrice,
+  suburbAvgPrice,
   isTierCPage,
   latestAndrewCallAt,
   nearestVerifiedPub,
@@ -146,6 +148,15 @@ export default function PubDetailClient({
     })
     : null
   const checkedDate = priceVerifiedAt ? formatLastVerifiedDate(priceVerifiedAt) : null
+  // Answer-first line (SEO/AEO) — directly answers "how much is a pint at X".
+  const hhWindowText = pub.happyHourDays && pub.happyHourStart && pub.happyHourEnd
+    ? `${formatReadableHappyHourDays(pub.happyHourDays)} ${formatHappyHourTime(pub.happyHourStart, pub.happyHourEnd)}`
+    : null
+  const answerLine = pub.regularPrice != null
+    ? `A pint at ${pub.name} is $${pub.regularPrice.toFixed(2)}${checkedDate ? `, last checked ${checkedDate}` : ''}.`
+    : pub.happyHourPrice != null
+      ? `${pub.name} pours a $${pub.happyHourPrice.toFixed(2)} pint during happy hour${hhWindowText ? ` (${hhWindowText})` : ''}. Standard price not confirmed yet.`
+      : null
   const happyHourDaysText = formatReadableHappyHourDays(pub.happyHourDays)
   const happyHourStartText = formatHappyHourVoiceTime(pub.happyHourStart)
   const happyHourEndText = formatHappyHourVoiceTime(pub.happyHourEnd)
@@ -207,7 +218,7 @@ export default function PubDetailClient({
         pub: pub.name,
         suburb: pub.suburb,
         price: standardPrice,
-        suburbAvg: avgPrice,
+        suburbAvg: suburbAvgPrice,
         checkedDate,
       }),
     },
@@ -237,7 +248,18 @@ export default function PubDetailClient({
       ),
     },
   ].filter((item): item is PubFaq => Boolean(item.answer))
-  const showFaq = faqItems.length >= 3
+  const showFaq = faqItems.length >= 2
+  const faqPageJsonLd = showFaq
+    ? {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: faqItems.map(item => ({
+        '@type': 'Question',
+        name: item.question,
+        acceptedAnswer: { '@type': 'Answer', text: item.answer },
+      })),
+    }
+    : null
   const trackingTier = isTierCPage ? 'tier_c' : 'priced'
 
   function openReportForm(source: string) {
@@ -283,7 +305,7 @@ export default function PubDetailClient({
           <span className="text-ink font-bold">{pub.name}</span>
         </nav>
 
-        {/* Name + vibe */}
+        {/* Name + vibe + answer-first line */}
         <div>
           <h1 className="type-hero">
             {pub.name}
@@ -294,6 +316,9 @@ export default function PubDetailClient({
               <span className="font-mono text-[0.6rem] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full border border-gray-light text-gray-mid">{pub.vibeTag}</span>
             )}
           </div>
+          {answerLine && (
+            <p className="mt-3 max-w-[42rem] font-body text-[0.95rem] leading-relaxed text-ink">{answerLine}</p>
+          )}
         </div>
 
         {/* Permanently closed notice — Places business_status */}
@@ -477,6 +502,12 @@ export default function PubDetailClient({
           </section>
         )}
 
+        {showFaq && faqPageJsonLd && (
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageJsonLd).replace(/</g, '\\u003c') }}
+          />
+        )}
         {showFaq && (
           <section className="border-3 border-ink rounded-card bg-white p-5 shadow-hard-sm">
             <div className="mb-4 flex items-center justify-between gap-3">

--- a/src/app/[suburb]/[pub]/page.tsx
+++ b/src/app/[suburb]/[pub]/page.tsx
@@ -85,18 +85,23 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   const indexability = getPubPageIndexability(pub)
   const suburbAvgPrice = await getSuburbAveragePrice(pub.suburb)
-  const price = pub.regularPrice ?? pub.price
-  const priceText = price !== null ? `$${price.toFixed(2)} pints` : 'Price TBC'
+  const hhPrice = typeof pub.happyHourPrice === 'number' && pub.happyHourPrice > 0 ? pub.happyHourPrice : null
+  const stablePrice = pub.regularPrice ?? hhPrice
+  const isHappyHourOnly = pub.regularPrice == null && hhPrice != null
+  const priceText = stablePrice !== null
+    ? `$${stablePrice.toFixed(2)} ${isHappyHourOnly ? 'happy-hour pints' : 'pints'}`
+    : 'Price TBC'
   const title = `${pub.name}, ${pub.suburb}: ${priceText}`
+  const hhWindow = formatMetaHappyHourLabel(pub.happyHourLabel)
   const description = pubMetaDescription({
     pub: pub.name,
     suburb: pub.suburb,
-    price,
+    price: pub.regularPrice,
     suburbAvg: suburbAvgPrice,
     checkedDate: formatMetaDate(pub.priceVerifiedAt || pub.lastVerified),
-    hhClause: formatMetaHappyHourLabel(pub.happyHourLabel)
-      ? `Happy hour: ${formatMetaHappyHourLabel(pub.happyHourLabel)}.`
-      : null,
+    hhClause: hhWindow ? `Happy hour: ${hhWindow}.` : null,
+    hhPrice,
+    hhWindow,
   })
 
   const canonical = absolutePubUrl(pub)
@@ -193,6 +198,7 @@ export default async function PubPage({ params }: PageProps) {
         priceRecency={priceRecency}
         nearbyPubs={nearbyPubs}
         avgPrice={Number(stats.avgPrice)}
+        suburbAvgPrice={suburbAvgPrice}
         isTierCPage={isTierCPage}
         latestAndrewCallAt={latestAndrewCallAt}
         nearestVerifiedPub={nearestVerifiedPub}

--- a/src/lib/pubJsonLd.ts
+++ b/src/lib/pubJsonLd.ts
@@ -141,6 +141,33 @@ function buildAmenityFeatures(pub: Pub): JsonLdNode[] {
     .map(([, name]) => ({ '@type': 'LocationFeatureSpecification', name, value: true }))
 }
 
+// The actual pint price(s) as Offers — the whole point of the site, made
+// machine-readable (rich results / AI answers). Standard pint + happy-hour pint.
+function buildOffers(pub: Pub): JsonLdNode[] {
+  const offers: JsonLdNode[] = []
+  const itemName = pub.beerType ? `Pint (${pub.beerType})` : 'Pint of beer'
+  if (typeof pub.regularPrice === 'number' && pub.regularPrice > 0) {
+    offers.push({
+      '@type': 'Offer',
+      name: 'Pint',
+      price: pub.regularPrice.toFixed(2),
+      priceCurrency: 'AUD',
+      availability: 'https://schema.org/InStock',
+      itemOffered: { '@type': 'MenuItem', name: itemName },
+    })
+  }
+  if (typeof pub.happyHourPrice === 'number' && pub.happyHourPrice > 0) {
+    offers.push({
+      '@type': 'Offer',
+      name: 'Happy hour pint',
+      price: pub.happyHourPrice.toFixed(2),
+      priceCurrency: 'AUD',
+      itemOffered: { '@type': 'MenuItem', name: itemName },
+    })
+  }
+  return offers
+}
+
 function buildPriceRange(price: number | null, avgPrice: number): string | null {
   if (price === null || price <= 0) return null
   if (avgPrice > 0) {
@@ -194,6 +221,10 @@ export function buildPubJsonLd(pub: Pub, avgPrice: number): JsonLdNode {
   }
   if (amenityFeature.length > 0) {
     barOrPub.amenityFeature = amenityFeature
+  }
+  const offers = buildOffers(pub)
+  if (offers.length > 0) {
+    barOrPub.makesOffer = offers
   }
 
   return {

--- a/src/lib/voiceCopy.ts
+++ b/src/lib/voiceCopy.ts
@@ -165,9 +165,15 @@ export interface PubMetaData {
   checkedDate: string | null
   hhClause?: string | null
   nearbyCheaperClause?: string | null
+  hhPrice?: number | null
+  hhWindow?: string | null
 }
 export function pubMetaDescription(d: PubMetaData): string {
   if (d.price == null) {
+    if (d.hhPrice != null && d.hhPrice > 0) {
+      const window = d.hhWindow ? ` (${d.hhWindow})` : ''
+      return `${d.pub} pours a ${money(d.hhPrice)} pint during happy hour${window} in ${d.suburb}. Standard price not confirmed yet.`
+    }
     const tail = d.nearbyCheaperClause ? ` ${d.nearbyCheaperClause}` : ''
     return `No verified pint price at ${d.pub} in ${d.suburb} yet.${tail}`.trim()
   }


### PR DESCRIPTION
## What & why

An audit (via the `seo-content` skill) of the new receipt pub template found it under-optimised for a **wide-open SERP**: searching *"how much is a pint at [pub]"* returns TripAdvisor + booking sites, **none of which answer the price**. Three fixes make the page the answer — across every priced/HH pub at once.

## #1 — Exact price in structured data
`pubJsonLd.ts`: `makesOffer` → `Offer` / `MenuItem` with the real pint price (+ happy-hour price) in AUD. Was only a coarse `priceRange: "$$"`. Now machine-readable for rich results + AI answers.

## #2 — Answer-first text + FAQPage
`PubDetailClient.tsx`: a plain, un-boxed one-line answer under the H1 (*"A pint at {pub} is ${price}, last checked {date}."*) — restoring the extractable answer the removed Quick-read box carried. Plus `FAQPage` JSON-LD from the price/HH/nearby Q&A (visible-FAQ gate 3→2 so schema matches visible). FAQ now uses the real **suburb** average (was the city average, mislabelled).

## #3 — Happy-hour titles
`page.tsx` + `voiceCopy.ts`: HH-only pubs (no standard price) title *"$6.00 happy-hour pints"* / meta *"pours a $6 pint during happy hour…"* instead of the flaky *"Price TBC"*.

## Verification
- `tsc` clean · 272 tests pass
- Rendered HTML confirmed: **priced** (Guildford → Offer `price:"9.00"` + answer line + FAQPage) and **HH-only** (Palace Arcade → title `$6.00 happy-hour pints` + Offer `price:"6.00"`)

Also adds `.claude/seo-content.config.md`. Deferred: #4 (content depth — the suburb/discover money pages are the next lever).

🤖 Generated with [Claude Code](https://claude.com/claude-code)