### PR TITLE
Soften the homepage live happy-hour banner

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,9 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Homepage live banner softened (2026-06-10)
+- The live happy-hour banner was the last solid-black element on the homepage: `bg-ink` pill with amber-light text (and a bare `shadow-hard`, which the design system bans). Now white with ink text, the green pulse + LIVE eyebrow kept, amber reserved for the price, `shadow-hard-sm`. Verified with Playwright; `tsc` clean.
+
 ### Pill no-wrap guard + happy-hour grid blowout fix (2026-06-10)
 - Global CSS guard in `globals.css`: anything with `rounded-pill` gets `white-space: nowrap` — a pill label breaking onto a second line reads as broken UI (spotted on the world-cup "Tell us about an early open" button, label shortened to "Report an early open").
 - While verifying at 320px, found a pre-existing 14px horizontal page overflow on /happy-hour: the best-of pick cards' `truncate` pub names couldn't clip because grid items refuse to shrink below content width. `min-w-0` on the three card links fixes it. All of /, /world-cup, /happy-hour now measure zero horizontal overflow at 320px and 375px.

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -46,19 +46,19 @@ function LiveHappyHourBanner({ pubs }: { pubs: Pub[] }) {
 
   return (
     <Link href="/happy-hour" className="block max-w-container mx-auto px-6 mb-5">
-      <div className="bg-ink border-3 border-ink rounded-pill px-6 py-3 flex items-center gap-3 shadow-hard">
+      <div className="bg-white border-3 border-ink rounded-pill px-6 py-3 flex items-center gap-3 shadow-hard-sm">
         <div className="flex items-center gap-1.5 flex-shrink-0">
           <span className="w-2 h-2 rounded-full bg-green shadow-[0_0_8px_rgba(45,122,61,0.5)] animate-pulse" />
-          <span className="type-eyebrow text-white">Live</span>
+          <span className="type-eyebrow">Live</span>
         </div>
-        <span className="text-white font-medium text-[0.85rem] flex-1 truncate transition-opacity duration-300" key={current.slug}>
-          <strong className="text-amber-light font-bold">{current.name}</strong> has ${current.price?.toFixed(2)} pints right now
+        <span className="text-ink font-medium text-[0.85rem] flex-1 truncate transition-opacity duration-300" key={current.slug}>
+          <strong className="font-bold">{current.name}</strong> has ${current.price?.toFixed(2)} pints right now
         </span>
-        <span className="type-price text-[1.1rem] text-amber-light flex-shrink-0">
+        <span className="type-price text-[1.1rem] text-amber flex-shrink-0">
           ${current.price?.toFixed(2)}
         </span>
         {liveHHPubs.length > 1 && (
-          <span className="font-mono text-[0.6rem] font-bold text-white/50 flex-shrink-0">
+          <span className="font-mono text-[0.6rem] font-bold text-gray-mid flex-shrink-0">
             {(activeIndex % liveHHPubs.length) + 1}/{liveHHPubs.length}
           </span>
         )}


### PR DESCRIPTION
## What

Softens the homepage live happy-hour banner — the last solid-black element on the page. It was a `bg-ink` pill with amber-light text (the black-with-orange combo), and it used a bare `shadow-hard`, which the design system bans.

Now: white pill, ink text, the green live pulse and LIVE eyebrow kept, amber reserved for the price, `shadow-hard-sm`. It sits quietly between the hero stat cards and the search bar instead of shouting.

## Verification

- `npx tsc --noEmit` clean
- Playwright screenshot with a live happy hour rendering (The Pipers Inn)

https://claude.ai/code/session_01FCyEdyeKbWCHzQP5nyfNex

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCyEdyeKbWCHzQP5nyfNex)_