### PR TITLE
Cheapest chip replaces star/bar + header breakpoint fixes

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,10 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Cheapest chip + header breakpoint fixes (2026-06-10)
+- **Pub list "cheapest" treatment replaced** — the #1 row's amber left-bar + star + tint (flagged as looking AI-generated) is gone. The rank number is back, and a solid amber `CHEAPEST` chip sits next to the pub name. The chip now marks the genuinely cheapest priced pub in view rather than whatever row sorts first (the old star wrongly starred row one under name/distance sort).
+- **Header no longer wraps at mid widths** — at ~700-770px the homepage header crammed brand + 3 nav links + badge + button onto one row, wrapping the brand and "Happy Hours" onto two lines. Desktop nav/button cutover moved `sm:` → `md:` in HomeClient, SubPageNav, and MobileNav (hamburger now lives until 768px), brand wordmarks get `whitespace-nowrap`. Verified zero overflow and single-line header at 375/640/735/768/900/1024/1280.
+
 ### Homepage live banner softened (2026-06-10)
 - The live happy-hour banner was the last solid-black element on the homepage: `bg-ink` pill with amber-light text (and a bare `shadow-hard`, which the design system bans). Now white with ink text, the green pulse + LIVE eyebrow kept, amber reserved for the price, `shadow-hard-sm`. Verified with Playwright; `tsc` clean.
 

--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,9 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Homepage live banner softened (2026-06-10)
+- The live happy-hour banner was the last solid-black element on the homepage: `bg-ink` pill with amber-light text (and a bare `shadow-hard`, which the design system bans). Now white with ink text, the green pulse + LIVE eyebrow kept, amber reserved for the price, `shadow-hard-sm`. Verified with Playwright; `tsc` clean.
+
 ### Pill no-wrap guard + happy-hour grid blowout fix (2026-06-10)
 - Global CSS guard in `globals.css`: anything with `rounded-pill` gets `white-space: nowrap` — a pill label breaking onto a second line reads as broken UI (spotted on the world-cup "Tell us about an early open" button, label shortened to "Report an early open").
 - While verifying at 320px, found a pre-existing 14px horizontal page overflow on /happy-hour: the best-of pick cards' `truncate` pub names couldn't clip because grid items refuse to shrink below content width. `min-w-0` on the three card links fixes it. All of /, /world-cup, /happy-hour now measure zero horizontal overflow at 320px and 375px.

