### PR TITLE
feat(world-cup): live fixture hub — AWST kickoffs, WA licensing windows, confirmed-opens ledger

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -1,6 +1,6 @@
 # Perth Pint Prices Project Status
 
-Last updated: 2026-06-08
+Last updated: 2026-06-10
 
 ## What this is
 
@@ -9,6 +9,13 @@ Perth Pint Prices (perthpintprices.com) tracks pint prices across **857 Perth pu
 Stack, database, routes, components, and lib files are documented in `CLAUDE.md` (auto-loaded every session). This file covers history, recent work, and the backlog.
 
 ## What's done recently
+
+### /world-cup live hub page (2026-06-10)
+- **New `/world-cup` route** — a FANZO-style fixture hub with the trust layer they fake: all **72 group-stage fixtures in AWST** (captured from FANZO's geo-localised rail, cross-checked against two AEST schedule sources; Socceroos times triple-verified against the official announcement), each tagged with its **WA trading window** — `permit hours` (midnight–6am any day, plus Sunday before 10am), `early doors` (6–9am, legal on a standard licence), `normal trading`. Knockouts deliberately omitted until the bracket settles — nothing TBC ships.
+- **`src/lib/worldCup.ts`** — fixtures data + `tradingStatus()` classifier built on `perthClock` (standard hours 6am–midnight Mon–Sat / 10am Sunday per DLGSC, checked 10 June 2026; World Cup extended-trading permit announced 5 June 2026), `formatKickoff` (midnight/midday/3am/8.30am style), `CONFIRMED_OPENINGS` ledger (renders an honest empty state until venues confirm door times — no Andrew for now, so confirmations are manual + report-form), `FORM_GUIDE_SLUGS`.
+- **`src/components/WorldCupFixtures.tsx`** — client fixture list grouped by Perth day: live clock (60s tick), ON NOW / NEXT chips, played matches auto-collapse, All / Socceroos & Group D filter, Socceroos rows highlighted.
+- **Page** (`src/app/world-cup/page.tsx`) — hero stat cards, Socceroos cards, dark confirmed-opens card with report CTA, **screens form guide** pulling live pint prices + checked dates from our own pubs data (the moat: FANZO lists venues, we list venues *with the price and the date we checked it*), Northbridge Piazza free-screen note, FAQPage JSON-LD + visible Q&A, breadcrumb schema, sitemap + footer link.
+- **Verification** — tsc clean, lint clean (one pre-existing SunsetSippers warning), **294 unit tests** pass (+18 new for fixtures data sanity, the licensing classifier incl. Sunday edge cases, kickoff formatting, match phases), Playwright screenshots at 1280x800 + 375x812 (mobile chip-wrap fixed).
 
 ### Fix Ahrefs size regressions: slim list payloads + resize venue photos (2026-06-09)
 - **Diagnosis from the 2026-06-08 Ahrefs crawl:** the photo-recovery work (#173) introduced every new Error this week. Verified live with `curl`: the homepage shipped **2.22MB** of HTML — all 857 pubs' full objects serialised into the RSC payload — tripping Googlebot's 2MB crawl limit; pub photos were hotlinked at up to **4800px (~208KB each)**, flagging "Image file size too large" on 15 pages. The real bulk wasn't the photos (~240KB) but the **full Pub enrichment the lists never render**: `periods` (441KB), editorial summaries (352KB), 15 Google attributes (282KB), opening-hours text (217KB).

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -55,6 +55,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${BASE_URL}/cheapest-pints`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },
     { url: `${BASE_URL}/how-much-is-a-pint-in-perth`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },
     { url: `${BASE_URL}/student-pints-perth`, lastModified: latestPubModified, changeFrequency: 'weekly', priority: 0.7 },
+    { url: `${BASE_URL}/world-cup`, lastModified: latestPubModified, changeFrequency: 'daily', priority: 0.8 },
     { url: `${BASE_URL}/articles`, lastModified: articles[0]?.updatedAt || FALLBACK_LAST_MODIFIED, changeFrequency: 'weekly', priority: 0.8 },
   ]
 

--- a/src/app/world-cup/page.tsx
+++ b/src/app/world-cup/page.tsx
@@ -1,0 +1,304 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowUpRight, ClipboardCheck, Tv } from 'lucide-react'
+import BreadcrumbJsonLd from '@/components/BreadcrumbJsonLd'
+import Footer from '@/components/Footer'
+import SubPageNav from '@/components/SubPageNav'
+import WorldCupFixtures from '@/components/WorldCupFixtures'
+import { formatAudPrice } from '@/lib/pintPriceStats'
+import { getPubs } from '@/lib/supabase'
+import { BASE_URL, pubUrl } from '@/lib/urls'
+import {
+  WC_FIXTURES,
+  CONFIRMED_OPENINGS,
+  FORM_GUIDE_SLUGS,
+  TIMES_CHECKED,
+  TRADING_BADGES,
+  formatDayHeading,
+  formatKickoff,
+  fixtureDay,
+} from '@/lib/worldCup'
+import type { Pub } from '@/types/pub'
+
+const canonical = `${BASE_URL}/world-cup`
+const description = 'Every 2026 World Cup kickoff in Perth time, which pubs can legally pour when, and confirmed early opens — checked and dated. All matches free on SBS.'
+
+export const revalidate = 3600
+
+export const metadata: Metadata = {
+  title: 'Where to Watch the 2026 World Cup in Perth',
+  description,
+  alternates: { canonical },
+  openGraph: {
+    title: 'Where to Watch the 2026 World Cup in Perth | Perth Pint Prices',
+    description,
+    url: canonical,
+    type: 'website',
+    siteName: 'Perth Pint Prices',
+    locale: 'en_AU',
+    images: [{ url: `${BASE_URL}/og-image.png`, width: 1200, height: 630, alt: 'Perth Pint Prices World Cup guide' }],
+  },
+  twitter: { card: 'summary_large_image' },
+}
+
+const FAQ_ITEMS = [
+  {
+    question: 'What time is USA v Australia in Perth?',
+    answer: '3am AWST on Saturday 20 June 2026. The kickoff is Friday lunchtime in Seattle, which lands in the middle of the night here — only venues holding a World Cup extended trading permit can legally pour at that hour.',
+  },
+  {
+    question: 'Can Perth pubs legally open for 3am World Cup games?',
+    answer: 'Only with a permit. Standard WA hotel, tavern and small bar licences trade 6am to midnight Monday to Saturday and from 10am on Sunday. On 5 June 2026 the WA Director of Liquor Licensing opened extended-trading applications for venues showing World Cup matches live — approved venues can trade until 30 minutes after full-time.',
+  },
+  {
+    question: 'What channel is the 2026 World Cup on in Australia?',
+    answer: 'Every match is free on SBS and SBS On Demand.',
+  },
+  {
+    question: 'What time do 2026 World Cup matches kick off in Perth?',
+    answer: 'Between midnight and midday AWST. Perth sits 12 to 15 hours ahead of the North American host cities, so there are no evening kickoffs for the entire tournament.',
+  },
+]
+
+const SOCCEROOS_NOTES: Record<string, string> = {
+  '2026-06-14-australia-turkiye': 'Saturday night in Vancouver lands as Sunday lunch here. Any pub with a screen can show it — pick a good room.',
+  '2026-06-20-usa-australia': 'The brutal one. 3am is permit hours, so the rooms showing it live have done the paperwork. Expect a short list.',
+  '2026-06-26-paraguay-australia': 'Mid-morning Friday. Legal everywhere from 6am — but earlier than many doors actually open, so check first.',
+}
+
+function buildFaqJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: FAQ_ITEMS.map(item => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: { '@type': 'Answer', text: item.answer },
+    })),
+  }
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return 'date TBC'
+  return new Date(value).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: 'numeric', timeZone: 'Australia/Perth' })
+}
+
+export default async function WorldCupPage() {
+  const pubs = await getPubs()
+  const bySlug = new Map(pubs.map(pub => [pub.slug, pub]))
+  const formGuide = FORM_GUIDE_SLUGS
+    .map(slug => bySlug.get(slug))
+    .filter((pub): pub is Pub => Boolean(pub))
+  const socceroos = WC_FIXTURES.filter(f => f.socceroos)
+  const renderedAtIso = new Date().toISOString()
+
+  return (
+    <main className="min-h-screen bg-[#FDF8F0]">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(buildFaqJsonLd()).replace(/</g, '\\u003c') }}
+      />
+      <BreadcrumbJsonLd items={[
+        { name: 'Home', url: BASE_URL },
+        { name: 'Where to watch the 2026 World Cup in Perth', url: canonical },
+      ]} />
+      <SubPageNav breadcrumbs={[{ label: 'World Cup' }]} />
+
+      <section className="max-w-container mx-auto px-6 pt-8 pb-12">
+        <p className="mb-3 type-eyebrow">World Cup 2026 · 11 June – 19 July</p>
+        <h1 className="type-hero-editorial">Where to watch the 2026 World Cup in Perth</h1>
+        <p className="mt-5 max-w-[640px] font-body text-[0.98rem] leading-relaxed text-gray-mid">
+          Perth sits 12 to 15 hours ahead of every host city, so all 104 matches land between midnight
+          and midday AWST — there is no evening kickoff for the entire tournament. Every match is free
+          on SBS, so a pub has to be worth getting out of bed for. This page keeps the kickoffs in Perth
+          time, shows which hours a venue can legally pour, and lists confirmed early opens with the
+          date we checked them.
+        </p>
+
+        <section className="my-8 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="type-eyebrow">Every kickoff</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">12am–12pm</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">All 104 matches land between midnight and midday, Perth time.</p>
+          </div>
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="type-eyebrow">Standard pour, Mon–Sat</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">6am</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Hotel, tavern and small bar licences trade 6am–midnight. Sunday starts at 10am.</p>
+          </div>
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <p className="type-eyebrow">Before 6am</p>
+            <p className="mt-2 font-mono text-3xl font-extrabold text-ink">Permit</p>
+            <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">Venues can apply to trade until 30 min after full-time while the broadcast runs.</p>
+          </div>
+        </section>
+        <p className="font-mono text-[0.68rem] text-gray-mid -mt-4 mb-8">
+          Licensing position checked {TIMES_CHECKED} — WA Director of Liquor Licensing announcement, 5 June 2026.
+        </p>
+
+        <section className="mb-10" aria-labelledby="socceroos-heading">
+          <h2 id="socceroos-heading" className="type-section mb-4">The Socceroos, in Perth time</h2>
+          <div className="grid gap-3 sm:grid-cols-3">
+            {socceroos.map(fixture => (
+              <div key={fixture.id} className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+                <p className="type-eyebrow">{formatDayHeading(fixtureDay(fixture.kickoff))}</p>
+                <p className="mt-2 font-mono text-3xl font-extrabold text-ink">{formatKickoff(fixture.kickoff)}</p>
+                <p className="mt-1 font-mono text-[0.82rem] font-bold text-ink">{fixture.home} v {fixture.away}</p>
+                <p className="mt-2 text-[0.76rem] leading-relaxed text-gray-mid">{SOCCEROOS_NOTES[fixture.id]}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="mb-10 rounded-card border-3 border-ink bg-ink p-5 text-white shadow-hard-sm" aria-labelledby="confirmed-heading">
+          <div className="flex items-start gap-3">
+            <ClipboardCheck className="mt-1 h-5 w-5 shrink-0 text-amber-light" />
+            <div className="min-w-0 flex-1">
+              <p className="type-eyebrow text-white/55">Checked and dated</p>
+              <h2 id="confirmed-heading" className="mt-2 type-section text-white">Confirmed early opens</h2>
+              {CONFIRMED_OPENINGS.length === 0 ? (
+                <>
+                  <p className="mt-3 font-body text-[0.9rem] leading-relaxed text-white/70">
+                    None confirmed yet — checked {TIMES_CHECKED}. When a venue confirms a door time for a
+                    specific match, it gets listed here with the date we checked, same as every pint price
+                    on this site. No venue gets listed on a maybe.
+                  </p>
+                  <Link
+                    href="/?submit=1"
+                    className="mt-4 inline-block rounded-pill border-3 border-white/90 bg-amber px-5 py-2.5 font-mono text-[0.72rem] font-bold uppercase tracking-[0.06em] text-white no-underline shadow-hard-sm hover:bg-amber-light"
+                  >
+                    Tell us about an early open
+                  </Link>
+                </>
+              ) : (
+                <ul className="mt-3 divide-y divide-white/15">
+                  {CONFIRMED_OPENINGS.map(opening => {
+                    const fixture = WC_FIXTURES.find(f => f.id === opening.fixtureId)
+                    return (
+                      <li key={`${opening.venue}-${opening.fixtureId}`} className="flex flex-wrap items-baseline gap-x-3 gap-y-1 py-3">
+                        <span className="font-mono text-[0.86rem] font-extrabold">{opening.venue}</span>
+                        <span className="text-[0.72rem] text-white/55">{opening.suburb}</span>
+                        {fixture && (
+                          <span className="text-[0.78rem] text-white/70">
+                            {fixture.home} v {fixture.away}, {formatKickoff(fixture.kickoff)} {formatDayHeading(fixtureDay(fixture.kickoff))}
+                          </span>
+                        )}
+                        <span className="font-mono text-[0.78rem] font-bold text-amber-light">{opening.doors}</span>
+                        <span className="text-[0.68rem] text-white/45">Confirmed {opening.confirmedAt} · {opening.source}</span>
+                      </li>
+                    )
+                  })}
+                </ul>
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section className="mb-10" aria-labelledby="fixtures-heading">
+          <h2 id="fixtures-heading" className="type-section mb-2">Every group game, Perth time</h2>
+          <p className="mb-4 max-w-[640px] font-body text-[0.88rem] leading-relaxed text-gray-mid">
+            Times converted from the confirmed schedule and checked on {TIMES_CHECKED}. Each match carries
+            its trading window: <span className="font-mono font-bold text-amber">permit hours</span> means
+            only venues holding the World Cup extended trading permit can pour,{' '}
+            <span className="font-mono font-bold text-ink">early doors</span> means legal from 6am on a
+            standard licence but earlier than most pubs open, and{' '}
+            <span className="font-mono font-bold text-gray-mid">normal trading</span> means any licensed
+            venue can show it. Knockout kickoffs get added once the bracket settles — we list nothing TBC.
+          </p>
+          <WorldCupFixtures renderedAtIso={renderedAtIso} />
+        </section>
+
+        <section className="mb-10" aria-labelledby="form-guide-heading">
+          <div className="rounded-card border-3 border-ink bg-white shadow-hard-sm">
+            <div className="border-b-3 border-ink bg-off-white px-5 py-4">
+              <p className="type-eyebrow">Form, not confirmations</p>
+              <h2 id="form-guide-heading" className="mt-1 type-section">The screens form guide</h2>
+              <p className="mt-2 max-w-[560px] text-[0.78rem] leading-relaxed text-gray-mid">
+                The rooms with form for live sport, with what a pint costs at each. None of these are
+                confirmed World Cup openings — the confirmed list above is the real thing. Run one of
+                these venues and opening early? Tell us and we will check it and list you.
+              </p>
+            </div>
+            <div className="divide-y divide-gray-light">
+              {formGuide.map(pub => (
+                <Link key={pub.id} href={pubUrl(pub)} className="group grid grid-cols-[1fr_auto] items-center gap-3 px-5 py-4 no-underline hover:bg-off-white">
+                  <span className="min-w-0">
+                    <span className="block truncate font-mono text-[0.86rem] font-extrabold text-ink group-hover:text-amber">{pub.name}</span>
+                    <span className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[0.68rem] text-gray-mid">
+                      <span>{pub.suburb}</span>
+                      {pub.regularPrice != null && <span>Checked {formatDate(pub.lastVerified ?? pub.priceVerifiedAt)}</span>}
+                    </span>
+                  </span>
+                  {pub.regularPrice != null ? (
+                    <span className="font-mono text-lg font-extrabold text-ink">{formatAudPrice(pub.regularPrice)}</span>
+                  ) : (
+                    <span className="font-mono text-[0.68rem] font-bold uppercase tracking-[0.06em] text-gray-mid">No checked price yet</span>
+                  )}
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="mb-10 grid gap-5 sm:grid-cols-2">
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <div className="mb-3 flex items-center gap-2">
+              <Tv className="h-4 w-4 text-amber" />
+              <h2 className="font-mono text-lg font-extrabold text-ink">The free options</h2>
+            </div>
+            <p className="font-body text-[0.85rem] leading-relaxed text-gray-mid">
+              Every match is on SBS and SBS On Demand for nothing. Northbridge Piazza is putting key
+              fixtures, including the Socceroos games, on its public screen, with Football West and
+              Perth Glory running fan activities for the Australia matches — and every pub we track
+              in <Link href="/northbridge" className="font-bold text-ink hover:text-amber">Northbridge</Link> is
+              a short walk from it.
+            </p>
+          </div>
+
+          <div className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+            <div className="mb-3 flex items-center gap-2">
+              <ClipboardCheck className="h-4 w-4 text-amber" />
+              <h2 className="font-mono text-lg font-extrabold text-ink">Picking a real early open</h2>
+            </div>
+            <p className="font-body text-[0.85rem] leading-relaxed text-gray-mid">
+              A real early open is specific: the venue names the match and the door time, not just a
+              generic World Cup graphic. For anything before 6am, ask if they have the extended trading
+              permit — paperwork beats an Instagram post. And a pint at 7am costs the same as a pint
+              at 7pm; nobody runs a breakfast discount.
+            </p>
+          </div>
+        </section>
+
+        <section className="mb-10 rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm" aria-labelledby="faq-heading">
+          <h2 id="faq-heading" className="type-section mb-4">Quick answers</h2>
+          <div className="space-y-4">
+            {FAQ_ITEMS.map(item => (
+              <div key={item.question}>
+                <h3 className="type-card">{item.question}</h3>
+                <p className="mt-1 text-[0.78rem] leading-relaxed text-gray-mid">{item.answer}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-card border-3 border-ink bg-white p-5 shadow-hard-sm">
+          <p className="type-eyebrow">Keep going</p>
+          <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            {[
+              { href: '/happy-hour', label: 'Happy hours for after the match' },
+              { href: '/discover', label: 'Find a pub near you' },
+              { href: '/cheapest-pints', label: 'Cheapest pints in Perth' },
+              { href: '/northbridge', label: 'Northbridge pint prices' },
+            ].map(link => (
+              <Link key={link.href} href={link.href} className="flex items-center justify-between rounded-card border border-gray-light px-4 py-3 font-mono text-[0.76rem] font-bold text-ink no-underline hover:border-amber hover:text-amber">
+                {link.label}<ArrowUpRight className="h-3.5 w-3.5" />
+              </Link>
+            ))}
+          </div>
+        </section>
+      </section>
+
+      <Footer />
+    </main>
+  )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -7,6 +7,7 @@ const NAV_LINKS = [
   { href: '/how-much-is-a-pint-in-perth', label: 'Pint Cost' },
   { href: '/student-pints-perth', label: 'Student Pints' },
   { href: '/pubs-near-perth-station', label: 'Near Station' },
+  { href: '/world-cup', label: 'World Cup' },
   { href: '/articles', label: 'Articles' },
   { href: '/suburbs', label: 'Suburbs' },
 ]

--- a/src/components/WorldCupFixtures.tsx
+++ b/src/components/WorldCupFixtures.tsx
@@ -1,0 +1,168 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  WC_FIXTURES,
+  TRADING_BADGES,
+  tradingStatus,
+  formatKickoff,
+  fixtureDay,
+  formatDayHeading,
+  matchPhase,
+  type MatchPhase,
+  type TradingStatus,
+  type WcFixture,
+} from '@/lib/worldCup'
+
+interface WorldCupFixturesProps {
+  renderedAtIso: string
+}
+
+type Filter = 'all' | 'groupD'
+
+const STATUS_CHIP_CLASSES: Record<TradingStatus, string> = {
+  permit: 'bg-amber-pale text-amber border border-amber/30',
+  early: 'bg-white text-ink/70 border border-ink/25',
+  normal: 'bg-off-white text-gray-mid border border-ink/10',
+}
+
+interface DayGroup {
+  day: string
+  heading: string
+  fixtures: Array<{ fixture: WcFixture; phase: MatchPhase; status: TradingStatus }>
+}
+
+export default function WorldCupFixtures({ renderedAtIso }: WorldCupFixturesProps) {
+  const [clockInstant, setClockInstant] = useState(() => new Date(renderedAtIso))
+  const [filter, setFilter] = useState<Filter>('all')
+  const [showPlayed, setShowPlayed] = useState(false)
+
+  useEffect(() => {
+    setClockInstant(new Date())
+    const interval = setInterval(() => setClockInstant(new Date()), 60_000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const { visibleDays, playedDays, nextFixtureId } = useMemo(() => {
+    const filtered = filter === 'groupD'
+      ? WC_FIXTURES.filter(f => f.socceroos || f.groupD)
+      : WC_FIXTURES
+
+    const groups = new Map<string, DayGroup>()
+    for (const fixture of filtered) {
+      const day = fixtureDay(fixture.kickoff)
+      if (!groups.has(day)) {
+        groups.set(day, { day, heading: formatDayHeading(day), fixtures: [] })
+      }
+      groups.get(day)!.fixtures.push({
+        fixture,
+        phase: matchPhase(fixture, clockInstant),
+        status: tradingStatus(fixture.kickoff),
+      })
+    }
+
+    const allDays = Array.from(groups.values())
+    const playedDays = allDays.filter(g => g.fixtures.every(f => f.phase === 'played'))
+    const currentDays = allDays.filter(g => g.fixtures.some(f => f.phase !== 'played'))
+    const nextFixtureId = currentDays
+      .flatMap(g => g.fixtures)
+      .find(f => f.phase === 'upcoming')?.fixture.id ?? null
+
+    return { visibleDays: currentDays, playedDays, nextFixtureId }
+  }, [clockInstant, filter])
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-2 mb-5">
+        {([
+          ['all', 'All matches'],
+          ['groupD', 'Socceroos & Group D'],
+        ] as Array<[Filter, string]>).map(([value, label]) => (
+          <button
+            key={value}
+            type="button"
+            onClick={() => setFilter(value)}
+            aria-pressed={filter === value}
+            className={`font-mono text-[0.7rem] font-bold uppercase tracking-[0.06em] px-4 py-2 rounded-pill border-3 border-ink transition-colors ${
+              filter === value ? 'bg-ink text-white' : 'bg-white text-ink hover:bg-off-white'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {playedDays.length > 0 && (
+        <div className="mb-5">
+          <button
+            type="button"
+            onClick={() => setShowPlayed(s => !s)}
+            className="font-mono text-[0.7rem] font-bold uppercase tracking-[0.06em] text-gray-mid hover:text-ink transition-colors"
+          >
+            {showPlayed ? 'Hide played matches' : `Show played matches (${playedDays.reduce((n, g) => n + g.fixtures.length, 0)})`}
+          </button>
+        </div>
+      )}
+
+      <div className="space-y-5">
+        {(showPlayed ? [...playedDays, ...visibleDays] : visibleDays).map(group => (
+          <section key={group.day} aria-label={group.heading} className="border-3 border-ink rounded-card bg-white shadow-hard-sm overflow-hidden">
+            <h3 className="font-mono text-[0.75rem] font-bold uppercase tracking-[0.06em] bg-ink text-white px-4 py-2.5">
+              {group.heading}
+            </h3>
+            <ul className="divide-y divide-ink/10">
+              {group.fixtures.map(({ fixture, phase, status }) => {
+                const isNext = fixture.id === nextFixtureId
+                const dimmed = phase === 'played'
+                return (
+                  <li
+                    key={fixture.id}
+                    className={`flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-3 ${
+                      fixture.socceroos ? 'bg-amber-pale/60' : ''
+                    } ${dimmed ? 'opacity-45' : ''}`}
+                  >
+                    <span className="font-mono text-[0.85rem] font-bold text-ink w-[4.5rem] shrink-0">
+                      {formatKickoff(fixture.kickoff)}
+                    </span>
+                    <span className={`font-body text-[0.9rem] text-ink min-w-[11rem] flex-1 ${fixture.socceroos ? 'font-bold' : ''}`}>
+                      {fixture.home} v {fixture.away}
+                    </span>
+                    <span className="ml-auto flex items-center gap-1.5 flex-wrap justify-end">
+                      {phase === 'live' && (
+                        <span className="font-mono text-[0.6rem] font-bold uppercase tracking-[0.06em] px-2 py-0.5 rounded-pill bg-amber text-white">
+                          On now
+                        </span>
+                      )}
+                      {isNext && phase === 'upcoming' && (
+                        <span className="font-mono text-[0.6rem] font-bold uppercase tracking-[0.06em] px-2 py-0.5 rounded-pill bg-ink text-white">
+                          Next
+                        </span>
+                      )}
+                      {(fixture.socceroos || fixture.groupD) && (
+                        <span className="font-mono text-[0.6rem] font-bold uppercase tracking-[0.06em] px-2 py-0.5 rounded-pill border border-ink/30 text-ink">
+                          {fixture.socceroos ? 'Socceroos' : 'Group D'}
+                        </span>
+                      )}
+                      <span
+                        className={`font-mono text-[0.6rem] font-bold uppercase tracking-[0.06em] px-2 py-0.5 rounded-pill ${STATUS_CHIP_CLASSES[status]}`}
+                        title={TRADING_BADGES[status].detail}
+                      >
+                        {TRADING_BADGES[status].label}
+                      </span>
+                    </span>
+                  </li>
+                )
+              })}
+            </ul>
+          </section>
+        ))}
+      </div>
+
+      {visibleDays.length === 0 && !showPlayed && (
+        <p className="font-body text-[0.9rem] text-gray-mid">
+          Group stage done. Knockout kickoff times land here once the bracket settles.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/lib/worldCup.test.ts
+++ b/src/lib/worldCup.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  WC_FIXTURES,
+  tradingStatus,
+  formatKickoff,
+  fixtureDay,
+  formatDayHeading,
+  matchPhase,
+  type WcFixture,
+} from './worldCup'
+
+describe('WC_FIXTURES data sanity', () => {
+  it('contains the full 72-match group stage', () => {
+    assert.equal(WC_FIXTURES.length, 72)
+  })
+
+  it('has unique ids', () => {
+    const ids = new Set(WC_FIXTURES.map(f => f.id))
+    assert.equal(ids.size, WC_FIXTURES.length)
+  })
+
+  it('every kickoff parses and carries the AWST offset', () => {
+    for (const f of WC_FIXTURES) {
+      assert.ok(!Number.isNaN(new Date(f.kickoff).getTime()), `${f.id} kickoff parses`)
+      assert.ok(f.kickoff.endsWith('+08:00'), `${f.id} kickoff is AWST`)
+    }
+  })
+
+  it('all fixtures land 12-28 June 2026 in Perth', () => {
+    for (const f of WC_FIXTURES) {
+      const day = fixtureDay(f.kickoff)
+      assert.ok(day >= '2026-06-12' && day <= '2026-06-28', `${f.id} on ${day}`)
+    }
+  })
+
+  it('every kickoff lands between midnight and midday AWST', () => {
+    for (const f of WC_FIXTURES) {
+      const label = formatKickoff(f.kickoff)
+      assert.ok(!label.endsWith('pm') || label === 'midday' || false, `${f.id} kicks off at ${label}`)
+    }
+  })
+
+  it('has exactly three Socceroos fixtures at the verified times', () => {
+    const socceroos = WC_FIXTURES.filter(f => f.socceroos)
+    assert.equal(socceroos.length, 3)
+    assert.deepEqual(
+      socceroos.map(f => [f.id, f.kickoff]),
+      [
+        ['2026-06-14-australia-turkiye', '2026-06-14T12:00:00+08:00'],
+        ['2026-06-20-usa-australia', '2026-06-20T03:00:00+08:00'],
+        ['2026-06-26-paraguay-australia', '2026-06-26T10:00:00+08:00'],
+      ],
+    )
+  })
+
+  it('marks the three non-Australia Group D fixtures', () => {
+    const groupD = WC_FIXTURES.filter(f => f.groupD)
+    assert.equal(groupD.length, 3)
+    assert.ok(groupD.every(f => !f.socceroos))
+  })
+})
+
+describe('tradingStatus', () => {
+  it('before 6am needs the permit, any day', () => {
+    assert.equal(tradingStatus('2026-06-20T03:00:00+08:00'), 'permit') // Saturday 3am
+    assert.equal(tradingStatus('2026-06-16T00:00:00+08:00'), 'permit') // Tuesday midnight
+    assert.equal(tradingStatus('2026-06-23T05:00:00+08:00'), 'permit') // Tuesday 5am
+  })
+
+  it('Sunday before 10am needs the permit even after 6am', () => {
+    assert.equal(tradingStatus('2026-06-14T06:00:00+08:00'), 'permit') // Sunday 6am
+    assert.equal(tradingStatus('2026-06-14T09:00:00+08:00'), 'permit') // Sunday 9am
+    assert.equal(tradingStatus('2026-06-28T07:30:00+08:00'), 'permit') // Sunday 7.30am
+  })
+
+  it('Sunday from 10am is normal trading', () => {
+    assert.equal(tradingStatus('2026-06-28T10:00:00+08:00'), 'normal')
+    assert.equal(tradingStatus('2026-06-14T12:00:00+08:00'), 'normal')
+  })
+
+  it('6am-9am Mon-Sat is early doors (legal, but check the venue opens)', () => {
+    assert.equal(tradingStatus('2026-06-19T06:00:00+08:00'), 'early') // Friday 6am
+    assert.equal(tradingStatus('2026-06-20T08:30:00+08:00'), 'early') // Saturday 8.30am
+  })
+
+  it('9am onwards Mon-Sat is normal trading', () => {
+    assert.equal(tradingStatus('2026-06-13T09:00:00+08:00'), 'normal') // Saturday 9am
+    assert.equal(tradingStatus('2026-06-17T12:00:00+08:00'), 'normal') // Wednesday midday
+  })
+})
+
+describe('formatKickoff', () => {
+  it('uses midnight and midday for the edges', () => {
+    assert.equal(formatKickoff('2026-06-16T00:00:00+08:00'), 'midnight')
+    assert.equal(formatKickoff('2026-06-14T12:00:00+08:00'), 'midday')
+  })
+
+  it('formats whole and half hours without trailing zeros', () => {
+    assert.equal(formatKickoff('2026-06-20T03:00:00+08:00'), '3am')
+    assert.equal(formatKickoff('2026-06-20T08:30:00+08:00'), '8.30am')
+    assert.equal(formatKickoff('2026-06-27T11:00:00+08:00'), '11am')
+    assert.equal(formatKickoff('2026-06-28T07:30:00+08:00'), '7.30am')
+  })
+})
+
+describe('formatDayHeading', () => {
+  it('renders the Perth weekday and date', () => {
+    assert.equal(formatDayHeading('2026-06-12'), 'Friday 12 June')
+    assert.equal(formatDayHeading('2026-06-14'), 'Sunday 14 June')
+    assert.equal(formatDayHeading('2026-06-28'), 'Sunday 28 June')
+  })
+})
+
+describe('matchPhase', () => {
+  const fixture: WcFixture = {
+    id: 'test',
+    kickoff: '2026-06-20T03:00:00+08:00',
+    home: 'USA',
+    away: 'Australia',
+  }
+
+  it('is upcoming before kickoff', () => {
+    assert.equal(matchPhase(fixture, new Date('2026-06-20T02:59:00+08:00')), 'upcoming')
+  })
+
+  it('is live from kickoff until two hours in', () => {
+    assert.equal(matchPhase(fixture, new Date('2026-06-20T03:00:00+08:00')), 'live')
+    assert.equal(matchPhase(fixture, new Date('2026-06-20T04:59:00+08:00')), 'live')
+  })
+
+  it('is played after the two-hour window', () => {
+    assert.equal(matchPhase(fixture, new Date('2026-06-20T05:00:00+08:00')), 'played')
+  })
+})

--- a/src/lib/worldCup.ts
+++ b/src/lib/worldCup.ts
@@ -1,0 +1,236 @@
+import { perthNow } from './perthClock'
+
+// 2026 FIFA World Cup — group-stage fixtures in Perth time (AWST, UTC+8).
+// Times cross-checked against two AEST schedule sources on 10 June 2026
+// (AWST = AEST − 2h). Knockout kickoffs are TBC until the bracket settles —
+// they are deliberately not listed rather than guessed.
+export const TIMES_CHECKED = '10 June 2026'
+
+export interface WcFixture {
+  id: string
+  /** Kickoff in AWST, ISO 8601 with +08:00 offset */
+  kickoff: string
+  home: string
+  away: string
+  /** Australia is playing */
+  socceroos?: boolean
+  /** Group D fixture that affects Australia's path */
+  groupD?: boolean
+}
+
+export const WC_FIXTURES: WcFixture[] = [
+  // Friday 12 June
+  { id: '2026-06-12-mexico-south-africa', kickoff: '2026-06-12T03:00:00+08:00', home: 'Mexico', away: 'South Africa' },
+  { id: '2026-06-12-south-korea-czech-republic', kickoff: '2026-06-12T10:00:00+08:00', home: 'South Korea', away: 'Czech Republic' },
+  // Saturday 13 June
+  { id: '2026-06-13-canada-bosnia', kickoff: '2026-06-13T03:00:00+08:00', home: 'Canada', away: 'Bosnia & Herzegovina' },
+  { id: '2026-06-13-usa-paraguay', kickoff: '2026-06-13T09:00:00+08:00', home: 'USA', away: 'Paraguay', groupD: true },
+  // Sunday 14 June
+  { id: '2026-06-14-qatar-switzerland', kickoff: '2026-06-14T03:00:00+08:00', home: 'Qatar', away: 'Switzerland' },
+  { id: '2026-06-14-brazil-morocco', kickoff: '2026-06-14T06:00:00+08:00', home: 'Brazil', away: 'Morocco' },
+  { id: '2026-06-14-haiti-scotland', kickoff: '2026-06-14T09:00:00+08:00', home: 'Haiti', away: 'Scotland' },
+  { id: '2026-06-14-australia-turkiye', kickoff: '2026-06-14T12:00:00+08:00', home: 'Australia', away: 'Türkiye', socceroos: true },
+  // Monday 15 June
+  { id: '2026-06-15-germany-curacao', kickoff: '2026-06-15T01:00:00+08:00', home: 'Germany', away: 'Curaçao' },
+  { id: '2026-06-15-netherlands-japan', kickoff: '2026-06-15T04:00:00+08:00', home: 'Netherlands', away: 'Japan' },
+  { id: '2026-06-15-ivory-coast-ecuador', kickoff: '2026-06-15T07:00:00+08:00', home: 'Ivory Coast', away: 'Ecuador' },
+  { id: '2026-06-15-sweden-tunisia', kickoff: '2026-06-15T10:00:00+08:00', home: 'Sweden', away: 'Tunisia' },
+  // Tuesday 16 June
+  { id: '2026-06-16-spain-cape-verde', kickoff: '2026-06-16T00:00:00+08:00', home: 'Spain', away: 'Cape Verde' },
+  { id: '2026-06-16-belgium-egypt', kickoff: '2026-06-16T03:00:00+08:00', home: 'Belgium', away: 'Egypt' },
+  { id: '2026-06-16-saudi-arabia-uruguay', kickoff: '2026-06-16T06:00:00+08:00', home: 'Saudi Arabia', away: 'Uruguay' },
+  { id: '2026-06-16-iran-new-zealand', kickoff: '2026-06-16T09:00:00+08:00', home: 'Iran', away: 'New Zealand' },
+  // Wednesday 17 June
+  { id: '2026-06-17-france-senegal', kickoff: '2026-06-17T03:00:00+08:00', home: 'France', away: 'Senegal' },
+  { id: '2026-06-17-iraq-norway', kickoff: '2026-06-17T06:00:00+08:00', home: 'Iraq', away: 'Norway' },
+  { id: '2026-06-17-argentina-algeria', kickoff: '2026-06-17T09:00:00+08:00', home: 'Argentina', away: 'Algeria' },
+  { id: '2026-06-17-austria-jordan', kickoff: '2026-06-17T12:00:00+08:00', home: 'Austria', away: 'Jordan' },
+  // Thursday 18 June
+  { id: '2026-06-18-portugal-dr-congo', kickoff: '2026-06-18T01:00:00+08:00', home: 'Portugal', away: 'DR Congo' },
+  { id: '2026-06-18-england-croatia', kickoff: '2026-06-18T04:00:00+08:00', home: 'England', away: 'Croatia' },
+  { id: '2026-06-18-ghana-panama', kickoff: '2026-06-18T07:00:00+08:00', home: 'Ghana', away: 'Panama' },
+  { id: '2026-06-18-uzbekistan-colombia', kickoff: '2026-06-18T10:00:00+08:00', home: 'Uzbekistan', away: 'Colombia' },
+  // Friday 19 June
+  { id: '2026-06-19-czech-republic-south-africa', kickoff: '2026-06-19T00:00:00+08:00', home: 'Czech Republic', away: 'South Africa' },
+  { id: '2026-06-19-switzerland-bosnia', kickoff: '2026-06-19T03:00:00+08:00', home: 'Switzerland', away: 'Bosnia & Herzegovina' },
+  { id: '2026-06-19-canada-qatar', kickoff: '2026-06-19T06:00:00+08:00', home: 'Canada', away: 'Qatar' },
+  { id: '2026-06-19-mexico-south-korea', kickoff: '2026-06-19T09:00:00+08:00', home: 'Mexico', away: 'South Korea' },
+  // Saturday 20 June
+  { id: '2026-06-20-usa-australia', kickoff: '2026-06-20T03:00:00+08:00', home: 'USA', away: 'Australia', socceroos: true },
+  { id: '2026-06-20-scotland-morocco', kickoff: '2026-06-20T06:00:00+08:00', home: 'Scotland', away: 'Morocco' },
+  { id: '2026-06-20-brazil-haiti', kickoff: '2026-06-20T08:30:00+08:00', home: 'Brazil', away: 'Haiti' },
+  { id: '2026-06-20-turkiye-paraguay', kickoff: '2026-06-20T11:00:00+08:00', home: 'Türkiye', away: 'Paraguay', groupD: true },
+  // Sunday 21 June
+  { id: '2026-06-21-netherlands-sweden', kickoff: '2026-06-21T01:00:00+08:00', home: 'Netherlands', away: 'Sweden' },
+  { id: '2026-06-21-germany-ivory-coast', kickoff: '2026-06-21T04:00:00+08:00', home: 'Germany', away: 'Ivory Coast' },
+  { id: '2026-06-21-ecuador-curacao', kickoff: '2026-06-21T08:00:00+08:00', home: 'Ecuador', away: 'Curaçao' },
+  { id: '2026-06-21-tunisia-japan', kickoff: '2026-06-21T12:00:00+08:00', home: 'Tunisia', away: 'Japan' },
+  // Monday 22 June
+  { id: '2026-06-22-spain-saudi-arabia', kickoff: '2026-06-22T00:00:00+08:00', home: 'Spain', away: 'Saudi Arabia' },
+  { id: '2026-06-22-belgium-iran', kickoff: '2026-06-22T03:00:00+08:00', home: 'Belgium', away: 'Iran' },
+  { id: '2026-06-22-uruguay-cape-verde', kickoff: '2026-06-22T06:00:00+08:00', home: 'Uruguay', away: 'Cape Verde' },
+  { id: '2026-06-22-new-zealand-egypt', kickoff: '2026-06-22T09:00:00+08:00', home: 'New Zealand', away: 'Egypt' },
+  // Tuesday 23 June
+  { id: '2026-06-23-argentina-austria', kickoff: '2026-06-23T01:00:00+08:00', home: 'Argentina', away: 'Austria' },
+  { id: '2026-06-23-france-iraq', kickoff: '2026-06-23T05:00:00+08:00', home: 'France', away: 'Iraq' },
+  { id: '2026-06-23-norway-senegal', kickoff: '2026-06-23T08:00:00+08:00', home: 'Norway', away: 'Senegal' },
+  { id: '2026-06-23-jordan-algeria', kickoff: '2026-06-23T11:00:00+08:00', home: 'Jordan', away: 'Algeria' },
+  // Wednesday 24 June
+  { id: '2026-06-24-portugal-uzbekistan', kickoff: '2026-06-24T01:00:00+08:00', home: 'Portugal', away: 'Uzbekistan' },
+  { id: '2026-06-24-england-ghana', kickoff: '2026-06-24T04:00:00+08:00', home: 'England', away: 'Ghana' },
+  { id: '2026-06-24-panama-croatia', kickoff: '2026-06-24T07:00:00+08:00', home: 'Panama', away: 'Croatia' },
+  { id: '2026-06-24-colombia-dr-congo', kickoff: '2026-06-24T10:00:00+08:00', home: 'Colombia', away: 'DR Congo' },
+  // Thursday 25 June
+  { id: '2026-06-25-switzerland-canada', kickoff: '2026-06-25T03:00:00+08:00', home: 'Switzerland', away: 'Canada' },
+  { id: '2026-06-25-bosnia-qatar', kickoff: '2026-06-25T03:00:00+08:00', home: 'Bosnia & Herzegovina', away: 'Qatar' },
+  { id: '2026-06-25-scotland-brazil', kickoff: '2026-06-25T06:00:00+08:00', home: 'Scotland', away: 'Brazil' },
+  { id: '2026-06-25-morocco-haiti', kickoff: '2026-06-25T06:00:00+08:00', home: 'Morocco', away: 'Haiti' },
+  { id: '2026-06-25-south-africa-south-korea', kickoff: '2026-06-25T09:00:00+08:00', home: 'South Africa', away: 'South Korea' },
+  { id: '2026-06-25-czech-republic-mexico', kickoff: '2026-06-25T09:00:00+08:00', home: 'Czech Republic', away: 'Mexico' },
+  // Friday 26 June
+  { id: '2026-06-26-curacao-ivory-coast', kickoff: '2026-06-26T04:00:00+08:00', home: 'Curaçao', away: 'Ivory Coast' },
+  { id: '2026-06-26-ecuador-germany', kickoff: '2026-06-26T04:00:00+08:00', home: 'Ecuador', away: 'Germany' },
+  { id: '2026-06-26-tunisia-netherlands', kickoff: '2026-06-26T07:00:00+08:00', home: 'Tunisia', away: 'Netherlands' },
+  { id: '2026-06-26-japan-sweden', kickoff: '2026-06-26T07:00:00+08:00', home: 'Japan', away: 'Sweden' },
+  { id: '2026-06-26-paraguay-australia', kickoff: '2026-06-26T10:00:00+08:00', home: 'Paraguay', away: 'Australia', socceroos: true },
+  { id: '2026-06-26-turkiye-usa', kickoff: '2026-06-26T10:00:00+08:00', home: 'Türkiye', away: 'USA', groupD: true },
+  // Saturday 27 June
+  { id: '2026-06-27-norway-france', kickoff: '2026-06-27T03:00:00+08:00', home: 'Norway', away: 'France' },
+  { id: '2026-06-27-senegal-iraq', kickoff: '2026-06-27T03:00:00+08:00', home: 'Senegal', away: 'Iraq' },
+  { id: '2026-06-27-uruguay-spain', kickoff: '2026-06-27T08:00:00+08:00', home: 'Uruguay', away: 'Spain' },
+  { id: '2026-06-27-cape-verde-saudi-arabia', kickoff: '2026-06-27T08:00:00+08:00', home: 'Cape Verde', away: 'Saudi Arabia' },
+  { id: '2026-06-27-egypt-iran', kickoff: '2026-06-27T11:00:00+08:00', home: 'Egypt', away: 'Iran' },
+  { id: '2026-06-27-new-zealand-belgium', kickoff: '2026-06-27T11:00:00+08:00', home: 'New Zealand', away: 'Belgium' },
+  // Sunday 28 June
+  { id: '2026-06-28-croatia-ghana', kickoff: '2026-06-28T05:00:00+08:00', home: 'Croatia', away: 'Ghana' },
+  { id: '2026-06-28-panama-england', kickoff: '2026-06-28T05:00:00+08:00', home: 'Panama', away: 'England' },
+  { id: '2026-06-28-colombia-portugal', kickoff: '2026-06-28T07:30:00+08:00', home: 'Colombia', away: 'Portugal' },
+  { id: '2026-06-28-dr-congo-uzbekistan', kickoff: '2026-06-28T07:30:00+08:00', home: 'DR Congo', away: 'Uzbekistan' },
+  { id: '2026-06-28-jordan-argentina', kickoff: '2026-06-28T10:00:00+08:00', home: 'Jordan', away: 'Argentina' },
+  { id: '2026-06-28-algeria-austria', kickoff: '2026-06-28T10:00:00+08:00', home: 'Algeria', away: 'Austria' },
+]
+
+// --- WA licensing windows -------------------------------------------------
+// Standard hotel/tavern/small bar hours: 6am–midnight Mon–Sat, 10am–midnight
+// Sunday (DLGSC licence types & trading hours, checked 10 June 2026).
+// For matches outside those hours, venues need the World Cup extended
+// trading permit announced by the Director of Liquor Licensing on
+// 5 June 2026 (trade until 30 min after full-time while the broadcast runs).
+
+export type TradingStatus = 'permit' | 'early' | 'normal'
+
+export interface TradingBadge {
+  label: string
+  detail: string
+}
+
+export const TRADING_BADGES: Record<TradingStatus, TradingBadge> = {
+  permit: {
+    label: 'Permit hours',
+    detail: 'Outside standard trading — only venues holding a World Cup extended trading permit can pour.',
+  },
+  early: {
+    label: 'Early doors',
+    detail: 'Legal from 6am on a standard licence — but earlier than most pubs open, so check doors.',
+  },
+  normal: {
+    label: 'Normal trading',
+    detail: 'Inside standard hours for any licensed venue. Screens, not licensing, decide where to go.',
+  },
+}
+
+/** Classify a kickoff against WA standard trading hours. */
+export function tradingStatus(kickoffIso: string): TradingStatus {
+  const perth = perthNow(new Date(kickoffIso))
+  const minutes = perth.minutesOfDay
+  const sunday = perth.dayOfWeek === 0
+  if (minutes < 6 * 60) return 'permit'
+  if (sunday && minutes < 10 * 60) return 'permit'
+  if (minutes < 9 * 60) return 'early'
+  return 'normal'
+}
+
+// --- Formatting helpers ---------------------------------------------------
+
+/** "midnight", "midday", "3am", "8.30am" */
+export function formatKickoff(kickoffIso: string): string {
+  const minutes = perthNow(new Date(kickoffIso)).minutesOfDay
+  if (minutes === 0) return 'midnight'
+  if (minutes === 12 * 60) return 'midday'
+  const h24 = Math.floor(minutes / 60)
+  const mins = minutes % 60
+  const suffix = h24 < 12 ? 'am' : 'pm'
+  const h12 = h24 % 12 === 0 ? 12 : h24 % 12
+  return mins === 0 ? `${h12}${suffix}` : `${h12}.${String(mins).padStart(2, '0')}${suffix}`
+}
+
+/** Perth calendar date of the kickoff, "2026-06-14" */
+export function fixtureDay(kickoffIso: string): string {
+  return perthNow(new Date(kickoffIso)).ymd
+}
+
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+const MONTH_NAMES = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+
+/** "Friday 12 June" from a Perth ymd string */
+export function formatDayHeading(ymd: string): string {
+  const perth = perthNow(new Date(`${ymd}T00:00:00+08:00`))
+  const [, month, day] = ymd.split('-').map(Number)
+  return `${DAY_NAMES[perth.dayOfWeek]} ${day} ${MONTH_NAMES[month - 1]}`
+}
+
+// --- Live state -----------------------------------------------------------
+
+export type MatchPhase = 'upcoming' | 'live' | 'played'
+
+const MATCH_RUNTIME_MS = 120 * 60 * 1000
+
+export function matchPhase(fixture: WcFixture, now: Date): MatchPhase {
+  const kickoff = new Date(fixture.kickoff).getTime()
+  const t = now.getTime()
+  if (t < kickoff) return 'upcoming'
+  if (t < kickoff + MATCH_RUNTIME_MS) return 'live'
+  return 'played'
+}
+
+// --- Confirmed openings ---------------------------------------------------
+// A venue lands here only once its opening time for a specific match is
+// confirmed — with the date we checked. No guesses: an empty list renders
+// as an honest empty state, not filler.
+
+export interface ConfirmedOpening {
+  /** Slug in our pubs table, when we track the venue */
+  pubSlug?: string
+  venue: string
+  suburb: string
+  fixtureId: string
+  /** e.g. "Doors 2.30am" */
+  doors: string
+  /** Date we confirmed it, e.g. "10 June 2026" */
+  confirmedAt: string
+  source: 'venue call' | 'venue post' | 'reader report'
+}
+
+export const CONFIRMED_OPENINGS: ConfirmedOpening[] = []
+
+// --- Form guide -----------------------------------------------------------
+// Venues with form for showing sport (and the ones the directories list),
+// mapped to our pub pages so prices and freshness ride along. This is form,
+// not confirmation — the confirmed list above is the real thing.
+
+export const FORM_GUIDE_SLUGS: string[] = [
+  'rosie-ogradys',
+  'the-brass-monkey',
+  'varsity-northbridge',
+  'durty-nellys-irish-pub',
+  'the-globe',
+  'the-generous-squire',
+  'the-lucky-shag',
+  'the-camfield',
+  'crown-sports-bar',
+  'the-royal-on-the-waterfront',
+  'brewdog-perth',
+  'j-b-oreillys',
+  'paddington-ale-house',
+  'victoria-park-hotel',
+]


### PR DESCRIPTION
## What

A new `/world-cup` page: the FANZO-style fixture hub, built on our trust loop. Tournament starts 11 June (first Perth kickoff: 3am Friday 12 June).

- **All 72 group-stage fixtures in Perth time**, grouped by day. Captured from FANZO's geo-localised rail and cross-checked against two independent AEST schedule sources (AWST = AEST − 2h); the three Socceroos kickoffs additionally verified against the official Socceroos announcement. Knockouts are deliberately omitted until the bracket settles — we list nothing TBC.
- **WA trading window on every match** — the column nobody else can render:
  - `permit hours` — midnight–6am any day, plus Sunday before 10am: only venues holding the World Cup extended trading permit (Director of Liquor Licensing announcement, 5 June 2026) can pour
  - `early doors` — 6–9am Mon–Sat: legal on a standard hotel/tavern/small bar licence, earlier than most pubs open
  - `normal trading` — inside standard hours
- **Live state**: ON NOW / NEXT chips, played matches auto-collapse, All / Socceroos & Group D filter, Socceroos rows highlighted.
- **Confirmed early opens ledger** — honest empty state until venues confirm a door time for a specific match; each future entry carries the date we checked and the source. No Andrew for now, so confirmations are manual + the report form.
- **Screens form guide** — the rooms with form for live sport, each with the live pint price and its checked date from our own data (FANZO lists venues; we list venues with the price and the date).
- SEO: title/description/canonical/OG/Twitter, BreadcrumbJsonLd, FAQPage JSON-LD with four verified Q&As, sitemap entry, footer link.

## Verification

- `tsc --noEmit` clean; lint clean (one pre-existing SunsetSippers warning)
- 294 unit tests pass — 18 new covering fixture-data sanity (72 matches, unique ids, all between midnight and midday AWST), the licensing classifier including the Sunday edge cases, kickoff formatting, and match phases
- Playwright screenshots verified at 1280x800 and 375x812; mobile chip-wrap fixed so chips drop below the fixture line instead of splitting team names
- Sunday licensing logic confirmed in the rendered page: Brazil v Morocco (Sun 6am) shows permit hours, Australia v Türkiye (Sun midday) shows normal trading

## Notes

- Independent of #176 (branched off main). The draft World Cup *article* in that workflow can publish later as the editorial long-read linking here.
- `CONFIRMED_OPENINGS` in `src/lib/worldCup.ts` is the single place to add a confirmed venue: pub slug, fixture id, doors time, checked date, source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)