### PR TITLE
World Cup page polish: softer confirmed-opens card, team flags, tidier fixture rows

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -28,6 +28,12 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 - **Action needed:** create a Slack incoming webhook and add `SLACK_WEBHOOK_URL` to Vercel env vars — until then the code no-ops with a console warning.
 - **Verification:** `tsc` clean, **308 unit tests** pass (+7 new in `slackNotify.test.ts`). Commit `dce54d2`.
 
+### /world-cup: softer confirmed-opens card + flag chips on fixture rows (2026-06-10)
+- The "Confirmed early opens" card was a solid `bg-ink` block mid-page — restyled to `bg-amber-pale` with ink text and the standard white pill button (user found the dark block harsh).
+- `TEAM_COLOURS` extended from Group D (4 teams) to **all 48 qualified teams** with real flag-stripe palettes; fixture rows now show a small stacked-stripe flag chip glued to each team name (no emoji), and the team-colour bands on Socceroos cards pick up the new entries automatically.
+- Fixture row layout moved from ragged flex-wrap to a grid: time column, teams with flags, chips right-aligned on desktop and indented under the match on mobile. Trading chips crispened (`border-2`, stronger tints).
+- Verified with Playwright at 375x812; `tsc` clean, 302 tests pass.
+
 ### Homepage World Cup strip: mobile polish (2026-06-10)
 - The strip's header crammed both labels side-by-side at 375px (each wrapped to two lines); now they stack on mobile, side-by-side from `sm:` up.
 - The fixture rail scrolls full-bleed (`-mx-6`/`px-6` with `scroll-pl-6`) with snap points and a hidden scrollbar, matching the /discover picks rail — the next card peeks at the screen edge instead of being chopped at the container boundary.

