### PR TITLE
Mobile polish for the homepage World Cup strip

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,11 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Homepage World Cup strip: mobile polish (2026-06-10)
+- The strip's header crammed both labels side-by-side at 375px (each wrapped to two lines); now they stack on mobile, side-by-side from `sm:` up.
+- The fixture rail scrolls full-bleed (`-mx-6`/`px-6` with `scroll-pl-6`) with snap points and a hidden scrollbar, matching the /discover picks rail — the next card peeks at the screen edge instead of being chopped at the container boundary.
+- Verified with Playwright at 375x812 (rest + scrolled states); `tsc` clean.
+
 ### Brand assets: stale arvo/PintDex images replaced (2026-06-10)
 - The OG share card still said **"arvo"** with dead stats (420+ venues / 154 suburbs); `logo.png`, `favicon.ico` and the PWA/iOS icons were older still (**"PintDex"**) — so every WhatsApp/social preview, browser tab and the Organization JSON-LD logo showed retired branding.
 - New `scripts/generate-brand-assets.mjs` (Playwright render of the real fonts/tokens) regenerates `og-image.png` (evergreen copy, no counts to go stale), `logo.png`, `icon-512/192`, `apple-touch-icon`; `scripts/build-favicon.py` assembles `favicon.ico`. Manifest colours updated to current tokens. Commit `eb3abc8`. PR #178.

--- a/src/components/HomeWorldCup.tsx
+++ b/src/components/HomeWorldCup.tsx
@@ -18,7 +18,7 @@ export default function HomeWorldCup() {
 
   return (
     <section aria-label="World Cup 2026" className="max-w-container mx-auto px-6 mb-6">
-      <div className="mb-3 flex items-center justify-between gap-3">
+      <div className="mb-3 flex flex-col items-start gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
         <p className="type-eyebrow">World Cup 2026 · free on SBS</p>
         <Link
           href="/world-cup"
@@ -28,12 +28,15 @@ export default function HomeWorldCup() {
           <ArrowUpRight className="h-3 w-3" />
         </Link>
       </div>
-      <div className="flex gap-3 overflow-x-auto pb-1 sm:grid sm:grid-cols-3 sm:overflow-visible sm:pb-0">
+      <div
+        className="-mx-6 flex snap-x snap-mandatory gap-3 overflow-x-auto scroll-pl-6 px-6 pb-1 sm:mx-0 sm:grid sm:grid-cols-3 sm:overflow-visible sm:px-0 sm:pb-0"
+        style={{ scrollbarWidth: 'none', msOverflowStyle: 'none', WebkitOverflowScrolling: 'touch' }}
+      >
         {socceroos.map(fixture => (
           <Link
             key={fixture.id}
             href="/world-cup"
-            className="block min-w-[230px] flex-1 overflow-hidden rounded-card border-3 border-ink bg-white shadow-hard-sm no-underline transition-all hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover sm:min-w-0"
+            className="block min-w-[240px] flex-1 snap-start overflow-hidden rounded-card border-3 border-ink bg-white shadow-hard-sm no-underline transition-all hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover sm:min-w-0"
           >
             <TeamStripes home={fixture.home} away={fixture.away} />
             <div className="px-4 py-3">


### PR DESCRIPTION
## What

Mobile polish for the homepage World Cup strip (flagged from a WhatsApp screenshot):

- The header row crammed "World Cup 2026 · free on SBS" and "Every kickoff in Perth time" side-by-side at 375px, wrapping both to two lines. They now stack on mobile and sit side-by-side from `sm:` up.
- The fixture rail now scrolls full-bleed to the screen edge with snap points and a hidden scrollbar (same pattern as the /discover picks rail), so the next card peeks naturally instead of being chopped at the container boundary.

## Verification

- `npx tsc --noEmit` clean
- Playwright screenshots at 375x812, both at rest and mid-scroll; desktop 3-up grid unchanged

https://claude.ai/code/session_01FCyEdyeKbWCHzQP5nyfNex

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCyEdyeKbWCHzQP5nyfNex)_