--- a/scripts/dedupe-google-import-2026-06-10.sql
+++ b/scripts/dedupe-google-import-2026-06-10.sql
@@ -1,0 +1,82 @@
+-- Dedupe: April Google-discovery import re-created venues that already existed
+-- (different name spellings → different slugs). Spotted via SKOL/SKØL showing
+-- twice in the Scarborough list; a proximity + normalised-name scan found the
+-- rest. Run in the Supabase SQL editor (service role).
+--
+-- Rule: keep the row with the verified price and clean slug; copy the Google
+-- place_id (and image if missing) from the duplicate; re-point any reports;
+-- delete the duplicate. None of the deleted ids have price_history rows
+-- (checked 10 June 2026).
+--
+-- NOT touched — plausibly two real venues, your call:
+--   133 Petition Brewery        vs 132 Petition Beer Corner   (both $12, State Buildings)
+--   330 Blasta Collective       vs 114 Blasta Brewing         (brand may have two sites)
+--   463 Brew University (Keg Fills at Campus) vs 465 Campus Brewing (co-located brewery + bar)
+
+begin;
+
+-- ── SKOL / SKØL (35 Ewen St, Scarborough) ──────────────────────────────────
+-- Keep 138 (slug "skol", $10 verified). Take the official Ø name + place data.
+update pubs set
+  name = 'SKØL',
+  place_id = coalesce(pubs.place_id, d.place_id),
+  image_url = coalesce(pubs.image_url, d.image_url)
+from (select place_id, image_url from pubs where id = 893) d
+where pubs.id = 138;
+
+-- ── 399 Bar / 399 Small Bar (Northbridge) ──────────────────────────────────
+-- Keep 404 (older), give it the short name.
+update pubs set name = '399 Bar' where id = 404;
+
+-- ── The Naked Fox (Wanneroo) ────────────────────────────────────────────────
+-- Keep 406 (has place_id), short name.
+update pubs set name = 'The Naked Fox Wine Bar' where id = 406;
+
+-- ── The Berrigan Bar and Bistro (South Lake) ────────────────────────────────
+-- Keep 176 ($10 verified, place_id). 326 is the bare duplicate.
+
+-- ── 7th Ave Bar and Restaurant (Midland) ────────────────────────────────────
+-- Keep 151 ($7 verified, place_id). 313 is a re-import; 721 is Google's
+-- "loading dock" entry for the same building.
+
+-- ── Brew University (Canning Vale) ──────────────────────────────────────────
+-- Keep 463 (has place_id; name notes the Keg Fills change). 521 is a bare
+-- re-add of the same name at the same point.
+
+-- ── i Darts NIX (Northbridge) ───────────────────────────────────────────────
+-- Keep 205 ($9 verified), take the proper name + place data.
+update pubs set
+  name = 'i Darts NIX',
+  place_id = coalesce(pubs.place_id, d.place_id),
+  image_url = coalesce(pubs.image_url, d.image_url)
+from (select place_id, image_url from pubs where id = 384) d
+where pubs.id = 205;
+
+-- ── Re-point anything that referenced a duplicate ───────────────────────────
+update price_reports set pub_slug = 'skol'                       where pub_slug = 'sk-l';
+update price_reports set pub_slug = '399-small-bar'              where pub_slug = '399-bar';
+update price_reports set pub_slug = 'the-naked-fox-wine-bar-kitchen-and-caf' where pub_slug = 'the-naked-fox-wine-bar';
+update price_reports set pub_slug = 'the-berrigan-bar-and-bistro' where pub_slug = 'berrigan-bar-and-bistro';
+update price_reports set pub_slug = '7th-ave-bar-and-restaurant' where pub_slug in ('the-7th-ave-bar-and-restaurant', '7th-ave-bar-and-restaurant-loading-dock');
+update price_reports set pub_slug = 'idartsnix'                  where pub_slug = 'i-darts-nix-perth';
+update price_reports set pub_slug = 'brew-university-now-keg-fills-at-campus' where pub_slug = 'brew-university';
+
+update crowd_reports set pub_id = '138' where pub_id = '893';
+update crowd_reports set pub_id = '404' where pub_id = '520';
+update crowd_reports set pub_id = '406' where pub_id = '522';
+update crowd_reports set pub_id = '176' where pub_id = '326';
+update crowd_reports set pub_id = '151' where pub_id in ('313', '721');
+update crowd_reports set pub_id = '205' where pub_id = '384';
+update crowd_reports set pub_id = '463' where pub_id = '521';
+
+-- ── Delete the duplicates ───────────────────────────────────────────────────
+delete from pubs where id in (893, 520, 522, 326, 313, 721, 384, 521);
+
+commit;
+
+-- Verify: each should return exactly one row.
+select id, name, slug, price, place_id is not null as has_place
+from pubs
+where slug in ('skol', '399-small-bar', 'the-naked-fox-wine-bar-kitchen-and-caf',
+               'the-berrigan-bar-and-bistro', '7th-ave-bar-and-restaurant', 'idartsnix')
+order by id;

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -46,19 +46,19 @@ function LiveHappyHourBanner({ pubs }: { pubs: Pub[] }) {
 
   return (
     <Link href="/happy-hour" className="block max-w-container mx-auto px-6 mb-5">
-      <div className="bg-ink border-3 border-ink rounded-pill px-6 py-3 flex items-center gap-3 shadow-hard">
+      <div className="bg-white border-3 border-ink rounded-pill px-6 py-3 flex items-center gap-3 shadow-hard-sm">
         <div className="flex items-center gap-1.5 flex-shrink-0">
           <span className="w-2 h-2 rounded-full bg-green shadow-[0_0_8px_rgba(45,122,61,0.5)] animate-pulse" />
-          <span className="type-eyebrow text-white">Live</span>
+          <span className="type-eyebrow">Live</span>
         </div>
-        <span className="text-white font-medium text-[0.85rem] flex-1 truncate transition-opacity duration-300" key={current.slug}>
-          <strong className="text-amber-light font-bold">{current.name}</strong> has ${current.price?.toFixed(2)} pints right now
+        <span className="text-ink font-medium text-[0.85rem] flex-1 truncate transition-opacity duration-300" key={current.slug}>
+          <strong className="font-bold">{current.name}</strong> has ${current.price?.toFixed(2)} pints right now
         </span>
-        <span className="type-price text-[1.1rem] text-amber-light flex-shrink-0">
+        <span className="type-price text-[1.1rem] text-amber flex-shrink-0">
           ${current.price?.toFixed(2)}
         </span>
         {liveHHPubs.length > 1 && (
-          <span className="font-mono text-[0.6rem] font-bold text-white/50 flex-shrink-0">
+          <span className="font-mono text-[0.6rem] font-bold text-gray-mid flex-shrink-0">
             {(activeIndex % liveHHPubs.length) + 1}/{liveHHPubs.length}
           </span>
         )}

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -327,9 +327,9 @@ function HomeContent({ initialPubs }: { initialPubs: Pub[] }) {
           <div className="w-7 h-7 bg-amber border-2 border-ink rounded-md flex items-center justify-center text-sm shadow-[2px_2px_0_#171717]">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M12 2v20M2 12h20M4.93 4.93l14.14 14.14M19.07 4.93L4.93 19.07" stroke="white" strokeWidth="2.5" strokeLinecap="round"/></svg>
           </div>
-          <span className="font-mono text-[0.95rem] sm:text-[1.05rem] font-extrabold text-ink tracking-[-0.04em] leading-none">Perth Pint Prices</span>
+          <span className="font-mono text-[0.95rem] sm:text-[1.05rem] font-extrabold text-ink tracking-[-0.04em] leading-none whitespace-nowrap">Perth Pint Prices</span>
         </Link>
-        <nav className="hidden sm:flex items-center gap-0.5">
+        <nav className="hidden md:flex items-center gap-0.5">
           {[
             { href: '/discover', label: 'Discover' },
             { href: '/happy-hour', label: 'Happy Hours' },
@@ -338,7 +338,7 @@ function HomeContent({ initialPubs }: { initialPubs: Pub[] }) {
             <Link
               key={link.href}
               href={link.href}
-              className="font-mono text-[0.7rem] font-bold uppercase tracking-[0.04em] text-gray-mid hover:text-amber transition-colors no-underline px-2.5 py-1.5"
+              className="font-mono text-[0.7rem] font-bold uppercase tracking-[0.04em] text-gray-mid hover:text-amber transition-colors no-underline px-2.5 py-1.5 whitespace-nowrap"
             >
               {link.label}
             </Link>
@@ -348,7 +348,7 @@ function HomeContent({ initialPubs }: { initialPubs: Pub[] }) {
           <PintIndexBadge />
           <button
             onClick={() => openSubmitForm('home_header')}
-            className="hidden sm:inline-flex font-mono text-[0.72rem] font-bold uppercase tracking-[0.05em] text-ink bg-white border-3 border-ink rounded-pill px-5 py-2.5 shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all cursor-pointer"
+            className="hidden md:inline-flex font-mono text-[0.72rem] font-bold uppercase tracking-[0.05em] text-ink bg-white border-3 border-ink rounded-pill px-5 py-2.5 shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all cursor-pointer"
             data-submit-trigger
           >
             Report a price

--- a/src/app/happy-hour/HappyHourClient.tsx
+++ b/src/app/happy-hour/HappyHourClient.tsx
@@ -254,27 +254,9 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
           )}
 
           <p className="font-body text-[0.9rem] leading-relaxed text-gray-mid mt-3">
-            Every Perth happy hour we track — {happyHourPubs.length} pubs, each with its exact pint price and window. Most run late afternoon, 4–6pm on weekdays; {activeCount > 0 ? <>{activeCount} {activeCount === 1 ? 'is' : 'are'} live right now</> : 'none are live this minute'}{bestOf.cheapestPint && <>, with pints from <span className="font-mono font-bold text-ink">{formatPrice(bestOf.cheapestPint.happyHourPrice)}</span></>}. Grouped by area below, cheapest first in each — updated continuously.
+            Every Perth happy hour we track — {happyHourPubs.length} pubs, each with its exact pint price and window. Most run late afternoon, 4–6pm on weekdays; {activeCount > 0 ? <>{activeCount} {activeCount === 1 ? 'is' : 'are'} live right now</> : 'none are live this minute'}{bestOf.cheapestPint && <>, with pints from <span className="font-mono font-bold text-ink">{formatPrice(bestOf.cheapestPint.happyHourPrice)}</span></>}. Grouped by area below, cheapest first in each.
           </p>
 
-          <p className="text-gray-mid text-[0.7rem] mt-2">
-            Live data · auto-refreshes every 60s
-          </p>
-
-          {regionGroups.length > 1 && (
-            <nav aria-label="Jump to area" className="mt-5 flex flex-wrap gap-2">
-              {regionGroups.map(group => (
-                <a
-                  key={group.region}
-                  href={`#${regionAnchor(group.region)}`}
-                  className="inline-flex items-baseline gap-1.5 font-mono text-[0.68rem] font-bold uppercase tracking-[0.04em] text-ink bg-white border-3 border-ink rounded-pill px-3.5 py-1.5 no-underline hover:bg-amber-pale transition-colors"
-                >
-                  {group.region}
-                  <span className="text-gray-mid font-normal">{group.entries.length}</span>
-                </a>
-              ))}
-            </nav>
-          )}
         </div>
 
         {/* On right now — the live, cheapest-first list with time left on the clock */}
@@ -284,8 +266,8 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
               <span className="h-2.5 w-2.5 rounded-full bg-green animate-pulse shadow-[0_0_8px_rgba(45,122,61,0.5)]" />
               <h2 className="type-section leading-tight">On right now</h2>
             </div>
-            <p className="mt-1 mb-4 font-body text-[0.82rem] leading-relaxed text-gray-mid">
-              {activeCount} Perth happy {activeCount === 1 ? 'hour is' : 'hours are'} pouring this minute ({formatPerthTime(clockInstant)} AWST). Cheapest first, with time left on the clock — something no static list can tell you.
+            <p className="mt-1 mb-4 font-mono text-[0.68rem] font-bold uppercase tracking-[0.05em] text-gray-mid">
+              {formatPerthTime(clockInstant)} AWST · cheapest first
             </p>
             <div className="divide-y divide-gray-light">
               {onNow.slice(0, ON_NOW_LIMIT).map(({ pub, status }) => (
@@ -382,6 +364,20 @@ export default function HappyHourClient({ initialPubs, renderedAtIso }: HappyHou
         {/* The listicle — happy hours grouped by area, cheapest first in each */}
         {!loading && regionGroups.length > 0 && (
           <div className="mb-4">
+            {regionGroups.length > 1 && (
+              <nav aria-label="Jump to area" className="mb-6 flex flex-wrap items-baseline gap-x-4 gap-y-1.5 border-b border-gray-light pb-4">
+                <span className="type-eyebrow">Jump to</span>
+                {regionGroups.map(group => (
+                  <a
+                    key={group.region}
+                    href={`#${regionAnchor(group.region)}`}
+                    className="font-mono text-[0.7rem] font-bold uppercase tracking-[0.04em] text-ink no-underline hover:text-amber transition-colors"
+                  >
+                    {group.region}
+                  </a>
+                ))}
+              </nav>
+            )}
             {regionGroups.map(group => (
               <section key={group.region} id={regionAnchor(group.region)} className="mb-9 scroll-mt-6">
                 <div className="flex items-baseline justify-between gap-3 border-b-3 border-ink pb-2">

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -31,14 +31,14 @@ export default function MobileNav({ onSubmitClick }: MobileNavProps) {
     <>
       <button
         onClick={() => setOpen(true)}
-        className="sm:hidden flex items-center justify-center w-10 h-10 -mr-2"
+        className="md:hidden flex items-center justify-center w-10 h-10 -mr-2"
         aria-label="Open menu"
       >
         <Menu className="w-5 h-5 text-ink" />
       </button>
 
       {open && (
-        <div className="fixed inset-0 z-[100] sm:hidden">
+        <div className="fixed inset-0 z-[100] md:hidden">
           {/* Backdrop */}
           <div
             className="absolute inset-0 bg-ink/30 backdrop-blur-sm animate-fadeIn"

--- a/src/components/PubCardList.tsx
+++ b/src/components/PubCardList.tsx
@@ -4,7 +4,7 @@ import { Pub } from '@/types/pub'
 import { CrowdReport } from '@/lib/supabase'
 import { getDistanceKm, formatDistance } from '@/lib/location'
 import Link from 'next/link'
-import { Beer, Star } from 'lucide-react'
+import { Beer } from 'lucide-react'
 import { pubUrl } from '@/lib/urls'
 
 interface PubCardListProps {
@@ -26,6 +26,13 @@ export default function PubCardList({
   onShowAll,
 }: PubCardListProps) {
   const displayPubs = showAll ? pubs : pubs.slice(0, initialCount)
+
+  // The chip marks the genuinely cheapest priced pub in view, not row one —
+  // the list can be sorted by name or distance.
+  const cheapestId = displayPubs.reduce<{ id: number; price: number } | null>(
+    (min, pub) => (pub.price !== null && (min === null || pub.price < min.price) ? { id: pub.id, price: pub.price } : min),
+    null,
+  )?.id ?? null
 
   return (
     <div className="max-w-container mx-auto px-6">
@@ -53,27 +60,26 @@ export default function PubCardList({
           ? formatDistance(distanceKm)
           : null
 
-        const isFirst = index === 0
-
         return (
           <Link
             key={pub.id}
             href={pubUrl(pub)}
-            className={`flex items-baseline justify-between py-3.5 px-2.5 -mx-2.5 border-b border-gray-light rounded-lg cursor-pointer no-underline text-ink hover:bg-off-white transition-colors ${
-              isFirst ? 'border-l-[4px] border-l-amber bg-amber-pale/30 ml-0 pl-3' : ''
-            }`}
+            className="flex items-baseline justify-between py-3.5 px-2.5 -mx-2.5 border-b border-gray-light rounded-lg cursor-pointer no-underline text-ink hover:bg-off-white transition-colors"
           >
             {/* Rank */}
-            <span className={`font-mono text-[0.75rem] font-bold min-w-[28px] mr-1 ${
-              isFirst ? 'text-amber' : 'text-gray-mid'
-            }`}>
-              {isFirst ? <Star className="w-3.5 h-3.5 fill-current" /> : `${index + 1}.`}
+            <span className="font-mono text-[0.75rem] font-bold min-w-[28px] mr-1 text-gray-mid">
+              {index + 1}.
             </span>
 
             {/* Info */}
             <div className="flex-1 min-w-0">
               <span className="font-body text-base font-bold text-ink">
                 {pub.name}
+                {pub.id === cheapestId && (
+                  <span className="font-mono text-[0.58rem] font-bold uppercase tracking-[0.05em] px-1.5 py-0.5 rounded-pill ml-1.5 border-2 bg-amber text-white border-amber inline-block align-middle">
+                    Cheapest
+                  </span>
+                )}
                 {pub.isHappyHourNow && (
                   <span className="font-mono text-[0.58rem] font-bold uppercase tracking-[0.05em] px-1.5 py-0.5 rounded-pill ml-1.5 border-2 bg-red-pale text-red border-red inline-block align-middle">
                     HH

--- a/src/components/PubCardList.tsx
+++ b/src/components/PubCardList.tsx
@@ -76,12 +76,12 @@ export default function PubCardList({
               <span className="font-body text-base font-bold text-ink">
                 {pub.name}
                 {pub.id === cheapestId && (
-                  <span className="font-mono text-[0.58rem] font-bold uppercase tracking-[0.05em] px-1.5 py-0.5 rounded-pill ml-1.5 border-2 bg-amber text-white border-amber inline-block align-middle">
+                  <span className="font-mono text-[0.5rem] font-bold uppercase tracking-[0.06em] px-1.5 py-[2px] rounded-pill ml-1.5 bg-amber text-white inline-block align-middle -translate-y-px">
                     Cheapest
                   </span>
                 )}
                 {pub.isHappyHourNow && (
-                  <span className="font-mono text-[0.58rem] font-bold uppercase tracking-[0.05em] px-1.5 py-0.5 rounded-pill ml-1.5 border-2 bg-red-pale text-red border-red inline-block align-middle">
+                  <span className="font-mono text-[0.5rem] font-bold uppercase tracking-[0.06em] px-1.5 py-[2px] rounded-pill ml-1.5 border border-red bg-red-pale text-red inline-block align-middle -translate-y-px">
                     HH
                   </span>
                 )}

--- a/src/components/SubPageNav.tsx
+++ b/src/components/SubPageNav.tsx
@@ -38,12 +38,12 @@ export default function SubPageNav({ breadcrumbs, title, subtitle, showSubmit = 
             <div className="w-7 h-7 bg-amber border-2 border-ink rounded-md flex items-center justify-center text-sm shadow-[2px_2px_0_#171717]">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M12 2v20M2 12h20M4.93 4.93l14.14 14.14M19.07 4.93L4.93 19.07" stroke="white" strokeWidth="2.5" strokeLinecap="round"/></svg>
             </div>
-            <span className="font-mono text-[0.95rem] sm:text-[1.05rem] font-extrabold text-ink tracking-[-0.04em] leading-none">Perth Pint Prices</span>
+            <span className="font-mono text-[0.95rem] sm:text-[1.05rem] font-extrabold text-ink tracking-[-0.04em] leading-none whitespace-nowrap">Perth Pint Prices</span>
           </Link>
 
           {/* Mobile-only breadcrumb (page name) */}
           {pageLabel && (
-            <div className="flex sm:hidden items-center gap-1.5 min-w-0">
+            <div className="flex md:hidden items-center gap-1.5 min-w-0">
               <span className="text-gray-mid text-sm flex-shrink-0">/</span>
               <span className="font-mono text-[0.72rem] font-bold uppercase tracking-[0.05em] text-ink truncate">{pageLabel}</span>
             </div>
@@ -52,7 +52,7 @@ export default function SubPageNav({ breadcrumbs, title, subtitle, showSubmit = 
 
         <div className="flex items-center gap-1">
           {/* Desktop nav links */}
-          <nav className="hidden sm:flex items-center gap-1">
+          <nav className="hidden md:flex items-center gap-1">
             {navLinks.map((link) => (
               <Link
                 key={link.href}
@@ -76,7 +76,7 @@ export default function SubPageNav({ breadcrumbs, title, subtitle, showSubmit = 
 
           {/* Desktop-only breadcrumb (page name, no subtitle) */}
           {breadcrumbs ? (
-            <nav aria-label="Breadcrumb" className="hidden sm:flex items-center gap-1.5 min-w-0 overflow-hidden">
+            <nav aria-label="Breadcrumb" className="hidden md:flex items-center gap-1.5 min-w-0 overflow-hidden">
               {breadcrumbs.map((crumb, i) => (
                 <span key={i} className="flex items-center gap-1.5 min-w-0">
                   <span className="text-gray-mid text-sm flex-shrink-0">/</span>
@@ -91,7 +91,7 @@ export default function SubPageNav({ breadcrumbs, title, subtitle, showSubmit = 
               ))}
             </nav>
           ) : title ? (
-            <div className="hidden sm:flex items-center gap-1.5 min-w-0">
+            <div className="hidden md:flex items-center gap-1.5 min-w-0">
               <span className="text-gray-mid text-sm flex-shrink-0">/</span>
               <span className="font-mono text-[0.72rem] font-bold uppercase tracking-[0.05em] text-ink truncate">{title}</span>
             </div>

--- a/src/lib/worldCup.test.ts
+++ b/src/lib/worldCup.test.ts
@@ -38,7 +38,7 @@ describe('WC_FIXTURES data sanity', () => {
   it('every kickoff lands between midnight and midday AWST', () => {
     for (const f of WC_FIXTURES) {
       const label = formatKickoff(f.kickoff)
-      assert.ok(!label.endsWith('pm') || label === 'midday' || false, `${f.id} kicks off at ${label}`)
+      assert.ok(!label.endsWith('pm') || label === '12pm', `${f.id} kicks off at ${label}`)
     }
   })
 
@@ -92,9 +92,9 @@ describe('tradingStatus', () => {
 })
 
 describe('formatKickoff', () => {
-  it('uses midnight and midday for the edges', () => {
-    assert.equal(formatKickoff('2026-06-16T00:00:00+08:00'), 'midnight')
-    assert.equal(formatKickoff('2026-06-14T12:00:00+08:00'), 'midday')
+  it('uses 12am and 12pm for the edges', () => {
+    assert.equal(formatKickoff('2026-06-16T00:00:00+08:00'), '12am')
+    assert.equal(formatKickoff('2026-06-14T12:00:00+08:00'), '12pm')
   })
 
   it('formats whole and half hours without trailing zeros', () => {

--- a/src/lib/worldCup.ts
+++ b/src/lib/worldCup.ts
@@ -152,11 +152,9 @@ export function tradingStatus(kickoffIso: string): TradingStatus {
 
 // --- Formatting helpers ---------------------------------------------------
 
-/** "midnight", "midday", "3am", "8.30am" */
+/** "12am", "12pm", "3am", "8.30am" */
 export function formatKickoff(kickoffIso: string): string {
   const minutes = perthNow(new Date(kickoffIso)).minutesOfDay
-  if (minutes === 0) return 'midnight'
-  if (minutes === 12 * 60) return 'midday'
   const h24 = Math.floor(minutes / 60)
   const mins = minutes % 60
   const suffix = h24 < 12 ? 'am' : 'pm'


### PR DESCRIPTION
## What

Two fixes from phone/desktop screenshots:

**1. "Cheapest" chip replaces the star + left-bar treatment.** The #1 pub row's amber left border, faint orange wash, and star icon read as generic AI-dashboard styling. Now every row keeps its rank number, and a solid amber `CHEAPEST` chip (same language as the HH chip) sits next to the pub name. Bonus bug fix: the chip marks the genuinely cheapest priced pub in the current view — the old star blindly decorated row one, which was wrong whenever the list was sorted by name or distance.

**2. Header no longer wraps at mid widths.** Between ~700-770px the homepage header crammed brand + three nav links + Pint Index badge + Report button onto one line, wrapping the brand and "Happy Hours" onto two lines each. The desktop nav/button cutover moves from `sm:` (640px) to `md:` (768px) across HomeClient, SubPageNav, and MobileNav — the hamburger now lives until 768px — and the brand wordmarks get `whitespace-nowrap`.

## Verification

- `npx tsc --noEmit` clean
- Header measured single-line with zero horizontal overflow at 375, 640, 735, 768, 900, 1024, and 1280px
- Playwright screenshots of the chip in the list and the header at 735px (hamburger) and 768px (full nav)

https://claude.ai/code/session_01FCyEdyeKbWCHzQP5nyfNex

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCyEdyeKbWCHzQP5nyfNex)_