### PR TITLE
Kill tone-on-tone amber chips site-wide

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,10 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Amber-on-amber chip restyle, site-wide (2026-06-10)
+- Killed every tone-on-tone amber combo (`text-amber` on `bg-amber-pale`) — flagged as looking cheap. New rules: active/live chips (happy-hour-active, Golden Hour, HH toggles) go solid `bg-amber text-white`; passive badges (admin pending/warning, promotion-zone divider) keep the pale tint but switch to ink text; the World Cup permit chip becomes amber-on-white with an amber border.
+- Touched: WorldCupFixtures, SunsetSippers, TonightsMoves, DadBar, SubmitPubForm, SuburbLeague, admin dashboard, DiscoverClient, SuburbsClient (hover state). `tsc` clean; verified on /world-cup at 375x812.
+
 ### Pint receipt readability pass (2026-06-10)
 - Prompted by a user screenshot of The Vale Bar & Brasserie on mobile. Five fixes to `PintReceipt.tsx`:
 - **Happy hour row** no longer reads "TBC · 7 days 4pm - 5pm" — the schedule is the value when the price is unknown, "7 days" renders as "daily", and a known price shows red with the schedule on a right-aligned sub-line (no more crushed dotted leaders).

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,10 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Pill no-wrap guard + happy-hour grid blowout fix (2026-06-10)
+- Global CSS guard in `globals.css`: anything with `rounded-pill` gets `white-space: nowrap` — a pill label breaking onto a second line reads as broken UI (spotted on the world-cup "Tell us about an early open" button, label shortened to "Report an early open").
+- While verifying at 320px, found a pre-existing 14px horizontal page overflow on /happy-hour: the best-of pick cards' `truncate` pub names couldn't clip because grid items refuse to shrink below content width. `min-w-0` on the three card links fixes it. All of /, /world-cup, /happy-hour now measure zero horizontal overflow at 320px and 375px.
+
 ### Amber-on-amber chip restyle, site-wide (2026-06-10)
 - Killed every tone-on-tone amber combo (`text-amber` on `bg-amber-pale`) — flagged as looking cheap. New rules: active/live chips (happy-hour-active, Golden Hour, HH toggles) go solid `bg-amber text-white`; passive badges (admin pending/warning, promotion-zone divider) keep the pale tint but switch to ink text; the World Cup permit chip becomes amber-on-white with an amber border.
 - Touched: WorldCupFixtures, SunsetSippers, TonightsMoves, DadBar, SubmitPubForm, SuburbLeague, admin dashboard, DiscoverClient, SuburbsClient (hover state). `tsc` clean; verified on /world-cup at 375x812.

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -140,13 +140,13 @@ function StatCard({ label, value, sub, icon: Icon }: {
 
 function StatusBadge({ status }: { status: string }) {
   const styles: Record<string, string> = {
-    pending: 'bg-amber-pale text-amber border-amber',
+    pending: 'bg-amber-pale text-ink border-amber',
     verified: 'bg-green-pale text-green border-green',
     approved: 'bg-green-pale text-green border-green',
     rejected: 'bg-red-pale text-red border-red',
     success: 'bg-green-pale text-green border-green',
     error: 'bg-red-pale text-red border-red',
-    warning: 'bg-amber-pale text-amber border-amber',
+    warning: 'bg-amber-pale text-ink border-amber',
   }
   return (
     <span className={`inline-flex items-center gap-1 px-2 py-0.5 border-2 rounded-pill font-mono text-[0.6rem] font-bold uppercase tracking-[0.05em] ${styles[status] || 'bg-gray-light text-gray-mid border-gray'}`}>
@@ -501,7 +501,7 @@ function ReportsTab({ data, password, onRefresh }: { data: DashboardData; passwo
                       <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5">
                         <span className="font-mono text-[0.9rem] font-extrabold text-ink tabular-nums">${Number(r.reportedPrice).toFixed(2)}</span>
                         {r.reportType === 'happy_hour_report' && (
-                          <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 bg-amber-pale text-amber border-2 border-amber rounded-pill font-mono text-[0.55rem] font-bold uppercase tracking-[0.05em]">
+                          <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 bg-amber-pale text-ink border-2 border-amber rounded-pill font-mono text-[0.55rem] font-bold uppercase tracking-[0.05em]">
                             <Clock size={9} />HH
                           </span>
                         )}

--- a/src/app/discover/DiscoverClient.tsx
+++ b/src/app/discover/DiscoverClient.tsx
@@ -194,7 +194,7 @@ export default function DiscoverClient({ initialPubs }: { initialPubs?: Pub[] })
               </div>
               <p className="text-[0.75rem] text-gray-mid mt-1">{pintOfTheDay.reason}</p>
               {pintOfTheDay.pub.isHappyHourNow && (
-                <span className="inline-flex items-center gap-1 mt-2 px-2.5 py-1 bg-amber-pale text-amber border-2 border-amber/30 rounded-pill font-mono text-[0.6rem] font-bold uppercase tracking-[0.05em]">
+                <span className="inline-flex items-center gap-1 mt-2 px-2.5 py-1 bg-amber text-white border-2 border-amber rounded-pill font-mono text-[0.6rem] font-bold uppercase tracking-[0.05em]">
                   <Clock className="w-3 h-3" />Happy Hour Active
                 </span>
               )}
@@ -250,7 +250,7 @@ export default function DiscoverClient({ initialPubs }: { initialPubs?: Pub[] })
                       <p className="text-xs text-gray-mid">{pub.suburb}</p>
                     </div>
                     <div className="flex items-center gap-2 flex-shrink-0">
-                      <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-bold ${status.isActive ? 'bg-amber-pale text-amber border border-amber/30' : 'bg-off-white text-gray-mid border border-gray-light'}`}>
+                      <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-bold ${status.isActive ? 'bg-amber text-white border border-amber' : 'bg-off-white text-gray-mid border border-gray-light'}`}>
                         {status.countdown || status.happyHourLabel}
                       </span>
                       <span className="font-mono text-lg font-extrabold text-ink tabular-nums">{status.effectivePrice !== null ? `$${status.effectivePrice.toFixed(2)}` : 'TBC'}</span>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -522,3 +522,10 @@
 ::-webkit-scrollbar-thumb:hover {
   background: #a8a29e;
 }
+
+/* Pills never wrap — a pill whose label breaks onto a second line reads as
+   broken UI. If a label doesn't fit on one line at 320px, shorten the label
+   rather than removing this guard. */
+[class*="rounded-pill"] {
+  white-space: nowrap;
+}

--- a/src/app/happy-hour/HappyHourClient.tsx
+++ b/src/app/happy-hour/HappyHourClient.tsx
@@ -326,7 +326,7 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
             <h2 className="type-section leading-tight mb-3">Perth&apos;s best happy-hour pints</h2>
             <div className="grid gap-3 sm:grid-cols-3">
               {bestOf.cheapestPint && (
-                <Link href={pubUrl(bestOf.cheapestPint)} className="block rounded-card border-3 border-ink bg-white p-4 shadow-hard-sm no-underline hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all">
+                <Link href={pubUrl(bestOf.cheapestPint)} className="block min-w-0 rounded-card border-3 border-ink bg-white p-4 shadow-hard-sm no-underline hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all">
                   <p className="type-eyebrow text-amber">Cheapest pint</p>
                   <p className="mt-1 type-price text-[1.7rem] leading-none">{formatPrice(bestOf.cheapestPint.happyHourPrice)}</p>
                   <p className="mt-2 font-mono text-[0.82rem] font-bold text-ink truncate">{bestOf.cheapestPint.name}</p>
@@ -334,7 +334,7 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
                 </Link>
               )}
               {bestOf.biggestSaving && (
-                <Link href={pubUrl(bestOf.biggestSaving)} className="block rounded-card border-3 border-ink bg-white p-4 shadow-hard-sm no-underline hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all">
+                <Link href={pubUrl(bestOf.biggestSaving)} className="block min-w-0 rounded-card border-3 border-ink bg-white p-4 shadow-hard-sm no-underline hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all">
                   <p className="type-eyebrow text-amber">Biggest saving</p>
                   <p className="mt-1 type-price text-[1.7rem] leading-none text-green">{formatPrice((bestOf.biggestSaving.regularPrice ?? 0) - (bestOf.biggestSaving.happyHourPrice ?? 0))} off</p>
                   <p className="mt-2 font-mono text-[0.82rem] font-bold text-ink truncate">{bestOf.biggestSaving.name}</p>
@@ -342,7 +342,7 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
                 </Link>
               )}
               {bestOf.beerGarden && (
-                <Link href={pubUrl(bestOf.beerGarden)} className="block rounded-card border-3 border-ink bg-white p-4 shadow-hard-sm no-underline hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all">
+                <Link href={pubUrl(bestOf.beerGarden)} className="block min-w-0 rounded-card border-3 border-ink bg-white p-4 shadow-hard-sm no-underline hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all">
                   <p className="type-eyebrow text-amber">Best beer garden</p>
                   <p className="mt-1 type-price text-[1.7rem] leading-none">{formatPrice(bestOf.beerGarden.happyHourPrice)}</p>
                   <p className="mt-2 font-mono text-[0.82rem] font-bold text-ink truncate">{bestOf.beerGarden.name}</p>

--- a/src/app/suburbs/SuburbsClient.tsx
+++ b/src/app/suburbs/SuburbsClient.tsx
@@ -176,7 +176,7 @@ export default function SuburbsClient({ suburbs }: SuburbsClientProps) {
             <a
               key={letter}
               href={`#${letter}`}
-              className="font-mono text-[0.7rem] font-bold w-8 h-8 flex items-center justify-center rounded-md text-gray-mid hover:text-amber hover:bg-amber-pale transition-colors no-underline"
+              className="font-mono text-[0.7rem] font-bold w-8 h-8 flex items-center justify-center rounded-md text-gray-mid hover:text-ink hover:bg-amber-pale transition-colors no-underline"
             >
               {letter}
             </a>

--- a/src/app/world-cup/page.tsx
+++ b/src/app/world-cup/page.tsx
@@ -177,7 +177,7 @@ export default async function WorldCupPage() {
                     href="/?submit=1"
                     className="mt-4 inline-block rounded-pill border-3 border-ink bg-white px-5 py-2.5 font-mono text-[0.72rem] font-bold uppercase tracking-[0.06em] text-ink no-underline shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all"
                   >
-                    Tell us about an early open
+                    Report an early open
                   </Link>
                 </>
               ) : (

--- a/src/components/DadBar.tsx
+++ b/src/components/DadBar.tsx
@@ -84,7 +84,7 @@ export default function DadBar({ pubs, userLocation }: { pubs: Pub[], userLocati
             </div>
           </div>
           <div className="flex items-center gap-2">
-            <span className="font-mono text-[0.58rem] font-bold uppercase tracking-[0.05em] px-1.5 py-0.5 rounded-pill border-2 border-amber/30 bg-amber-pale text-amber">
+            <span className="font-mono text-[0.58rem] font-bold uppercase tracking-[0.05em] px-1.5 py-0.5 rounded-pill border-2 border-amber bg-amber text-white">
               {dadPubs.length} venues
             </span>
             {!isExpanded && dadPubs[0]?.price && (

--- a/src/components/SubmitPubForm.tsx
+++ b/src/components/SubmitPubForm.tsx
@@ -831,7 +831,7 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
                       onClick={() => setPriceType('happy_hour')}
                       className={`flex-1 px-3 py-1.5 rounded-pill font-mono text-[0.65rem] font-bold transition-all ${
                         priceType === 'happy_hour'
-                          ? 'bg-amber-pale text-amber shadow-hard-sm'
+                          ? 'bg-amber text-white shadow-hard-sm'
                           : 'text-gray-mid hover:text-ink'
                       }`}
                     >
@@ -986,7 +986,7 @@ export default function SubmitPubForm({ isOpen, onClose, userLocation, initialPu
                               onClick={() => updateExtractedItem(i, 'price_type', item.price_type === 'regular' ? 'happy_hour' : 'regular')}
                               className={`flex-shrink-0 px-2 py-1 rounded-pill font-mono text-[0.55rem] font-bold border-2 transition-all ${
                                 item.price_type === 'happy_hour'
-                                  ? 'bg-amber-pale text-amber border-amber/30'
+                                  ? 'bg-amber text-white border-amber'
                                   : 'bg-white text-gray-mid border-gray-light'
                               }`}
                             >

--- a/src/components/SuburbLeague.tsx
+++ b/src/components/SuburbLeague.tsx
@@ -42,7 +42,7 @@ export default function SuburbLeague({ pubs }: { pubs: Pub[] }) {
       const pos = i + 1
 
       if (pos === 5 && total > 5) {
-        items.push({ type: 'divider', label: '- Promotion Zone -', colorClass: 'bg-amber-pale text-amber border-amber/30' })
+        items.push({ type: 'divider', label: '- Promotion Zone -', colorClass: 'bg-amber-pale text-ink border-amber/30' })
       }
 
       if (pos === total - 2 && total > 6) {

--- a/src/components/SunsetSippers.tsx
+++ b/src/components/SunsetSippers.tsx
@@ -211,7 +211,7 @@ export default function SunsetSippers({ pubs, userLocation }: SunsetSippersProps
             <div className="flex items-center justify-center gap-2 mb-4">
               <StatusIcon className="w-5 h-5 text-amber" />
               {isGoldenHour && (
-                <span className="font-mono text-[0.6rem] font-bold uppercase tracking-[0.05em] px-2.5 py-1 rounded-pill border-2 border-amber bg-amber-pale text-amber">
+                <span className="font-mono text-[0.6rem] font-bold uppercase tracking-[0.05em] px-2.5 py-1 rounded-pill border-2 border-amber bg-amber text-white">
                   Golden Hour
                 </span>
               )}

--- a/src/components/TonightsMoves.tsx
+++ b/src/components/TonightsMoves.tsx
@@ -247,7 +247,7 @@ export default function TonightsMoves({ pubs, userLocation }: TonightsMovesProps
                           <p className="font-body text-[0.7rem] text-gray-mid">{pub.suburb}{userLocation && ` · ${formatDistance(getDistanceKm(userLocation.lat, userLocation.lng, pub.lat, pub.lng))}`}</p>
                         </div>
                         <div className="flex items-center gap-2 flex-shrink-0">
-                          <span className="font-mono text-[0.58rem] font-bold uppercase tracking-[0.05em] px-1.5 py-0.5 rounded-pill border-2 border-amber/30 bg-amber-pale text-amber">
+                          <span className="font-mono text-[0.58rem] font-bold uppercase tracking-[0.05em] px-1.5 py-0.5 rounded-pill border-2 border-amber bg-amber text-white">
                             {status.countdown}
                           </span>
                           <span className="font-mono text-[1rem] font-extrabold text-gray-mid">{status.effectivePrice !== null ? `$${status.effectivePrice.toFixed(2)}` : 'TBC'}</span>

--- a/src/components/WorldCupFixtures.tsx
+++ b/src/components/WorldCupFixtures.tsx
@@ -37,7 +37,7 @@ interface WorldCupFixturesProps {
 type Filter = 'all' | 'groupD'
 
 const STATUS_CHIP_CLASSES: Record<TradingStatus, string> = {
-  permit: 'bg-amber-pale text-amber border-2 border-amber/50',
+  permit: 'bg-white text-amber border-2 border-amber',
   early: 'bg-white text-ink border-2 border-ink/30',
   normal: 'bg-off-white text-gray-mid border-2 border-ink/10',
 }


### PR DESCRIPTION
## What

Removes every tone-on-tone amber combination (`text-amber` on `bg-amber-pale`) across the site — the orange-on-orange chips read as cheap.

New conventions, applied consistently:

- **Active/live chips** — "Happy Hour Active", Golden Hour, the HH/REG toggles in the submit form, the live countdown chip on /discover — go solid `bg-amber` with white text.
- **Passive badges** — admin pending/warning statuses, the Suburb League promotion-zone divider — keep the warm pale tint but switch to ink text.
- **World Cup permit chip** — amber text on white with an amber border, so it stays visually distinct from the early-doors and normal-trading chips without the pale-orange fill.
- The suburbs A–Z hover state also loses its amber-on-amber-pale pairing.

Touched: `WorldCupFixtures`, `SunsetSippers`, `TonightsMoves`, `DadBar`, `SubmitPubForm`, `SuburbLeague`, admin dashboard, `DiscoverClient`, `SuburbsClient`.

## Verification

- `npx tsc --noEmit` clean
- Verified on /world-cup at 375x812 — permit chips render amber-on-white, NEXT chip is all-white text on ink
- Grep confirms no remaining `text-amber` + `bg-amber-pale` pairings in `src/`

https://claude.ai/code/session_01FCyEdyeKbWCHzQP5nyfNex

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCyEdyeKbWCHzQP5nyfNex)_