### PR TITLE
SEO: keyword pass + rebuild /happy-hour for "happy hour perth"

### DIFF
--- a/.claude/seo-content.config.md
+++ b/.claude/seo-content.config.md
@@ -12,7 +12,7 @@ project:
 
 data_layer:
   provider: ahrefs-mcp
-  ahrefs_project_id:           # BLANK — confirm which Ahrefs project maps to perthpintprices.com
+  ahrefs_project_id: 9843078   # Perthpintprices (verified, owned by macca.mck@gmail.com; rank-tracker has 0 keywords set up yet)
   csv_path:
   notes: >
     Ahrefs MCP connected. Money values are USD cents (÷100). Per-pub queries
@@ -21,7 +21,7 @@ data_layer:
     Use Ahrefs for the higher-volume suburb/discover money pages, not the pub template.
 
 keywords:
-  store: docs/seo/keywords.md  # BLANK/not-yet-created — proposed location
+  store: docs/seo/keywords.md  # written 2026-06-05 — money-page keyword set (Ahrefs AU)
   published_index: >
     Supabase `pubs` table (857 rows) → /[suburb]/[pub]; suburbs → /[suburb];
     indexable set in /sitemap.xml. A keyword is "covered" if a matching pub/suburb page exists.

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,12 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### SEO #4: money-page keyword pass + `/happy-hour` rebuild (2026-06-05)
+- **Keyword research (Ahrefs, AU)** → `docs/seo/keywords.md`. The on-brand terms are wide open: **happy hour perth (250/mo, KD 0)**, best pubs perth (400, KD 0), beer garden perth (100, KD 0), dog friendly pubs perth (150, KD 0); `cheap pints perth` triggers an **AI Overview** (citation prize). Flagged `rooftop bars perth` (1,500, KD 30) + `bars perth` (800) as high-volume but off the pint-price USP. Filled the Ahrefs project id (9843078) + keyword-store blanks in `.claude/seo-content.config.md`.
+- **`/happy-hour` optimised for "happy hour perth"** (the #1 opportunity). The SERP rewards a comprehensive list (Perth is OK / sitchu listicles rank), but our page filtered the visible list to `isHappyHourNow` — so outside ~4–6pm it showed "No happy hours right now" + an empty list, unrankable for the query. Now it lists **every timed happy hour, cheapest first, with active ones flagged live**: keyword H1 ("Happy hours in Perth"), an answer-first intro, a sharper title ("Happy Hour Perth — Every Deal, Live & Priced"), and a FAQ + `FAQPage` schema (what time / where cheapest / which pubs). Keeps the live board + countdowns — the freshness the static listicles can't match.
+- **Verification:** `tsc` clean, 272 tests, rendered HTML confirmed (full list, keyword H1, FAQPage, no empty state).
+- **Next:** the KD-0 guide gaps — `/guides/dog-friendly-pubs`, `/guides/beer-gardens` (the `allows_dogs` / `outdoor_seating` data already exists).
+
 ### Pub page SEO: price schema + answer-first + happy-hour titles (2026-06-05)
 - **`feat/pub-page-seo`:** an SEO audit (via the `seo-content` skill) of the post-receipt pub template found the pages under-optimised for a wide-open SERP — searching "how much is a pint at [pub]" returns TripAdvisor / booking sites, none of which answer the price. Three fixes, hitting every priced/HH pub at once:
   - **Exact price in structured data** (`pubJsonLd.ts`): added `makesOffer` → `Offer`/`MenuItem` with the real pint price (+ happy-hour price) in AUD — previously the price was only a coarse `priceRange: "$$"`. Now machine-readable for rich results + AI answers.

--- a/docs/seo/keywords.md
+++ b/docs/seo/keywords.md
@@ -1,0 +1,33 @@
+# Keyword set — money/discovery pages
+
+Source: Ahrefs Keywords Explorer (project 9843078, country AU), pulled 2026-06-05. Real volume/KD/CPC/intent — not estimates. Gates: KD ≤ 30, volume ≥ 100, local/commercial intent (volume relaxed for on-brand, AI-Overview, or buy-intent terms). Ranked by opportunity = on-brand winnability first, raw volume second.
+
+`status`: `update` = a page already targets this (sharpen it, don't duplicate); `new` = gap. All intents here are **local** (Perth) — these are "money"/discovery pages, not blog posts.
+
+| # | primary | vol | KD | cpc | cluster terms (vol) | status → page | notes |
+|---|---------|-----|----|-----|---------------------|---------------|-------|
+| 1 | happy hour perth | 250 | 0 | $0.40 | best happy hour perth (20), cheap drinks perth (20) | update → `/happy-hour` | KD 0, **clean SERP** (no features to fight). Highest on-brand vol. Roll the suburb HH terms up under it via internal links. |
+| 2 | best pubs perth | 400 | 0 | $0.70 | pubs perth (600, KD 20) | update → `/discover` (or new `/best-pubs-perth` hub) | ~1000 combined vol, parent "pubs perth". A "best pubs in Perth, sorted by pint price" hub is the on-brand angle nobody else has. |
+| 3 | dog friendly pubs perth | 150 | 0 | $0.10 | — | new → `/guides/dog-friendly-pubs` | KD 0. PPP already has the `allows_dogs` data — pure data → page. |
+| 4 | beer garden perth | 100 | 0 | $0.80 | best beer gardens perth (80, $1.20 cpc) | new → `/guides/beer-gardens` (or fold into `/guides/beer-weather`) | KD 0, **local_pack** in SERP, highest CPC here. PPP has `outdoor_seating` data. |
+| 5 | cheap pints perth | 40 | 0 | — | cheap beer perth (40, KD 1, **commercial**) | update → `/cheap-pints` | Low vol BUT the exact brand term, and the SERP has an **AI Overview + knowledge panel** → the citation prize. Make this page the quotable source. |
+| 6 | pubs fremantle | 250 | 28 | $0.25 | happy hour fremantle (70) | update → `/fremantle` | Winnable suburb page (exists). Ensure the H1/title/answer line nail "pubs fremantle" + the suburb pint average. |
+| 7 | bars northbridge | 250 | 30 | $0.25 | pubs northbridge (80, KD 39), happy hour northbridge (30) | update → `/northbridge` | **local_pack** dominates — aim for the best organic result below the map. Suburb page. |
+| 8 | how much is a pint in perth | — | — | — | average pint price perth, pint price perth | keep → `/how-much-is-a-pint-in-perth` | Ahrefs shows ~0 vol (ultra-long-tail it undercounts), but it's the literal brand question + an existing answer-first page. Value is aggregate + AI citations, not this one term's volume. |
+
+## Flagged — high volume but OFF the pint-price USP (your call)
+| primary | vol | KD | note |
+|---------|-----|----|----|
+| rooftop bars perth | 1500 | 30 | Biggest volume by far, but "rooftop bars" ≠ cheap pints. Only worth a page if you want the traffic and can serve the intent (PPP has rooftop data? mostly not). Decide before building. |
+| bars perth | 800 | 16 | Broad/generic, "best bars in perth" parent. Winnable KD but tangential to the price angle and a crowded "listicle" SERP. Low priority vs the on-brand KD-0 terms above. |
+
+## Recommended order
+1. **`/happy-hour`** (update) — biggest on-brand vol, KD 0, clean SERP. Quickest win.
+2. **`/guides/dog-friendly-pubs`** + **`/guides/beer-gardens`** (new) — KD 0, data already exists, fills two gaps.
+3. **`/cheap-pints`** (update) — own the AI Overview for the brand term.
+4. Suburb pages (`/fremantle`, `/northbridge`, …) — already exist; the pub-page SEO pass + suburb answer-first copy should lift these.
+
+## Not done here (next passes)
+- Expand winners with `keywords-explorer-matching-terms` / `related-terms` for the cluster long-tail.
+- `serp-overview` on #1–#5 to SERP-steal the top-3 blueprint before writing.
+- Per-suburb volume sweep (each `/[suburb]` page's "pubs {suburb}" / "happy hour {suburb}" demand) once the template wins are in.

--- a/src/app/happy-hour/HappyHourClient.tsx
+++ b/src/app/happy-hour/HappyHourClient.tsx
@@ -60,9 +60,8 @@ function formatDealWindow(pub: Pub, status: HappyHourStatus): string {
 
 export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHourClientProps) {
   const [happyHourPubs, setHappyHourPubs] = useState<Pub[]>(initialPubs)
-  const [allPubs, setAllPubs] = useState<Pub[]>(initialPubs.filter(p => p.isHappyHourNow))
+  const [allPubs, setAllPubs] = useState<Pub[]>(initialPubs.filter(hasTimedHappyHour))
   const [loading, setLoading] = useState(false) // Start as false since we have server data
-  const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
   const [clockInstant, setClockInstant] = useState(() => new Date(renderedAtIso))
   const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null)
   const [locationState, setLocationState] = useState<'pending' | 'granted' | 'denied'>('pending')
@@ -87,8 +86,7 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
       const pubs = await getPubs()
       const pubsWithHappyHours = pubs.filter((p) => p.happyHour)
       setHappyHourPubs(pubsWithHappyHours)
-      setAllPubs(pubsWithHappyHours.filter((p) => p.isHappyHourNow))
-      setLastRefresh(new Date())
+      setAllPubs(pubsWithHappyHours.filter(hasTimedHappyHour))
     } catch (err) {
       console.error('Error fetching happy hour pubs:', err)
     } finally {
@@ -177,7 +175,27 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
     const pr = p.happyHourPrice ?? p.price ?? p.regularPrice
     return pr != null && pr < min ? pr : min
   }, Infinity)
-  const activePubCopy = pubs.length === 1 ? 'one happy-hour pub' : `${pubs.length} happy-hour pubs`
+  const faqItems = [
+    {
+      q: 'What time is happy hour in Perth?',
+      a: `Most Perth happy hours run late afternoon to early evening — commonly 4–6pm on weekdays, though some pubs go later or all day. Every pub below lists its exact window${planner.activeCount > 0 ? `, and ${planner.activeCount} ${planner.activeCount === 1 ? 'is' : 'are'} on right now` : ''}.`,
+    },
+    {
+      q: "Where's the cheapest happy-hour pint in Perth?",
+      a: planner.cheapestActive
+        ? `Right now it's ${formatPrice(getActiveDisplayPrice(planner.cheapestActive.pub, planner.cheapestActive.status))} at ${planner.cheapestActive.pub.name} in ${planner.cheapestActive.pub.suburb}. The list below is sorted cheapest first.`
+        : `${minHhPrice !== Infinity ? `Happy-hour pints start from ${formatPrice(minHhPrice)}. ` : ''}The list below is sorted cheapest first, so the best deal is always at the top.`,
+    },
+    {
+      q: 'Which Perth pubs have a happy hour?',
+      a: `We track ${happyHourPubs.length} Perth pubs with a happy hour, each with a live window and pint price — from the CBD and Northbridge to Fremantle and the beaches.`,
+    },
+  ]
+  const faqJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqItems.map(f => ({ '@type': 'Question', name: f.q, acceptedAnswer: { '@type': 'Answer', text: f.a } })),
+  }
 
   return (
     <div className="min-h-screen bg-[#FDF8F0]">
@@ -187,31 +205,25 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
         {/* Page heading */}
         <div className="mb-6">
           <h1 className="type-hero">
-            Perth happy hours, on now
+            Happy hours in Perth
           </h1>
 
-          {!loading && pubs.length > 0 && (
+          {planner.activeCount > 0 && (
             <div className="flex items-center gap-2 mt-3">
               <span className="w-2 h-2 rounded-full bg-green shadow-[0_0_8px_rgba(45,122,61,0.5)] animate-pulse" />
               <span className="font-mono text-[0.75rem] font-bold text-ink">
-                {pubs.length} active now
+                {planner.activeCount} on right now
               </span>
             </div>
           )}
 
           <p className="font-body text-[0.9rem] leading-relaxed text-gray-mid mt-3">
-            {pubs.length > 0 ? (
-              <>Perth has {activePubCopy} running right now{minHhPrice !== Infinity && <>, with pints from <span className="font-mono font-bold text-ink">{formatPrice(minHhPrice)}</span></>}. We list them live, with the pint price, the window, and the last check where we have it.</>
-            ) : (
-              <>No happy hours we&apos;ve confirmed running right now. They move around — check back later, or <Link href="/discover" className="text-amber font-bold hover:underline">see Perth prices</Link>.</>
-            )}
+            Every Perth happy hour we track — {happyHourPubs.length} pubs, each with its exact pint price and window. Most run late afternoon, 4–6pm on weekdays; {planner.activeCount > 0 ? <>{planner.activeCount} {planner.activeCount === 1 ? 'is' : 'are'} live right now</> : 'none are live this minute'}{minHhPrice !== Infinity && <>, with pints from <span className="font-mono font-bold text-ink">{formatPrice(minHhPrice)}</span></>}. Sorted cheapest first, updated continuously.
           </p>
 
-          {lastRefresh && !loading && (
-            <p className="text-gray-mid text-[0.7rem] mt-2">
-              Auto-refreshes every 60s
-            </p>
-          )}
+          <p className="text-gray-mid text-[0.7rem] mt-2">
+            Live data · auto-refreshes every 60s
+          </p>
         </div>
 
         {happyHourPubs.length > 0 && (
@@ -464,6 +476,20 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
             </Link>
           </div>
         )}
+
+        {/* FAQ — answers the "what time / where cheapest / which pubs" PAA + FAQPage schema */}
+        <section className="mt-10 rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+          <h2 className="type-section leading-tight mb-4">Perth happy hour FAQ</h2>
+          <div className="space-y-4">
+            {faqItems.map(f => (
+              <div key={f.q}>
+                <h3 className="type-card leading-snug">{f.q}</h3>
+                <p className="mt-1 font-body text-[0.85rem] leading-relaxed text-gray-mid">{f.a}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd).replace(/</g, '\\u003c') }} />
       </div>
 
       <Footer />

--- a/src/app/happy-hour/page.tsx
+++ b/src/app/happy-hour/page.tsx
@@ -7,9 +7,9 @@ import { pubUrl } from '@/lib/urls'
 export const revalidate = 60 // Revalidate every 60 seconds for fresh happy hour data
 
 export const metadata: Metadata = {
-  title: 'Happy Hours in Perth Right Now',
+  title: 'Happy Hour Perth — Every Deal, Live & Priced',
   description:
-    'Which Perth pubs have happy hour deals on right now. Live countdown timers, savings calculations, and the cheapest pints available today.',
+    'Every Perth happy hour in one live list — the exact pint price and window for each pub, and which deals are on right now. Sorted cheapest first, updated continuously.',
   alternates: { canonical: 'https://perthpintprices.com/happy-hour' },
   openGraph: {
     title: 'Happy Hours Live Now in Perth | Perth Pint Prices',


### PR DESCRIPTION
## What & why

Continuing the SEO work (#4). Keyword research (Ahrefs, AU) → `docs/seo/keywords.md`: the on-brand terms are **wide open** — `happy hour perth` (250/mo, **KD 0**), `best pubs perth` (400, KD 0), `beer garden perth` + `dog friendly pubs perth` (KD 0); `cheap pints perth` triggers an AI Overview. Filled the Ahrefs project (9843078) + keyword-store config blanks.

Then optimised the #1 opportunity: **`/happy-hour`** for "happy hour perth".

## The fix
The SERP wants a comprehensive list (Perth is OK, sitchu listicles rank). But the page filtered the visible list to `isHappyHourNow` — so **outside ~4–6pm it showed "No happy hours right now" + an empty list**, unrankable for the query.

Now it lists **every timed happy hour, cheapest first, with active ones flagged live** — plus:
- keyword H1 ("Happy hours in Perth") + an answer-first intro
- sharper title ("Happy Hour Perth — Every Deal, Live & Priced")
- FAQ + `FAQPage` schema (what time / where cheapest / which pubs)
- keeps the live board + countdowns — the freshness static listicles can't match

## Verification
- `tsc` clean · 272 tests
- Rendered HTML: keyword H1, FAQPage, **177 pub links, no empty state** (was empty most of the day)

Next: the KD-0 guide gaps (`/guides/dog-friendly-pubs`, `/guides/beer-gardens` — data already exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)