--- a/src/app/world-cup/page.tsx
+++ b/src/app/world-cup/page.tsx
@@ -160,41 +160,41 @@ export default async function WorldCupPage() {
           </div>
         </section>
 
-        <section className="mb-10 rounded-card border-3 border-ink bg-ink p-5 text-white shadow-hard-sm" aria-labelledby="confirmed-heading">
+        <section className="mb-10 rounded-card border-3 border-ink bg-amber-pale p-5 shadow-hard-sm" aria-labelledby="confirmed-heading">
           <div className="flex items-start gap-3">
-            <ClipboardCheck className="mt-1 h-5 w-5 shrink-0 text-amber-light" />
+            <ClipboardCheck className="mt-1 h-5 w-5 shrink-0 text-amber" />
             <div className="min-w-0 flex-1">
-              <p className="type-eyebrow text-white/55">Checked and dated</p>
-              <h2 id="confirmed-heading" className="mt-2 type-section text-white">Confirmed early opens</h2>
+              <p className="type-eyebrow">Checked and dated</p>
+              <h2 id="confirmed-heading" className="mt-2 type-section">Confirmed early opens</h2>
               {CONFIRMED_OPENINGS.length === 0 ? (
                 <>
-                  <p className="mt-3 font-body text-[0.9rem] leading-relaxed text-white/70">
+                  <p className="mt-3 font-body text-[0.9rem] leading-relaxed text-gray-mid">
                     None confirmed yet — checked {TIMES_CHECKED}. When a venue confirms a door time for a
                     specific match, it gets listed here with the date we checked, same as every pint price
                     on this site. No venue gets listed on a maybe.
                   </p>
                   <Link
                     href="/?submit=1"
-                    className="mt-4 inline-block rounded-pill border-3 border-white/90 bg-amber px-5 py-2.5 font-mono text-[0.72rem] font-bold uppercase tracking-[0.06em] text-white no-underline shadow-hard-sm hover:bg-amber-light"
+                    className="mt-4 inline-block rounded-pill border-3 border-ink bg-white px-5 py-2.5 font-mono text-[0.72rem] font-bold uppercase tracking-[0.06em] text-ink no-underline shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all"
                   >
                     Tell us about an early open
                   </Link>
                 </>
               ) : (
-                <ul className="mt-3 divide-y divide-white/15">
+                <ul className="mt-3 divide-y divide-ink/10">
                   {CONFIRMED_OPENINGS.map(opening => {
                     const fixture = WC_FIXTURES.find(f => f.id === opening.fixtureId)
                     return (
                       <li key={`${opening.venue}-${opening.fixtureId}`} className="flex flex-wrap items-baseline gap-x-3 gap-y-1 py-3">
-                        <span className="font-mono text-[0.86rem] font-extrabold">{opening.venue}</span>
-                        <span className="text-[0.72rem] text-white/55">{opening.suburb}</span>
+                        <span className="font-mono text-[0.86rem] font-extrabold text-ink">{opening.venue}</span>
+                        <span className="text-[0.72rem] text-gray-mid">{opening.suburb}</span>
                         {fixture && (
-                          <span className="text-[0.78rem] text-white/70">
+                          <span className="text-[0.78rem] text-gray-mid">
                             {fixture.home} v {fixture.away}, {formatKickoff(fixture.kickoff)} {formatDayHeading(fixtureDay(fixture.kickoff))}
                           </span>
                         )}
-                        <span className="font-mono text-[0.78rem] font-bold text-amber-light">{opening.doors}</span>
-                        <span className="text-[0.68rem] text-white/45">Confirmed {opening.confirmedAt} · {opening.source}</span>
+                        <span className="font-mono text-[0.78rem] font-bold text-amber">{opening.doors}</span>
+                        <span className="text-[0.68rem] text-gray-mid">Confirmed {opening.confirmedAt} · {opening.source}</span>
                       </li>
                     )
                   })}

--- a/src/components/WorldCupFixtures.tsx
+++ b/src/components/WorldCupFixtures.tsx
@@ -5,6 +5,7 @@ import WorldCupCountdown from '@/components/WorldCupCountdown'
 import {
   WC_FIXTURES,
   TRADING_BADGES,
+  teamColours,
   tradingStatus,
   formatKickoff,
   fixtureDay,
@@ -15,6 +16,20 @@ import {
   type WcFixture,
 } from '@/lib/worldCup'
 
+// Tiny stacked-stripe flag, glued to its team name so a wrap never separates them.
+function TeamName({ team, bold }: { team: string; bold?: boolean }) {
+  return (
+    <span className={`inline-flex items-center gap-1.5 ${bold ? 'font-bold' : ''}`}>
+      <span aria-hidden="true" className="flex h-[11px] w-[17px] shrink-0 flex-col overflow-hidden rounded-[2px] border border-ink/30">
+        {teamColours(team).map((colour, i) => (
+          <span key={i} className="w-full flex-1" style={{ backgroundColor: colour }} />
+        ))}
+      </span>
+      {team}
+    </span>
+  )
+}
+
 interface WorldCupFixturesProps {
   renderedAtIso: string
 }
@@ -22,9 +37,9 @@ interface WorldCupFixturesProps {
 type Filter = 'all' | 'groupD'
 
 const STATUS_CHIP_CLASSES: Record<TradingStatus, string> = {
-  permit: 'bg-amber-pale text-amber border border-amber/30',
-  early: 'bg-white text-ink/70 border border-ink/25',
-  normal: 'bg-off-white text-gray-mid border border-ink/10',
+  permit: 'bg-amber-pale text-amber border-2 border-amber/50',
+  early: 'bg-white text-ink border-2 border-ink/30',
+  normal: 'bg-off-white text-gray-mid border-2 border-ink/10',
 }
 
 interface DayGroup {
@@ -118,17 +133,19 @@ export default function WorldCupFixtures({ renderedAtIso }: WorldCupFixturesProp
                 return (
                   <li
                     key={fixture.id}
-                    className={`flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-3 ${
+                    className={`grid grid-cols-[4.2rem_1fr] items-center gap-x-3 gap-y-2 px-4 py-3.5 sm:grid-cols-[4.2rem_1fr_auto] ${
                       fixture.socceroos ? 'bg-amber-pale/60' : ''
                     } ${dimmed ? 'opacity-45' : ''}`}
                   >
-                    <span className="font-mono text-[0.85rem] font-bold text-ink w-[4.5rem] shrink-0">
+                    <span className="font-mono text-[0.85rem] font-bold text-ink">
                       {formatKickoff(fixture.kickoff)}
                     </span>
-                    <span className={`font-body text-[0.9rem] text-ink min-w-[11rem] flex-1 ${fixture.socceroos ? 'font-bold' : ''}`}>
-                      {fixture.home} v {fixture.away}
+                    <span className="flex flex-wrap items-center gap-x-2 gap-y-1 font-body text-[0.9rem] text-ink">
+                      <TeamName team={fixture.home} bold={fixture.socceroos} />
+                      <span className="font-mono text-[0.7rem] text-gray-mid">v</span>
+                      <TeamName team={fixture.away} bold={fixture.socceroos} />
                     </span>
-                    <span className="ml-auto flex items-center gap-1.5 flex-wrap justify-end">
+                    <span className="col-start-2 flex flex-wrap items-center gap-1.5 sm:col-start-3 sm:row-start-1 sm:justify-end">
                       {phase === 'live' && (
                         <span className="font-mono text-[0.6rem] font-bold uppercase tracking-[0.06em] px-2 py-0.5 rounded-pill bg-amber text-white">
                           On now

--- a/src/lib/worldCup.ts
+++ b/src/lib/worldCup.ts
@@ -212,15 +212,60 @@ export function matchPhase(fixture: WcFixture, now: Date): MatchPhase {
 }
 
 // --- Team colours ----------------------------------------------------------
-// Flag/kit colours for the stripe band on fixture cards. Group D only for
-// now — knockout opponents get added when the bracket settles. Unknown teams
-// fall back to a neutral stripe so a missing entry never breaks a card.
+// Flag colours (top-to-bottom stripes) for every qualified team in the
+// fixture list — drives the stripe bands on fixture cards and the flag chips
+// in the fixture rows. Unknown teams fall back to a neutral stripe so a
+// missing entry never breaks a card.
 
 export const TEAM_COLOURS: Record<string, string[]> = {
+  Algeria: ['#006233', '#FFFFFF', '#D21034'],
+  Argentina: ['#74ACDF', '#FFFFFF', '#74ACDF'],
   Australia: ['#FFCD00', '#00843D'],
-  'Türkiye': ['#E30A17', '#FFFFFF'],
-  USA: ['#041E42', '#FFFFFF', '#BF0D3E'],
+  Austria: ['#ED2939', '#FFFFFF', '#ED2939'],
+  Belgium: ['#000000', '#FDDA24', '#EF3340'],
+  'Bosnia & Herzegovina': ['#002395', '#FECB00', '#002395'],
+  Brazil: ['#009C3B', '#FFDF00', '#002776'],
+  Canada: ['#FF0000', '#FFFFFF', '#FF0000'],
+  'Cape Verde': ['#003893', '#FFFFFF', '#CF2027'],
+  Colombia: ['#FCD116', '#003893', '#CE1126'],
+  Croatia: ['#FF0000', '#FFFFFF', '#171796'],
+  'Curaçao': ['#002B7F', '#F9E814', '#002B7F'],
+  'Czech Republic': ['#FFFFFF', '#D7141A', '#11457E'],
+  'DR Congo': ['#007FFF', '#F7D618', '#CE1021'],
+  Ecuador: ['#FFDD00', '#034EA2', '#ED1C24'],
+  Egypt: ['#CE1126', '#FFFFFF', '#000000'],
+  England: ['#FFFFFF', '#CE1124', '#FFFFFF'],
+  France: ['#0055A4', '#FFFFFF', '#EF4135'],
+  Germany: ['#000000', '#DD0000', '#FFCE00'],
+  Ghana: ['#CE1126', '#FCD116', '#006B3F'],
+  Haiti: ['#00209F', '#D21034'],
+  Iran: ['#239F40', '#FFFFFF', '#DA0000'],
+  Iraq: ['#CE1126', '#FFFFFF', '#000000'],
+  'Ivory Coast': ['#FF8200', '#FFFFFF', '#009A44'],
+  Japan: ['#FFFFFF', '#BC002D', '#FFFFFF'],
+  Jordan: ['#000000', '#FFFFFF', '#007A3D'],
+  Mexico: ['#006847', '#FFFFFF', '#CE1126'],
+  Morocco: ['#C1272D', '#006233'],
+  Netherlands: ['#AE1C28', '#FFFFFF', '#21468B'],
+  'New Zealand': ['#00247D', '#CC142B'],
+  Norway: ['#BA0C2F', '#FFFFFF', '#00205B'],
+  Panama: ['#DA121A', '#FFFFFF', '#072357'],
   Paraguay: ['#D52B1E', '#FFFFFF', '#0038A8'],
+  Portugal: ['#046A38', '#DA291C'],
+  Qatar: ['#8A1538', '#FFFFFF'],
+  'Saudi Arabia': ['#006C35', '#FFFFFF'],
+  Scotland: ['#005EB8', '#FFFFFF', '#005EB8'],
+  Senegal: ['#00853F', '#FDEF42', '#E31B23'],
+  'South Africa': ['#E03C31', '#007749', '#001489'],
+  'South Korea': ['#FFFFFF', '#CD2E3A', '#0047A0'],
+  Spain: ['#AA151B', '#F1BF00', '#AA151B'],
+  Sweden: ['#006AA7', '#FECC02', '#006AA7'],
+  Switzerland: ['#DA291C', '#FFFFFF', '#DA291C'],
+  'Türkiye': ['#E30A17', '#FFFFFF'],
+  Tunisia: ['#E70013', '#FFFFFF', '#E70013'],
+  USA: ['#041E42', '#FFFFFF', '#BF0D3E'],
+  Uruguay: ['#0038A8', '#FFFFFF', '#0038A8'],
+  Uzbekistan: ['#0099B5', '#FFFFFF', '#1EB53A'],
 }
 
 export function teamColours(team: string): string[] {


### PR DESCRIPTION
## What

Two pieces of /world-cup polish, both from phone screenshots:

**1. "Confirmed early opens" card softened.** It was a solid black (`bg-ink`) block in the middle of a cream page. Now it's `bg-amber-pale` with ink text and the standard white pill button — same information, much less harsh.

**2. Fixture rows get flags and proper alignment.**
- `TEAM_COLOURS` extended from Group D's 4 teams to **all 48 qualified teams** with real flag-stripe palettes. Each team name in the fixture list now carries a small stacked-stripe flag chip (no emoji — consistent with the existing `TeamStripes` bands, which also pick up the new colours automatically).
- Rows moved from a ragged flex-wrap to a grid: fixed time column, teams with flags, and the status chips right-aligned on desktop / neatly indented under the match on mobile instead of hugging the right edge on their own line.
- Trading-window chips get crisper 2px borders and stronger tints.

## Verification

- `npx tsc --noEmit` clean, 302 unit tests pass
- Verified live at 375x812: 144 flag chips render (72 fixtures × 2 teams), zero dark cards remain
- Playwright screenshots of the fixture list and the restyled card

https://claude.ai/code/session_01FCyEdyeKbWCHzQP5nyfNex

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCyEdyeKbWCHzQP5nyfNex)_