### PR TITLE
feat(happy-hour): data-powered listicle (best-of picks + pour fix) + day formatting

### DIFF
--- a/src/app/happy-hour/HappyHourClient.tsx
+++ b/src/app/happy-hour/HappyHourClient.tsx
@@ -33,6 +33,18 @@ function formatPerthTime(date: Date): string {
   }).format(date).replace(' ', '').toLowerCase()
 }
 
+// Format a 24h time string ("17:30") to "5:30pm" / "5pm" (minutes preserved).
+function formatHHTime(value: string | null): string {
+  if (!value) return ''
+  const [h, m = '0'] = value.split(':')
+  const hour = Number(h)
+  const minute = Number(m)
+  if (!Number.isFinite(hour)) return ''
+  const period = hour >= 12 ? 'pm' : 'am'
+  const h12 = hour > 12 ? hour - 12 : hour === 0 ? 12 : hour
+  return minute > 0 ? `${h12}:${String(minute).padStart(2, '0')}${period}` : `${h12}${period}`
+}
+
 function getPubHappyHourStatus(pub: Pub, now: Date): HappyHourStatus {
   return getHappyHourStatus({
     price: pub.regularPrice,
@@ -52,10 +64,14 @@ function getActiveDisplayPrice(pub: Pub, status: HappyHourStatus): number | null
 }
 
 function formatDealWindow(pub: Pub, status: HappyHourStatus): string {
-  if (status.happyHourLabel) return status.happyHourLabel
   const days = formatHappyHourDays(pub.happyHourDays)
-  if (days) return days
-  return pub.happyHour ?? 'Happy hour'
+  if (days) {
+    const time = pub.happyHourStart && pub.happyHourEnd
+      ? ` ${formatHHTime(pub.happyHourStart)}-${formatHHTime(pub.happyHourEnd)}`
+      : ''
+    return `${days}${time}`
+  }
+  return status.happyHourLabel || pub.happyHour || 'Happy hour'
 }
 
 export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHourClientProps) {
@@ -423,8 +439,8 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
                       {distance != null && (
                         <span>· {formatDistance(distance)}</span>
                       )}
-                      {pub.happyHourLabel && (
-                        <span>· {pub.happyHourLabel}</span>
+                      {pub.happyHourDays && (
+                        <span>· {formatHappyHourDays(pub.happyHourDays)} {formatHHTime(pub.happyHourStart)}-{formatHHTime(pub.happyHourEnd)}</span>
                       )}
                     </div>
                     {pub.happyHourMinutesRemaining != null && (

--- a/src/app/happy-hour/HappyHourClient.tsx
+++ b/src/app/happy-hour/HappyHourClient.tsx
@@ -11,6 +11,7 @@ import { pubUrl } from '@/lib/urls'
 import { getHappyHourStatus, formatHappyHourDays, type HappyHourStatus } from '@/lib/happyHourLive'
 import { getPriceRecency } from '@/lib/freshness'
 import { HAPPY_HOUR_DAYS } from '@/lib/happyHourDays'
+import { happyHourPourLabel, isPintHappyHour } from '@/lib/happyHourPour'
 
 type SortMode = 'price' | 'nearest'
 
@@ -169,11 +170,28 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
       activeCount: activeRows.length,
       timedCount: timedRows.length,
       freshCount,
-      cheapestActive: activeRows[0] ?? null,
+      cheapestActive: activeRows.find(r => isPintHappyHour(r.pub.slug)) ?? null,
       nextDeal: upcomingRows[0] ?? null,
       laterDeal: laterRows[0] ?? null,
     }
   }, [happyHourPubs, clockInstant])
+
+  // Editorial "best of" picks, auto-selected from live data. "Cheapest pint" and
+  // the picks only count real pints — schooner/small-pour happy hours are excluded
+  // (see happyHourPour) so we never headline a non-pint as the cheapest.
+  const bestOf = useMemo(() => {
+    const priced = allPubs.filter(p => p.happyHourPrice != null)
+    const pints = priced.filter(p => isPintHappyHour(p.slug))
+    const byPrice = (a: Pub, b: Pub) => (a.happyHourPrice ?? 999) - (b.happyHourPrice ?? 999)
+    const biggestSaving = priced
+      .filter(p => isPintHappyHour(p.slug) && p.regularPrice != null && p.happyHourPrice != null && p.regularPrice > p.happyHourPrice)
+      .sort((a, b) => (b.regularPrice! - b.happyHourPrice!) - (a.regularPrice! - a.happyHourPrice!))[0] ?? null
+    return {
+      cheapestPint: [...pints].sort(byPrice)[0] ?? null,
+      biggestSaving,
+      beerGarden: [...pints].filter(p => p.outdoorSeating).sort(byPrice)[0] ?? null,
+    }
+  }, [allPubs])
 
   const formatMinutesRemaining = (mins: number | null): string => {
     if (mins == null) return ''
@@ -187,10 +205,6 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
 
   const hasLocation = locationState === 'granted' && userLocation !== null
 
-  const minHhPrice = pubs.reduce((min, p) => {
-    const pr = p.happyHourPrice ?? p.price ?? p.regularPrice
-    return pr != null && pr < min ? pr : min
-  }, Infinity)
   const faqItems = [
     {
       q: 'What time is happy hour in Perth?',
@@ -198,9 +212,9 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
     },
     {
       q: "Where's the cheapest happy-hour pint in Perth?",
-      a: planner.cheapestActive
-        ? `Right now it's ${formatPrice(getActiveDisplayPrice(planner.cheapestActive.pub, planner.cheapestActive.status))} at ${planner.cheapestActive.pub.name} in ${planner.cheapestActive.pub.suburb}. The list below is sorted cheapest first.`
-        : `${minHhPrice !== Infinity ? `Happy-hour pints start from ${formatPrice(minHhPrice)}. ` : ''}The list below is sorted cheapest first, so the best deal is always at the top.`,
+      a: bestOf.cheapestPint
+        ? `${bestOf.cheapestPint.name} in ${bestOf.cheapestPint.suburb} has the cheapest happy-hour pint we've found — ${formatPrice(bestOf.cheapestPint.happyHourPrice)}. (We don't count schooner or small-pour deals as pints.) The list below is sorted cheapest first.`
+        : 'The list below is sorted cheapest first, so the best deal is always at the top.',
     },
     {
       q: 'Which Perth pubs have a happy hour?',
@@ -234,13 +248,46 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
           )}
 
           <p className="font-body text-[0.9rem] leading-relaxed text-gray-mid mt-3">
-            Every Perth happy hour we track — {happyHourPubs.length} pubs, each with its exact pint price and window. Most run late afternoon, 4–6pm on weekdays; {planner.activeCount > 0 ? <>{planner.activeCount} {planner.activeCount === 1 ? 'is' : 'are'} live right now</> : 'none are live this minute'}{minHhPrice !== Infinity && <>, with pints from <span className="font-mono font-bold text-ink">{formatPrice(minHhPrice)}</span></>}. Sorted cheapest first, updated continuously.
+            Every Perth happy hour we track — {happyHourPubs.length} pubs, each with its exact pint price and window. Most run late afternoon, 4–6pm on weekdays; {planner.activeCount > 0 ? <>{planner.activeCount} {planner.activeCount === 1 ? 'is' : 'are'} live right now</> : 'none are live this minute'}{bestOf.cheapestPint && <>, with pints from <span className="font-mono font-bold text-ink">{formatPrice(bestOf.cheapestPint.happyHourPrice)}</span></>}. Sorted cheapest first, updated continuously.
           </p>
 
           <p className="text-gray-mid text-[0.7rem] mt-2">
             Live data · auto-refreshes every 60s
           </p>
         </div>
+
+        {/* Best-of editorial picks — auto-selected from live data, pour-aware */}
+        {(bestOf.cheapestPint || bestOf.biggestSaving || bestOf.beerGarden) && (
+          <section className="mb-6">
+            <h2 className="type-section leading-tight mb-3">Perth&apos;s best happy-hour pints</h2>
+            <div className="grid gap-3 sm:grid-cols-3">
+              {bestOf.cheapestPint && (
+                <Link href={pubUrl(bestOf.cheapestPint)} className="block rounded-card border-3 border-ink bg-white p-4 shadow-hard-sm no-underline hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all">
+                  <p className="type-eyebrow text-amber">Cheapest pint</p>
+                  <p className="mt-1 type-price text-[1.7rem] leading-none">{formatPrice(bestOf.cheapestPint.happyHourPrice)}</p>
+                  <p className="mt-2 font-mono text-[0.82rem] font-bold text-ink truncate">{bestOf.cheapestPint.name}</p>
+                  <p className="font-body text-[0.76rem] text-gray-mid">{bestOf.cheapestPint.suburb} · {formatHappyHourDays(bestOf.cheapestPint.happyHourDays)} {formatHHTime(bestOf.cheapestPint.happyHourStart)}-{formatHHTime(bestOf.cheapestPint.happyHourEnd)}</p>
+                </Link>
+              )}
+              {bestOf.biggestSaving && (
+                <Link href={pubUrl(bestOf.biggestSaving)} className="block rounded-card border-3 border-ink bg-white p-4 shadow-hard-sm no-underline hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all">
+                  <p className="type-eyebrow text-amber">Biggest saving</p>
+                  <p className="mt-1 type-price text-[1.7rem] leading-none text-green">{formatPrice((bestOf.biggestSaving.regularPrice ?? 0) - (bestOf.biggestSaving.happyHourPrice ?? 0))} off</p>
+                  <p className="mt-2 font-mono text-[0.82rem] font-bold text-ink truncate">{bestOf.biggestSaving.name}</p>
+                  <p className="font-body text-[0.76rem] text-gray-mid">{formatPrice(bestOf.biggestSaving.happyHourPrice)}, was {formatPrice(bestOf.biggestSaving.regularPrice)} · {bestOf.biggestSaving.suburb}</p>
+                </Link>
+              )}
+              {bestOf.beerGarden && (
+                <Link href={pubUrl(bestOf.beerGarden)} className="block rounded-card border-3 border-ink bg-white p-4 shadow-hard-sm no-underline hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all">
+                  <p className="type-eyebrow text-amber">Best beer garden</p>
+                  <p className="mt-1 type-price text-[1.7rem] leading-none">{formatPrice(bestOf.beerGarden.happyHourPrice)}</p>
+                  <p className="mt-2 font-mono text-[0.82rem] font-bold text-ink truncate">{bestOf.beerGarden.name}</p>
+                  <p className="font-body text-[0.76rem] text-gray-mid">{bestOf.beerGarden.suburb} · pints in the sun</p>
+                </Link>
+              )}
+            </div>
+          </section>
+        )}
 
         {happyHourPubs.length > 0 && (
           <section className="mb-6 overflow-hidden rounded-card border-3 border-ink bg-white shadow-hard-sm">
@@ -441,6 +488,9 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
                       )}
                       {pub.happyHourDays && (
                         <span>· {formatHappyHourDays(pub.happyHourDays)} {formatHHTime(pub.happyHourStart)}-{formatHHTime(pub.happyHourEnd)}</span>
+                      )}
+                      {happyHourPourLabel(pub.slug) && (
+                        <span className="font-bold text-amber">· {happyHourPourLabel(pub.slug)}</span>
                       )}
                     </div>
                     {pub.happyHourMinutesRemaining != null && (

--- a/src/lib/happyHourLive.ts
+++ b/src/lib/happyHourLive.ts
@@ -40,8 +40,20 @@ export function formatHappyHourDays(days: string | null): string {
   if (uniq.length === 7) return '7 days'
   if (uniq.length === 5 && [1, 2, 3, 4, 5].every(d => uniq.includes(d))) return 'Mon–Fri'
   if (uniq.length === 2 && uniq.includes(0) && uniq.includes(6)) return 'Weekends'
-  if (uniq.length > 2 && uniq.every((v, i) => i === 0 || v === uniq[i - 1] + 1)) {
-    return `${shortByIndex[uniq[0]]}–${shortByIndex[uniq[uniq.length - 1]]}`
+  if (uniq.length > 2) {
+    const consecutive = (arr: number[]) => arr.every((v, i) => i === 0 || v === arr[i - 1] + 1)
+    if (consecutive(uniq)) {
+      return `${shortByIndex[uniq[0]]}–${shortByIndex[uniq[uniq.length - 1]]}`
+    }
+    // Wrap-around run (e.g. Wed–Sun = {3,4,5,6,0}): the present days form a single
+    // run exactly when the missing days are a contiguous block.
+    const present = new Set(uniq)
+    const missing = [0, 1, 2, 3, 4, 5, 6].filter(d => !present.has(d))
+    if (missing.length > 0 && consecutive(missing)) {
+      const start = (missing[missing.length - 1] + 1) % 7
+      const end = (missing[0] + 6) % 7
+      return `${shortByIndex[start]}–${shortByIndex[end]}`
+    }
   }
   return uniq.map(i => shortByIndex[i]).join(', ')
 }

--- a/src/lib/happyHourPour.ts
+++ b/src/lib/happyHourPour.ts
@@ -1,0 +1,29 @@
+// Curated pour-size data for happy-hour prices.
+//
+// PPP stores a single `happyHourPrice` with no pour size, so small pours
+// (schooners, tapas-bar pours) can masquerade as cheap pints — e.g. Pinchos's
+// $3.50 or Palace Arcade's $6 show up as the "cheapest pint" when they aren't
+// pints at all. Every ranking competitor distinguishes them: Urban List lists
+// Palace Arcade as "$6 Schooners", Perth is OK lists St Brigid as "$6 schooners".
+//
+// Until a per-pub pour size lives in the DB, this curated set marks the confirmed
+// non-pint happy hours (keyed by pub slug, value = the pour label to display) so
+// the "cheapest pint" logic skips them and the list labels them honestly.
+//
+// Add a slug here whenever a venue's happy-hour price is verified to be a
+// schooner/pot/small pour rather than a standard pint.
+const NON_PINT_HAPPY_HOUR: Record<string, string> = {
+  'pinchos-bar-de-tapas': 'small pour', // tapas bar — $3.50 is not a pint
+  'palace-arcade': 'schooner',          // Urban List: "$6 Schooners"
+  'st-brigid': 'schooner',              // Perth is OK: "$6 schooners"
+}
+
+/** The pour label when this pub's happy hour is NOT a standard pint, else null. */
+export function happyHourPourLabel(slug: string): string | null {
+  return NON_PINT_HAPPY_HOUR[slug] ?? null
+}
+
+/** True when the happy-hour price is a standard pint — safe to rank as "cheapest pint". */
+export function isPintHappyHour(slug: string): boolean {
+  return !(slug in NON_PINT_HAPPY_HOUR)
+}


### PR DESCRIPTION
The `/happy-hour` list rendered the raw stored `happyHourLabel` ("Monday,Tuesday,Wednesday,Thursday,Friday 5pm-6pm") instead of a formatted window. Now it renders days via `formatHappyHourDays` + a minute-preserving time helper → every row/board entry reads "Mon-Fri 5pm-6pm".

Also fixed `formatHappyHourDays` to collapse **wrap-around** runs: `Wed,Thu,Fri,Sat,Sun` → "Wed–Sun" (was "Sun, Wed, Thu, Fri, Sat"), `Fri,Sat,Sun,Mon` → "Fri–Mon".

Verified: `tsc` clean, **272 tests**, formatter checked across cases (Mon–Fri, Tue–Fri, Wed–Sun, Fri–Mon, 7 days, Weekends, non-consecutive). Surfaced while comparing the page to the top-10 SERP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)