### PR TITLE
Pint Signal Phase 1 — light a signal, the crew answers, it burns out

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,11 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Pint Signal Phase 1 (2026-06-10)
+- **The feature:** one mate lights the signal (pub + time), the crew gets the link, everyone answers IN/OUT with one tap; signals burn out 3h after the meet time. No accounts, no push — the group chat is the delivery (share sheet). Plan: `docs/pint-signal-plan.md`; prototype: `docs/prototypes/pint-signal.html`.
+- **New:** `signals` + `signal_answers` schema (`scripts/pint-signal-schema.sql` — **must be run in the Supabase SQL editor before the feature works**), `signalId`/`signals` libs (+14 tests), `POST /api/signal` (5/hr per ip_hash, auto-INs the lighter), `GET/POST /api/signal/[id](/answer)` (410 after expiry, one answer per IP, 30s poll), `/signal/new` (price-aware picker, live-HH pubs first, Perth-time chips), `/signal/[id]` (the dark beacon card + draining-glass timer + crew list, noindex, force-dynamic, graceful burned-out/missing states), robots disallow `/signal/`, `SubPageNav` gains an optional Beta `badge` prop.
+- **Verification:** tsc clean, **321 tests** pass, lint clean bar pre-existing warnings, Playwright screenshots of `/signal/new` (375+1280) and the no-signal state. Built by a subagent against the plan spec, reviewed + verified by the orchestrating session.
+
 ### Cheapest chip + header breakpoint fixes (2026-06-10)
 - **Pub list "cheapest" treatment replaced** — the #1 row's amber left-bar + star + tint (flagged as looking AI-generated) is gone. The rank number is back, and a solid amber `CHEAPEST` chip sits next to the pub name. The chip now marks the genuinely cheapest priced pub in view rather than whatever row sorts first (the old star wrongly starred row one under name/distance sort).
 - **Header no longer wraps at mid widths** — at ~700-770px the homepage header crammed brand + 3 nav links + badge + button onto one row, wrapping the brand and "Happy Hours" onto two lines. Desktop nav/button cutover moved `sm:` → `md:` in HomeClient, SubPageNav, and MobileNav (hamburger now lives until 768px), brand wordmarks get `whitespace-nowrap`. Verified zero overflow and single-line header at 375/640/735/768/900/1024/1280.

--- a/scripts/pint-signal-schema.sql
+++ b/scripts/pint-signal-schema.sql
@@ -1,0 +1,45 @@
+-- Pint Signal — Phase 1 schema (see docs/pint-signal-plan.md)
+--
+-- Run this in the Supabase SQL editor (project ifxkoblvgttelzboenpi, Sydney).
+-- Safe to re-run: tables use IF NOT EXISTS and policies are dropped before
+-- being recreated.
+--
+-- Writes go through the API routes using the service role key; there are
+-- deliberately NO client-side insert/update/delete policies.
+
+create table if not exists signals (
+  id          text primary key,              -- 10-char base62, unguessable share key
+  pub_slug    text not null,
+  crew_name   text,                          -- "Fremantle crew", free text
+  lit_by      text not null,                 -- first name, no auth
+  meet_at     timestamptz not null,
+  expires_at  timestamptz not null,          -- meet_at + 3h
+  ip_hash     text,                          -- lighter's hashed IP, for rate limiting
+  created_at  timestamptz default now()
+);
+
+create table if not exists signal_answers (
+  id         uuid primary key default gen_random_uuid(),
+  signal_id  text not null references signals(id) on delete cascade,
+  name       text not null,
+  answer     text not null check (answer in ('in','out')),
+  note       text,
+  ip_hash    text,
+  created_at timestamptz default now()
+);
+
+create index if not exists signals_ip_hash_created_at_idx
+  on signals (ip_hash, created_at);
+create index if not exists signal_answers_signal_id_idx
+  on signal_answers (signal_id);
+create index if not exists signal_answers_ip_hash_created_at_idx
+  on signal_answers (ip_hash, created_at);
+
+alter table signals enable row level security;
+alter table signal_answers enable row level security;
+
+drop policy if exists "public read signals" on signals;
+drop policy if exists "public read answers" on signal_answers;
+create policy "public read signals"  on signals        for select using (true);
+create policy "public read answers"  on signal_answers for select using (true);
+-- writes go through API routes using the service role; no client-side policies

--- a/src/app/api/signal/[id]/answer/route.ts
+++ b/src/app/api/signal/[id]/answer/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { serviceClient } from '@/lib/supabaseGateway'
+import { isExpired } from '@/lib/signals'
+import { hashRequestIp } from '../../ipHash'
+
+// Max answers one IP can post per hour (across all signals).
+const RATE_LIMIT_PER_HOUR = 10
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  let body: Record<string, unknown>
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
+  }
+
+  const name = typeof body.name === 'string' ? body.name.trim() : ''
+  const answer = body.answer
+  const note = typeof body.note === 'string' ? body.note.trim().slice(0, 60) : null
+
+  if (name.length < 1 || name.length > 30) {
+    return NextResponse.json({ error: 'Add your name (up to 30 characters).' }, { status: 400 })
+  }
+  if (answer !== 'in' && answer !== 'out') {
+    return NextResponse.json({ error: 'Answer must be in or out.' }, { status: 400 })
+  }
+
+  // Construct the privileged client inside the handler — never at import time.
+  let supabase
+  try {
+    supabase = serviceClient()
+  } catch (err) {
+    console.error('Signal answer route missing service client:', err)
+    return NextResponse.json({ error: 'Signals are down right now. Try again shortly.' }, { status: 500 })
+  }
+
+  try {
+    const { data: signal, error: signalError } = await supabase
+      .from('signals')
+      .select('id, expires_at')
+      .eq('id', params.id)
+      .single()
+
+    if (signalError || !signal || isExpired(signal)) {
+      return NextResponse.json({ error: 'This signal burned out.' }, { status: 410 })
+    }
+
+    const ipHash = hashRequestIp(req)
+    const hourAgo = new Date(Date.now() - 3600000).toISOString()
+    const { data: recent } = await supabase
+      .from('signal_answers')
+      .select('id')
+      .eq('ip_hash', ipHash)
+      .gte('created_at', hourAgo)
+
+    if (recent && recent.length >= RATE_LIMIT_PER_HOUR) {
+      return NextResponse.json({ error: 'Too many answers from here. Try again in an hour.' }, { status: 429 })
+    }
+
+    // One answer per person (per ip_hash) per signal — re-answering replaces
+    // the earlier row rather than stacking duplicates.
+    await supabase
+      .from('signal_answers')
+      .delete()
+      .eq('signal_id', params.id)
+      .eq('ip_hash', ipHash)
+
+    const { error: insertError } = await supabase.from('signal_answers').insert({
+      signal_id: params.id,
+      name,
+      answer,
+      note: note || null,
+      ip_hash: ipHash,
+    })
+
+    if (insertError) {
+      console.error('Error inserting signal answer:', insertError)
+      return NextResponse.json({ error: 'Could not save your answer. Try again.' }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    console.error('Signal answer route error:', err)
+    return NextResponse.json({ error: 'Could not save your answer. Try again.' }, { status: 500 })
+  }
+}

--- a/src/app/api/signal/[id]/route.ts
+++ b/src/app/api/signal/[id]/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { anonClient } from '@/lib/supabaseGateway'
+import { isExpired, type Signal, type SignalAnswer } from '@/lib/signals'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/signal/[id] — the answer page polls this every 30s for fresh
+ * answers. Public read via the anon client (RLS allows select only).
+ */
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = anonClient()
+
+  const { data: signal, error: signalError } = await supabase
+    .from('signals')
+    .select('id, pub_slug, crew_name, lit_by, meet_at, expires_at, created_at')
+    .eq('id', params.id)
+    .single()
+
+  if (signalError || !signal) {
+    return NextResponse.json({ error: 'Signal not found' }, { status: 404 })
+  }
+
+  const { data: answers, error: answersError } = await supabase
+    .from('signal_answers')
+    .select('id, signal_id, name, answer, note, created_at')
+    .eq('signal_id', params.id)
+    .order('created_at', { ascending: true })
+
+  if (answersError) {
+    return NextResponse.json({ error: 'Could not load answers' }, { status: 500 })
+  }
+
+  return NextResponse.json({
+    signal: signal as Signal,
+    answers: (answers || []) as SignalAnswer[],
+    expired: isExpired(signal as Signal),
+  })
+}

--- a/src/app/api/signal/ipHash.ts
+++ b/src/app/api/signal/ipHash.ts
@@ -1,0 +1,12 @@
+import { createHash } from 'node:crypto'
+import type { NextRequest } from 'next/server'
+
+/**
+ * Hash the caller's IP for rate limiting, matching the salt + truncation used
+ * by /api/price-report so an IP maps to the same opaque token everywhere.
+ */
+export function hashRequestIp(req: NextRequest): string {
+  const forwarded = req.headers.get('x-forwarded-for')
+  const ip = forwarded?.split(',')[0]?.trim() || 'unknown'
+  return createHash('sha256').update(ip + 'arvo-salt-2025').digest('hex').slice(0, 16)
+}

--- a/src/app/api/signal/route.ts
+++ b/src/app/api/signal/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { serviceClient } from '@/lib/supabaseGateway'
+import { generateSignalId } from '@/lib/signalId'
+import { expiresAtFrom, isMeetAtInWindow } from '@/lib/signals'
+import { hashRequestIp } from './ipHash'
+
+// Max signals one IP can light per hour.
+const RATE_LIMIT_PER_HOUR = 5
+
+export async function POST(req: NextRequest) {
+  let body: Record<string, unknown>
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
+  }
+
+  const pubSlug = typeof body.pubSlug === 'string' ? body.pubSlug.trim() : ''
+  const litBy = typeof body.litBy === 'string' ? body.litBy.trim() : ''
+  const crewName = typeof body.crewName === 'string' ? body.crewName.trim().slice(0, 60) : null
+  const meetAtRaw = typeof body.meetAt === 'string' ? body.meetAt : ''
+
+  if (!pubSlug) {
+    return NextResponse.json({ error: 'Pick a pub first.' }, { status: 400 })
+  }
+  if (litBy.length < 1 || litBy.length > 30) {
+    return NextResponse.json({ error: 'Add your name (up to 30 characters).' }, { status: 400 })
+  }
+
+  const meetAt = new Date(meetAtRaw)
+  const now = new Date()
+  if (!Number.isFinite(meetAt.getTime())) {
+    return NextResponse.json({ error: 'That meet time does not parse.' }, { status: 400 })
+  }
+  if (!isMeetAtInWindow(meetAt, now)) {
+    return NextResponse.json({ error: 'Pick a time between now and tomorrow night.' }, { status: 400 })
+  }
+
+  // Construct the privileged client inside the handler — CI builds without the
+  // service key, so doing this at import time would crash `next build`.
+  let supabase
+  try {
+    supabase = serviceClient()
+  } catch (err) {
+    console.error('Signal route missing service client:', err)
+    return NextResponse.json({ error: 'Signals are down right now. Try again shortly.' }, { status: 500 })
+  }
+
+  try {
+    const { data: pub, error: pubError } = await supabase
+      .from('pubs')
+      .select('id, slug')
+      .eq('slug', pubSlug)
+      .single()
+
+    if (pubError || !pub) {
+      return NextResponse.json({ error: 'We do not know that pub.' }, { status: 404 })
+    }
+
+    const ipHash = hashRequestIp(req)
+    const hourAgo = new Date(now.getTime() - 3600000).toISOString()
+    const { data: recent } = await supabase
+      .from('signals')
+      .select('id')
+      .eq('ip_hash', ipHash)
+      .gte('created_at', hourAgo)
+
+    if (recent && recent.length >= RATE_LIMIT_PER_HOUR) {
+      return NextResponse.json({ error: 'You have lit enough signals for now. Try again in an hour.' }, { status: 429 })
+    }
+
+    const id = generateSignalId()
+    const { error: insertError } = await supabase.from('signals').insert({
+      id,
+      pub_slug: pubSlug,
+      crew_name: crewName || null,
+      lit_by: litBy,
+      meet_at: meetAt.toISOString(),
+      expires_at: expiresAtFrom(meetAt).toISOString(),
+      ip_hash: ipHash,
+    })
+
+    if (insertError) {
+      console.error('Error inserting signal:', insertError)
+      return NextResponse.json({ error: 'Could not light the signal. Try again.' }, { status: 500 })
+    }
+
+    // The lighter is automatically IN — no empty-room signals.
+    const { error: answerError } = await supabase.from('signal_answers').insert({
+      signal_id: id,
+      name: litBy,
+      answer: 'in',
+      note: 'lit the signal',
+      ip_hash: ipHash,
+    })
+    if (answerError) {
+      console.error('Error inserting lighter answer:', answerError)
+    }
+
+    return NextResponse.json({ id })
+  } catch (err) {
+    console.error('Signal route error:', err)
+    return NextResponse.json({ error: 'Could not light the signal. Try again.' }, { status: 500 })
+  }
+}

--- a/src/app/robots.test.ts
+++ b/src/app/robots.test.ts
@@ -12,6 +12,15 @@ test('robots explicitly allows AI citation crawlers while keeping private routes
 
   assert.ok(aiRule)
   assert.equal(aiRule.allow, '/')
-  assert.deepEqual(aiRule.disallow, ['/admin', '/api/'])
+  assert.deepEqual(aiRule.disallow, ['/admin', '/api/', '/signal/'])
   assert.equal(result.sitemap, 'https://perthpintprices.com/sitemap.xml')
+})
+
+test('robots keeps semi-private signal links out of every crawler', () => {
+  const result = robots()
+  const rules = Array.isArray(result.rules) ? result.rules : [result.rules]
+  for (const rule of rules) {
+    const disallow = Array.isArray(rule.disallow) ? rule.disallow : [rule.disallow]
+    assert.ok(disallow.includes('/signal/'))
+  }
 })

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,12 +6,12 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: ['GPTBot', 'PerplexityBot', 'Google-Extended'],
         allow: '/',
-        disallow: ['/admin', '/api/'],
+        disallow: ['/admin', '/api/', '/signal/'],
       },
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/admin', '/api/'],
+        disallow: ['/admin', '/api/', '/signal/'],
       },
     ],
     sitemap: 'https://perthpintprices.com/sitemap.xml',

--- a/src/app/signal/[id]/SignalClient.tsx
+++ b/src/app/signal/[id]/SignalClient.tsx
@@ -1,0 +1,548 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
+import SubPageNav from '@/components/SubPageNav'
+import Footer from '@/components/Footer'
+import {
+  formatTimeLeft,
+  SIGNAL_TTL_MS,
+  type SignalAnswer,
+  type SignalAnswerValue,
+} from '@/lib/signals'
+
+export interface SignalView {
+  id: string
+  pubName: string
+  pubShortName: string
+  suburb: string | null
+  crewName: string | null
+  litBy: string
+  meetLabel: string
+  meetAt: string
+  expiresAt: string
+  priceLine: string | null
+  hhLine: string | null
+}
+
+interface SignalClientProps {
+  view: SignalView | null
+  initialAnswers: SignalAnswer[]
+  state: 'live' | 'expired' | 'missing'
+}
+
+// Deterministic avatar colors from the site palette.
+const AVATAR_COLORS = ['#D4740A', '#2D7A3D', '#C43D2E', '#3B82F6', '#7C3AED', '#171717']
+
+function avatarColor(name: string): string {
+  let hash = 0
+  for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) >>> 0
+  return AVATAR_COLORS[hash % AVATAR_COLORS.length]
+}
+
+function initialsFor(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean)
+  if (words.length === 0) return '?'
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase()
+  return (words[0][0] + words[1][0]).toUpperCase()
+}
+
+interface StoredAnswer {
+  answer: SignalAnswerValue
+  name: string
+  note: string
+}
+
+function readStoredAnswer(id: string): StoredAnswer | null {
+  try {
+    const raw = window.localStorage.getItem(`pps-signal-answer-${id}`)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as StoredAnswer
+    if (parsed && (parsed.answer === 'in' || parsed.answer === 'out')) return parsed
+    return null
+  } catch {
+    return null
+  }
+}
+
+function PintGlyph({ size = 46 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M8 3h8l-1 9.5a3 3 0 0 1-3 2.5 3 3 0 0 1-3-2.5L8 3Z" stroke="#F2A91A" strokeWidth="1.6" strokeLinejoin="round" />
+      <path d="M16 5h2.2a1.8 1.8 0 0 1 0 3.6H15.6" stroke="#F2A91A" strokeWidth="1.6" strokeLinecap="round" />
+      <path d="M12 15v4M9.5 19h5" stroke="#F2A91A" strokeWidth="1.6" strokeLinecap="round" />
+      <path d="M9 6.5c.8.7 2.2.7 3 0 .8-.7 2.2-.7 3 0" stroke="#F2A91A" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+// Beam sway/flicker + glyph glow ported from the prototype. Class names are
+// prefixed so this stays self-contained to the signal card.
+const SIGNAL_CARD_CSS = `
+@keyframes pps-signal-sway {
+  from { transform: translateX(-50%) rotate(7deg); }
+  to { transform: translateX(-50%) rotate(-7deg); }
+}
+@keyframes pps-signal-flicker {
+  0%, 100% { opacity: 1; }
+  48% { opacity: .84; }
+  52% { opacity: .96; }
+  71% { opacity: .8; }
+  74% { opacity: 1; }
+}
+@keyframes pps-signal-glow {
+  0%, 100% { filter: brightness(1); }
+  50% { filter: brightness(1.3); }
+}
+@keyframes pps-signal-landed {
+  to { opacity: 1; transform: none; }
+}
+.pps-signal-beam {
+  position: absolute; bottom: -20%; left: 50%; width: 300px; height: 150%;
+  transform-origin: 50% 100%; transform: translateX(-50%) rotate(8deg);
+  background: linear-gradient(to top, rgba(242,169,26,.32), rgba(242,169,26,.1) 55%, transparent);
+  clip-path: polygon(43% 100%, 57% 100%, 100% 0, 0 0);
+  animation: pps-signal-sway 8s ease-in-out infinite alternate, pps-signal-flicker 4.2s steps(12) infinite;
+}
+.pps-signal-glyph {
+  animation: pps-signal-glow 4.2s ease-in-out infinite;
+}
+.pps-signal-glyph svg {
+  filter: drop-shadow(0 0 18px rgba(242,169,26,.8));
+}
+.pps-signal-row {
+  opacity: 0; transform: translateY(7px);
+  animation: pps-signal-landed .35s ease-out forwards;
+}
+`
+
+function BurnedOutCard({ view, state }: { view: SignalView | null; state: 'expired' | 'missing' }) {
+  return (
+    <div className="border-3 border-ink rounded-card bg-white shadow-hard-sm px-6 py-10 mt-4 text-center">
+      <div className="w-16 h-16 mx-auto rounded-full bg-off-white border-2 border-gray-light flex items-center justify-center opacity-60">
+        <PintGlyph size={32} />
+      </div>
+      <h1 className="font-mono font-extrabold text-ink text-2xl tracking-[-0.03em] mt-5">
+        {state === 'expired' ? 'This signal burned out' : 'No signal here'}
+      </h1>
+      <p className="font-body text-sm text-gray-mid mt-3 max-w-[380px] mx-auto leading-relaxed">
+        {state === 'expired' ? (
+          view
+            ? `${view.pubName} at ${view.meetLabel} — that round is done. Signals only last three hours past the meet time.`
+            : 'That round is done. Signals only last three hours past the meet time.'
+        ) : (
+          'That link does not point at a live signal. It may have burned out and been cleared.'
+        )}
+      </p>
+      <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mt-7">
+        <Link
+          href="/signal/new"
+          className="inline-flex items-center justify-center font-mono text-[0.72rem] font-extrabold uppercase tracking-[0.05em] bg-amber text-white border-3 border-ink rounded-pill px-6 py-3 shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover transition-all no-underline whitespace-nowrap"
+        >
+          Light a new one
+        </Link>
+        <Link
+          href="/"
+          className="font-mono text-[0.68rem] font-bold uppercase tracking-[0.05em] text-gray-mid underline underline-offset-4 hover:text-amber transition-colors"
+        >
+          Back to the prices
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+export default function SignalClient({ view, initialAnswers, state }: SignalClientProps) {
+  const [answers, setAnswers] = useState<SignalAnswer[]>(initialAnswers)
+  const [burnedOut, setBurnedOut] = useState(state === 'expired')
+  const [nowMs, setNowMs] = useState<number | null>(null)
+
+  const [myAnswer, setMyAnswer] = useState<StoredAnswer | null>(null)
+  const [pending, setPending] = useState<SignalAnswerValue | null>(null)
+  const [name, setName] = useState('')
+  const [note, setNote] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [answerError, setAnswerError] = useState<string | null>(null)
+
+  const [toast, setToast] = useState<string | null>(null)
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const signalId = view?.id ?? null
+  const expiresAtMs = view ? new Date(view.expiresAt).getTime() : 0
+
+  // Restore my own answer + remembered name.
+  useEffect(() => {
+    if (!signalId) return
+    const stored = readStoredAnswer(signalId)
+    if (stored) setMyAnswer(stored)
+    const rememberedName = window.localStorage.getItem('pps-signal-name')
+    if (rememberedName) setName(rememberedName)
+  }, [signalId])
+
+  // Tick the burn bar every second.
+  useEffect(() => {
+    if (state !== 'live') return
+    setNowMs(Date.now())
+    const interval = setInterval(() => setNowMs(Date.now()), 1000)
+    return () => clearInterval(interval)
+  }, [state])
+
+  useEffect(() => {
+    if (state === 'live' && nowMs !== null && nowMs >= expiresAtMs) {
+      setBurnedOut(true)
+    }
+  }, [state, nowMs, expiresAtMs])
+
+  // Poll for fresh answers every 30s.
+  useEffect(() => {
+    if (state !== 'live' || !signalId) return
+    const interval = setInterval(async () => {
+      try {
+        const res = await fetch(`/api/signal/${signalId}`)
+        if (res.status === 404 || res.status === 410) {
+          setBurnedOut(true)
+          return
+        }
+        if (!res.ok) return
+        const data = await res.json()
+        if (Array.isArray(data.answers)) setAnswers(data.answers)
+        if (data.expired === true) setBurnedOut(true)
+      } catch {
+        // Network blip — next poll will catch up.
+      }
+    }, 30000)
+    return () => clearInterval(interval)
+  }, [state, signalId])
+
+  const showToast = useCallback((message: string) => {
+    setToast(message)
+    if (toastTimer.current) clearTimeout(toastTimer.current)
+    toastTimer.current = setTimeout(() => setToast(null), 2200)
+  }, [])
+
+  const handleShare = useCallback(async () => {
+    if (!view) return
+    const url = window.location.href
+    const shareData = {
+      title: `Pint Signal — ${view.pubName} ${view.meetLabel}`,
+      text: `${view.litBy} lit the signal: ${view.pubName}, ${view.meetLabel}. Answer it before it burns out.`,
+      url,
+    }
+    if (typeof navigator.share === 'function') {
+      try {
+        await navigator.share(shareData)
+        return
+      } catch {
+        // Cancelled or unsupported payload — fall through to clipboard.
+      }
+    }
+    try {
+      await navigator.clipboard.writeText(url)
+      showToast('Link copied — paste it in the chat')
+    } catch {
+      showToast('Could not copy the link')
+    }
+  }, [view, showToast])
+
+  const refreshAnswers = useCallback(async () => {
+    if (!signalId) return
+    try {
+      const res = await fetch(`/api/signal/${signalId}`)
+      if (!res.ok) return
+      const data = await res.json()
+      if (Array.isArray(data.answers)) setAnswers(data.answers)
+    } catch {
+      // Leave the optimistic list in place.
+    }
+  }, [signalId])
+
+  const submitAnswer = useCallback(async () => {
+    if (!signalId || !pending || submitting) return
+    const trimmedName = name.trim()
+    if (trimmedName.length < 1) {
+      setAnswerError('Add your name so the crew knows who answered.')
+      return
+    }
+    setSubmitting(true)
+    setAnswerError(null)
+    try {
+      const res = await fetch(`/api/signal/${signalId}/answer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: trimmedName, answer: pending, note: note.trim() || undefined }),
+      })
+      if (res.status === 410) {
+        setBurnedOut(true)
+        return
+      }
+      if (!res.ok) {
+        const data = await res.json().catch(() => null)
+        setAnswerError(data?.error || 'Could not save your answer. Try again.')
+        return
+      }
+      const stored: StoredAnswer = { answer: pending, name: trimmedName, note: note.trim() }
+      setMyAnswer(stored)
+      setPending(null)
+      try {
+        window.localStorage.setItem(`pps-signal-answer-${signalId}`, JSON.stringify(stored))
+        window.localStorage.setItem('pps-signal-name', trimmedName)
+      } catch {
+        // Private browsing — the answer still landed server-side.
+      }
+      // Optimistic row while the canonical list refreshes.
+      setAnswers(prev => [
+        ...prev.filter(a => a.name !== trimmedName),
+        {
+          id: `local-${Date.now()}`,
+          signal_id: signalId,
+          name: trimmedName,
+          answer: pending,
+          note: note.trim() || null,
+          created_at: new Date().toISOString(),
+        },
+      ])
+      void refreshAnswers()
+    } catch {
+      setAnswerError('Could not save your answer. Try again.')
+    } finally {
+      setSubmitting(false)
+    }
+  }, [signalId, pending, submitting, name, note, refreshAnswers])
+
+  // ── Burned out / missing states ───────────────────────────────────────────
+  if (!view || burnedOut || state !== 'live') {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <SubPageNav breadcrumbs={[{ label: 'Pint Signal' }]} badge="Beta" showSubmit={false} />
+        <main className="max-w-container mx-auto px-6 w-full flex-1">
+          <BurnedOutCard view={view} state={!view || state === 'missing' ? 'missing' : 'expired'} />
+        </main>
+        <div className="mt-11">
+          <Footer />
+        </div>
+      </div>
+    )
+  }
+
+  // ── Live state ────────────────────────────────────────────────────────────
+  const remainingMs = nowMs === null ? SIGNAL_TTL_MS : Math.max(0, expiresAtMs - nowMs)
+  const burnPercent = Math.max(0, Math.min(100, (remainingMs / SIGNAL_TTL_MS) * 100))
+  const inCount = answers.filter(a => a.answer === 'in').length
+  const answeredLine = `${answers.length} answered · ${inCount} in`
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <style>{SIGNAL_CARD_CSS}</style>
+      <SubPageNav breadcrumbs={[{ label: 'Pint Signal' }]} badge="Beta" showSubmit={false} />
+
+      <main className="max-w-container mx-auto px-6 w-full flex-1">
+        {/* The dark signal card */}
+        <div className="relative mt-4 border-3 border-ink rounded-card bg-[#100F0C] text-[#FDF8F0] overflow-hidden shadow-hard-sm">
+          <div
+            className="absolute inset-0"
+            style={{ background: 'radial-gradient(130% 120% at 50% 130%, #2c2216 0%, #18130d 48%, #100F0C 100%)' }}
+          />
+          <div
+            className="absolute inset-0 opacity-50"
+            style={{
+              backgroundImage: [
+                'radial-gradient(1px 1px at 12% 30%, #fff8 0, transparent 100%)',
+                'radial-gradient(1px 1px at 80% 18%, #fff6 0, transparent 100%)',
+                'radial-gradient(1.5px 1.5px at 60% 12%, #fff7 0, transparent 100%)',
+                'radial-gradient(1px 1px at 30% 14%, #fff5 0, transparent 100%)',
+                'radial-gradient(1px 1px at 92% 44%, #fff5 0, transparent 100%)',
+              ].join(', '),
+            }}
+          />
+          <div className="pps-signal-beam" />
+
+          <div className="relative px-6 pt-8 pb-7 text-center">
+            <div
+              className="pps-signal-glyph w-[92px] h-[92px] mx-auto rounded-full flex items-center justify-center"
+              style={{ background: 'radial-gradient(circle, rgba(242,169,26,.28) 0%, transparent 70%)' }}
+            >
+              <PintGlyph />
+            </div>
+            <p className="font-mono text-[0.62rem] font-bold uppercase tracking-[0.26em] text-amber-light mt-1.5">
+              The signal is up{view.crewName ? ` · ${view.crewName}` : ''}
+            </p>
+            <h1 className="font-mono font-extrabold tracking-[-0.05em] leading-[1.05] mt-2 text-[clamp(1.75rem,6vw,2.4rem)]">
+              {view.pubShortName}.{' '}
+              <em className="font-display italic font-normal text-amber-light tracking-normal">{view.meetLabel}.</em>
+            </h1>
+            <p className="font-body text-[0.82rem] text-[#FDF8F0]/60 mt-2">
+              Lit by <b className="text-[#FDF8F0] font-bold">{view.litBy}</b>
+              {view.priceLine ? <> · {view.priceLine}</> : null}
+              {view.hhLine ? <>, <b className="text-[#FDF8F0] font-bold">{view.hhLine}</b></> : null}
+            </p>
+          </div>
+
+          {/* Burn bar — fused to the card's bottom edge */}
+          <div className="relative border-t-3 border-ink bg-amber-pale text-ink px-4 sm:px-5 pt-2.5 pb-3">
+            <div className="flex justify-between items-baseline mb-1.5">
+              <span className="font-mono text-[0.56rem] font-bold uppercase tracking-[0.1em] text-gray-mid">The glass is draining</span>
+              <span className="font-mono text-[0.62rem] font-bold uppercase tracking-[0.1em] text-amber">
+                {nowMs === null ? '—' : formatTimeLeft(remainingMs)}
+              </span>
+            </div>
+            <div className="h-3 border-[2.5px] border-ink rounded-pill bg-white overflow-hidden">
+              <div
+                className="h-full transition-[width] duration-1000 ease-linear"
+                style={{ width: `${burnPercent}%`, background: 'linear-gradient(90deg, #D4740A, #F2A91A)' }}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Answer buttons */}
+        <div className="flex gap-2.5 mt-5 flex-wrap">
+          <button
+            type="button"
+            onClick={() => {
+              if (myAnswer) return
+              setPending('in')
+              setAnswerError(null)
+            }}
+            disabled={myAnswer !== null || submitting}
+            className={`flex-[2_1_200px] font-mono font-extrabold text-sm uppercase tracking-[0.1em] border-3 border-ink rounded-pill py-4 shadow-hard-sm transition-all whitespace-nowrap ${
+              myAnswer?.answer === 'in'
+                ? 'bg-ink text-white cursor-default'
+                : myAnswer
+                  ? 'bg-green/40 text-white/80 cursor-default'
+                  : 'bg-green text-white hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover'
+            }`}
+          >
+            {myAnswer?.answer === 'in' ? `Locked in — see you at ${view.meetLabel}` : 'I’m in'}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              if (myAnswer) return
+              setPending('out')
+              setAnswerError(null)
+            }}
+            disabled={myAnswer !== null || submitting}
+            className={`flex-[1_1_130px] font-mono font-extrabold text-[0.72rem] uppercase tracking-[0.05em] border-3 border-ink rounded-pill py-4 px-5 shadow-hard-sm transition-all whitespace-nowrap ${
+              myAnswer?.answer === 'out'
+                ? 'bg-ink text-white cursor-default'
+                : myAnswer
+                  ? 'bg-white text-gray-mid cursor-default'
+                  : 'bg-white text-ink hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover'
+            }`}
+          >
+            {myAnswer?.answer === 'out' ? 'Noted — next time' : 'Can’t tonight'}
+          </button>
+        </div>
+
+        {/* Inline name + note composer after choosing */}
+        {pending && !myAnswer && (
+          <div className="mt-4 border-3 border-ink rounded-card bg-white shadow-hard-sm p-4">
+            <p className="type-eyebrow mb-3">
+              {pending === 'in' ? 'Locking you in' : 'Fair enough'}
+            </p>
+            <div className="flex flex-col sm:flex-row gap-2.5">
+              <input
+                type="text"
+                value={name}
+                onChange={e => setName(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') void submitAnswer() }}
+                maxLength={30}
+                placeholder="Your name"
+                aria-label="Your name"
+                className="flex-1 font-mono text-sm font-bold text-ink bg-off-white border-2 border-ink rounded-card px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-amber"
+              />
+              <input
+                type="text"
+                value={note}
+                onChange={e => setNote(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') void submitAnswer() }}
+                maxLength={60}
+                placeholder={pending === 'in' ? 'Add a note — optional' : 'Reason — optional'}
+                aria-label="Note"
+                className="flex-[1.4] font-body text-sm text-ink bg-off-white border-2 border-ink rounded-card px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-amber"
+              />
+              <button
+                type="button"
+                onClick={() => void submitAnswer()}
+                disabled={submitting}
+                className={`font-mono text-[0.68rem] font-extrabold uppercase tracking-[0.05em] border-3 border-ink rounded-pill px-5 py-2.5 shadow-hard-sm transition-all whitespace-nowrap ${
+                  pending === 'in' ? 'bg-green text-white' : 'bg-white text-ink'
+                } ${submitting ? 'opacity-60' : 'hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover'}`}
+              >
+                {submitting ? 'Sending…' : pending === 'in' ? 'Lock it in' : 'Send it'}
+              </button>
+            </div>
+            {answerError && (
+              <p className="font-mono text-[0.68rem] font-bold text-red mt-2.5">{answerError}</p>
+            )}
+          </div>
+        )}
+
+        {/* Share link */}
+        <div className="flex justify-center mt-4">
+          <button
+            type="button"
+            onClick={() => void handleShare()}
+            className="font-mono text-[0.66rem] font-bold uppercase tracking-[0.05em] text-gray-mid underline underline-offset-4 hover:text-amber transition-colors"
+          >
+            Share to the group chat
+          </button>
+        </div>
+
+        {/* Who's answered */}
+        <section className="mt-10">
+          <div className="flex justify-between items-baseline pb-2.5 border-b-3 border-ink">
+            <span className="type-eyebrow text-ink">Who&apos;s answered</span>
+            <span className="type-eyebrow">{answeredLine}</span>
+          </div>
+          {answers.length === 0 ? (
+            <p className="font-body text-sm text-gray-mid py-4">No answers yet. Send the link.</p>
+          ) : (
+            <div>
+              {answers.map(a => (
+                <div key={a.id} className="pps-signal-row flex items-center gap-3 py-3 border-b border-gray-light">
+                  <div
+                    className="w-[30px] h-[30px] rounded-full border-[2.5px] border-ink flex items-center justify-center font-mono text-[0.62rem] font-extrabold text-white flex-shrink-0"
+                    style={{ backgroundColor: avatarColor(a.name) }}
+                  >
+                    {initialsFor(a.name)}
+                  </div>
+                  <span className="font-mono font-extrabold text-[0.84rem] text-ink flex-shrink-0">{a.name}</span>
+                  {a.note && <span className="font-body text-[0.72rem] text-gray-mid truncate min-w-0">{a.note}</span>}
+                  <span
+                    className={`ml-auto font-mono text-[0.56rem] font-extrabold uppercase tracking-[0.06em] rounded-pill px-2.5 py-1 whitespace-nowrap flex-shrink-0 ${
+                      a.answer === 'in'
+                        ? 'bg-green text-white'
+                        : 'bg-off-white text-gray-mid border border-gray-light'
+                    }`}
+                  >
+                    {a.answer === 'in' ? 'IN' : 'OUT'}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+          {inCount >= 4 && (
+            <p className="font-mono text-[0.7rem] font-extrabold text-green text-center pt-4">
+              That&apos;s a table. See you down there.
+            </p>
+          )}
+        </section>
+      </main>
+
+      {/* Toast */}
+      <div
+        aria-live="polite"
+        className={`fixed left-1/2 bottom-6 -translate-x-1/2 bg-ink text-white font-mono text-[0.7rem] font-bold rounded-pill px-5 py-3 shadow-[0_8px_30px_rgba(0,0,0,0.35)] z-50 transition-all duration-300 whitespace-nowrap ${
+          toast ? 'translate-y-0 opacity-100' : 'translate-y-20 opacity-0 pointer-events-none'
+        }`}
+      >
+        {toast}
+      </div>
+
+      <div className="mt-11">
+        <Footer />
+      </div>
+    </div>
+  )
+}

--- a/src/app/signal/[id]/page.tsx
+++ b/src/app/signal/[id]/page.tsx
@@ -1,0 +1,139 @@
+import type { Metadata } from 'next'
+import { anonClient } from '@/lib/supabaseGateway'
+import { getHappyHourStatus } from '@/lib/happyHourLive'
+import {
+  formatClockLabel,
+  formatMeetTimeLabel,
+  isExpired,
+  shortPubName,
+  type Signal,
+  type SignalAnswer,
+} from '@/lib/signals'
+import SignalClient, { type SignalView } from './SignalClient'
+
+// Signals are live, semi-private objects — never cache, never index.
+export const dynamic = 'force-dynamic'
+
+interface SignalPub {
+  name: string
+  slug: string
+  suburb: string | null
+  address: string | null
+  price: number | null
+  happy_hour_price: number | null
+  happy_hour_days: string | null
+  happy_hour_start: string | null
+  happy_hour_end: string | null
+}
+
+async function fetchSignal(id: string): Promise<Signal | null> {
+  try {
+    const { data, error } = await anonClient()
+      .from('signals')
+      .select('id, pub_slug, crew_name, lit_by, meet_at, expires_at, created_at')
+      .eq('id', id)
+      .single()
+    // Any error (including "relation does not exist" before the schema is
+    // applied) degrades to the not-found state.
+    if (error || !data) return null
+    return data as Signal
+  } catch {
+    return null
+  }
+}
+
+async function fetchAnswers(id: string): Promise<SignalAnswer[]> {
+  try {
+    const { data, error } = await anonClient()
+      .from('signal_answers')
+      .select('id, signal_id, name, answer, note, created_at')
+      .eq('signal_id', id)
+      .order('created_at', { ascending: true })
+    if (error || !data) return []
+    return data as SignalAnswer[]
+  } catch {
+    return []
+  }
+}
+
+async function fetchPub(slug: string): Promise<SignalPub | null> {
+  try {
+    const { data, error } = await anonClient()
+      .from('pubs')
+      .select('name, slug, suburb, address, price, happy_hour_price, happy_hour_days, happy_hour_start, happy_hour_end')
+      .eq('slug', slug)
+      .single()
+    if (error || !data) return null
+    return data as SignalPub
+  } catch {
+    return null
+  }
+}
+
+export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
+  const signal = await fetchSignal(params.id)
+  const pub = signal ? await fetchPub(signal.pub_slug) : null
+  const title = signal
+    ? `Pint Signal — ${pub?.name || signal.pub_slug} ${formatMeetTimeLabel(signal.meet_at)}`
+    : 'Pint Signal'
+  return {
+    title,
+    description: 'One mate lit the signal. Answer it before it burns out.',
+    robots: { index: false, follow: false },
+  }
+}
+
+export default async function SignalPage({ params }: { params: { id: string } }) {
+  const signal = await fetchSignal(params.id)
+
+  if (!signal) {
+    return <SignalClient view={null} initialAnswers={[]} state="missing" />
+  }
+
+  const [answers, pub] = await Promise.all([
+    fetchAnswers(signal.id),
+    fetchPub(signal.pub_slug),
+  ])
+
+  const meetAt = new Date(signal.meet_at)
+  const price = pub?.price != null ? Number(pub.price) : null
+  const hhPrice = pub?.happy_hour_price != null ? Number(pub.happy_hour_price) : null
+
+  // Only pitch the happy hour when it actually covers the meet time.
+  let hhLine: string | null = null
+  if (pub && hhPrice != null && Number.isFinite(meetAt.getTime())) {
+    const hhAtMeet = getHappyHourStatus({
+      price,
+      happyHourPrice: hhPrice,
+      happyHourDays: pub.happy_hour_days,
+      happyHourStart: pub.happy_hour_start,
+      happyHourEnd: pub.happy_hour_end,
+    }, meetAt)
+    const endLabel = formatClockLabel(pub.happy_hour_end)
+    if (hhAtMeet.isActive && endLabel) {
+      hhLine = `$${hhPrice.toFixed(2)} till ${endLabel}`
+    }
+  }
+
+  const view: SignalView = {
+    id: signal.id,
+    pubName: pub?.name || signal.pub_slug,
+    pubShortName: shortPubName(pub?.name || signal.pub_slug),
+    suburb: pub?.suburb || null,
+    crewName: signal.crew_name,
+    litBy: signal.lit_by,
+    meetLabel: formatMeetTimeLabel(signal.meet_at),
+    meetAt: signal.meet_at,
+    expiresAt: signal.expires_at,
+    priceLine: price != null ? `$${price.toFixed(2)} pints` : null,
+    hhLine,
+  }
+
+  return (
+    <SignalClient
+      view={view}
+      initialAnswers={answers}
+      state={isExpired(signal) ? 'expired' : 'live'}
+    />
+  )
+}

--- a/src/app/signal/new/NewSignalClient.tsx
+++ b/src/app/signal/new/NewSignalClient.tsx
@@ -1,0 +1,287 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import SubPageNav from '@/components/SubPageNav'
+import Footer from '@/components/Footer'
+import { perthNow } from '@/lib/perthClock'
+import type { SlimPub } from '@/lib/pubPhoto'
+
+interface NewSignalClientProps {
+  pubs: SlimPub[]
+}
+
+interface TimeChip {
+  key: string
+  label: string
+  /** Perth hour of day (24h), or null for "Now". */
+  hour: number | null
+}
+
+const TIME_CHIPS: TimeChip[] = [
+  { key: 'now', label: 'Now', hour: null },
+  { key: '17', label: '5pm', hour: 17 },
+  { key: '18', label: '6pm', hour: 18 },
+  { key: '19', label: '7pm', hour: 19 },
+  { key: '20', label: '8pm', hour: 20 },
+]
+
+const PERTH_OFFSET_HOURS = 8
+
+/** ISO instant for a Perth wall-clock hour today. */
+function perthHourTodayIso(hour: number): string {
+  const perth = perthNow(new Date())
+  const [y, m, d] = perth.ymd.split('-').map(Number)
+  return new Date(Date.UTC(y, m - 1, d, hour - PERTH_OFFSET_HOURS, 0, 0)).toISOString()
+}
+
+export default function NewSignalClient({ pubs }: NewSignalClientProps) {
+  const router = useRouter()
+
+  const [query, setQuery] = useState('')
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null)
+  const [timeKey, setTimeKey] = useState<string | null>(null)
+  const [name, setName] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Perth clock for disabling past chips — set after mount so server and
+  // client render the same initial HTML.
+  const [perthMinutes, setPerthMinutes] = useState<number | null>(null)
+  useEffect(() => {
+    const tick = () => setPerthMinutes(perthNow(new Date()).minutesOfDay)
+    tick()
+    const interval = setInterval(tick, 60000)
+    return () => clearInterval(interval)
+  }, [])
+
+  useEffect(() => {
+    const remembered = window.localStorage.getItem('pps-signal-name')
+    if (remembered) setName(remembered)
+  }, [])
+
+  const shownPubs = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    let list: SlimPub[]
+    if (q === '') {
+      // Top suggestions: cheapest priced pubs, live happy hours first.
+      list = pubs
+        .filter(p => p.price != null)
+        .sort((a, b) => {
+          if (a.isHappyHourNow !== b.isHappyHourNow) return a.isHappyHourNow ? -1 : 1
+          return (a.price ?? Number.MAX_VALUE) - (b.price ?? Number.MAX_VALUE)
+        })
+        .slice(0, 5)
+    } else {
+      list = pubs
+        .filter(p =>
+          p.name.toLowerCase().includes(q) || (p.suburb || '').toLowerCase().includes(q),
+        )
+        .sort((a, b) => (a.price ?? Number.MAX_VALUE) - (b.price ?? Number.MAX_VALUE))
+        .slice(0, 12)
+    }
+    // Keep the chosen pub visible even when the filter no longer matches it.
+    if (selectedSlug && !list.some(p => p.slug === selectedSlug)) {
+      const selected = pubs.find(p => p.slug === selectedSlug)
+      if (selected) list = [selected, ...list]
+    }
+    return list
+  }, [pubs, query, selectedSlug])
+
+  const chipDisabled = (chip: TimeChip): boolean => {
+    if (chip.hour === null) return false
+    if (perthMinutes === null) return false
+    return perthMinutes >= chip.hour * 60
+  }
+
+  const canSubmit = selectedSlug !== null && timeKey !== null && name.trim().length >= 1 && !submitting
+
+  const handleSubmit = async () => {
+    if (!canSubmit || !selectedSlug || !timeKey) return
+    setSubmitting(true)
+    setError(null)
+
+    const chip = TIME_CHIPS.find(c => c.key === timeKey)
+    const meetAt = chip && chip.hour !== null ? perthHourTodayIso(chip.hour) : new Date().toISOString()
+
+    try {
+      const res = await fetch('/api/signal', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pubSlug: selectedSlug, litBy: name.trim(), meetAt }),
+      })
+      const data = await res.json().catch(() => null)
+      if (!res.ok || !data?.id) {
+        setError(data?.error || 'Could not light the signal. Try again.')
+        setSubmitting(false)
+        return
+      }
+
+      try {
+        window.localStorage.setItem('pps-signal-name', name.trim())
+        // The lighter is auto-answered IN — remember that on this device too.
+        window.localStorage.setItem(
+          `pps-signal-answer-${data.id}`,
+          JSON.stringify({ answer: 'in', name: name.trim(), note: 'lit the signal' }),
+        )
+      } catch {
+        // Private browsing — carry on.
+      }
+
+      const url = `${window.location.origin}/signal/${data.id}`
+      if (typeof navigator.share === 'function') {
+        try {
+          await navigator.share({ title: 'Pint Signal', text: 'The signal is up. Answer it before it burns out.', url })
+        } catch {
+          // Share sheet dismissed or blocked — the answer page has its own share link.
+        }
+      }
+      router.push(`/signal/${data.id}`)
+    } catch {
+      setError('Could not light the signal. Try again.')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <SubPageNav breadcrumbs={[{ label: 'Pint Signal' }]} badge="Beta" showSubmit={false} />
+
+      <main className="max-w-container mx-auto px-6 w-full flex-1">
+        <h1 className="type-hero mt-6">
+          Light the <em className="font-display italic font-normal text-amber tracking-normal">signal</em>
+        </h1>
+        <p className="font-body text-sm text-gray-mid mt-2 max-w-[440px] leading-relaxed">
+          Pick the pub, pick the time, send the link. The crew answers before it burns out — signals last three hours past the meet time.
+        </p>
+
+        {/* ── Pub picker ── */}
+        <section className="mt-8">
+          <div className="flex justify-between items-baseline pb-2.5 border-b-3 border-ink">
+            <span className="type-eyebrow text-ink">Where</span>
+            {query.trim() === '' && <span className="type-eyebrow">Cheapest first</span>}
+          </div>
+          <input
+            type="text"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="Search pub or suburb"
+            aria-label="Search pub or suburb"
+            className="w-full mt-4 font-mono text-sm font-bold text-ink bg-white border-3 border-ink rounded-pill px-5 py-3 shadow-hard-sm focus:outline-none focus:ring-2 focus:ring-amber placeholder:text-gray-mid placeholder:font-normal"
+          />
+          <div className="mt-2">
+            {shownPubs.length === 0 ? (
+              <p className="font-body text-sm text-gray-mid py-4">No pubs match that. Try the suburb name.</p>
+            ) : (
+              shownPubs.map(pub => {
+                const selected = pub.slug === selectedSlug
+                return (
+                  <button
+                    key={pub.slug}
+                    type="button"
+                    onClick={() => setSelectedSlug(pub.slug)}
+                    aria-pressed={selected}
+                    className="w-full flex items-center gap-3 py-3.5 px-0.5 border-b border-gray-light text-left hover:bg-off-white transition-colors"
+                  >
+                    <span
+                      className={`w-5 h-5 rounded-full border-2 border-ink flex-shrink-0 flex items-center justify-center ${selected ? 'bg-amber' : 'bg-white'}`}
+                      aria-hidden="true"
+                    >
+                      {selected && <span className="w-1.5 h-1.5 rounded-full bg-white" />}
+                    </span>
+                    <span className="min-w-0">
+                      <span className="flex items-center gap-2">
+                        <span className="font-body font-bold text-[1.02rem] text-ink truncate">{pub.name}</span>
+                        {pub.isHappyHourNow && (
+                          <span className="font-mono text-[0.52rem] font-extrabold uppercase tracking-[0.05em] bg-amber text-white rounded-pill px-2 py-0.5 whitespace-nowrap flex-shrink-0">HH now</span>
+                        )}
+                      </span>
+                      <span className="block font-body text-xs text-gray-mid mt-0.5">{pub.suburb}</span>
+                    </span>
+                    <span className="ml-auto font-mono font-extrabold text-[1.1rem] text-ink flex-shrink-0">
+                      {pub.price != null ? `$${pub.price.toFixed(2)}` : 'TBC'}
+                    </span>
+                  </button>
+                )
+              })
+            )}
+          </div>
+        </section>
+
+        {/* ── Time chips ── */}
+        <section className="mt-8">
+          <div className="pb-2.5 border-b-3 border-ink">
+            <span className="type-eyebrow text-ink">When</span>
+          </div>
+          <div className="flex flex-wrap gap-2.5 mt-4">
+            {TIME_CHIPS.map(chip => {
+              const disabled = chipDisabled(chip)
+              const selected = timeKey === chip.key
+              return (
+                <button
+                  key={chip.key}
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => setTimeKey(chip.key)}
+                  aria-pressed={selected}
+                  className={`font-mono text-[0.72rem] font-extrabold uppercase tracking-[0.05em] border-3 border-ink rounded-pill px-5 py-2.5 transition-all whitespace-nowrap ${
+                    disabled
+                      ? 'opacity-30 bg-white text-gray-mid cursor-not-allowed'
+                      : selected
+                        ? 'bg-ink text-white shadow-hard-sm'
+                        : 'bg-white text-ink shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover'
+                  }`}
+                >
+                  {chip.label}
+                </button>
+              )
+            })}
+          </div>
+        </section>
+
+        {/* ── Name ── */}
+        <section className="mt-8">
+          <div className="pb-2.5 border-b-3 border-ink">
+            <span className="type-eyebrow text-ink">Who&apos;s lighting it</span>
+          </div>
+          <input
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            maxLength={30}
+            placeholder="Your name"
+            aria-label="Your name"
+            className="w-full sm:max-w-[320px] mt-4 font-mono text-sm font-bold text-ink bg-white border-3 border-ink rounded-card px-4 py-3 focus:outline-none focus:ring-2 focus:ring-amber placeholder:text-gray-mid placeholder:font-normal"
+          />
+        </section>
+
+        {error && (
+          <div className="mt-6 border-3 border-ink rounded-card bg-red-pale shadow-hard-sm p-4">
+            <p className="type-eyebrow text-red">Signal not lit</p>
+            <p className="font-body text-sm text-ink mt-1.5">{error}</p>
+          </div>
+        )}
+
+        <button
+          type="button"
+          onClick={() => void handleSubmit()}
+          disabled={!canSubmit}
+          className={`w-full mt-8 font-mono font-extrabold text-sm uppercase tracking-[0.1em] border-3 border-ink rounded-pill py-4 transition-all whitespace-nowrap ${
+            canSubmit
+              ? 'bg-amber text-white shadow-hard-sm hover:translate-x-[1.5px] hover:translate-y-[1.5px] hover:shadow-hard-hover'
+              : 'bg-amber/40 text-white/80 cursor-not-allowed shadow-hard-sm'
+          }`}
+        >
+          {submitting ? 'Lighting…' : 'Light the signal'}
+        </button>
+        <p className="font-body text-xs text-gray-mid text-center mt-3">
+          You&apos;re automatically in. Next stop: the group chat.
+        </p>
+      </main>
+
+      <div className="mt-11">
+        <Footer />
+      </div>
+    </div>
+  )
+}

--- a/src/app/signal/new/page.tsx
+++ b/src/app/signal/new/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+import { getPubs } from '@/lib/supabase'
+import { slimPubForList } from '@/lib/pubPhoto'
+import NewSignalClient from './NewSignalClient'
+
+export const metadata: Metadata = {
+  title: 'Light a Pint Signal',
+  description: 'Pick the pub, pick the time, send the link. The crew answers before it burns out.',
+  robots: { index: false, follow: false },
+}
+
+export const revalidate = 300
+
+export default async function NewSignalPage() {
+  const pubs = (await getPubs()).map(slimPubForList)
+
+  return <NewSignalClient pubs={pubs} />
+}

--- a/src/components/SubPageNav.tsx
+++ b/src/components/SubPageNav.tsx
@@ -15,9 +15,11 @@ interface SubPageNavProps {
   title?: string
   subtitle?: string
   showSubmit?: boolean
+  /** Optional chip rendered after the page label, e.g. "Beta". */
+  badge?: string
 }
 
-export default function SubPageNav({ breadcrumbs, title, subtitle, showSubmit = true }: SubPageNavProps) {
+export default function SubPageNav({ breadcrumbs, title, subtitle, showSubmit = true, badge }: SubPageNavProps) {
   const pathname = usePathname()
   const navLinks = [
     { href: '/discover', label: 'Discover' },
@@ -46,6 +48,9 @@ export default function SubPageNav({ breadcrumbs, title, subtitle, showSubmit = 
             <div className="flex md:hidden items-center gap-1.5 min-w-0">
               <span className="text-gray-mid text-sm flex-shrink-0">/</span>
               <span className="font-mono text-[0.72rem] font-bold uppercase tracking-[0.05em] text-ink truncate">{pageLabel}</span>
+              {badge && (
+                <span className="font-mono text-[0.53rem] font-extrabold uppercase tracking-[0.08em] bg-amber text-white rounded-pill px-2 py-0.5 flex-shrink-0 whitespace-nowrap">{badge}</span>
+              )}
             </div>
           )}
         </div>
@@ -96,6 +101,9 @@ export default function SubPageNav({ breadcrumbs, title, subtitle, showSubmit = 
               <span className="font-mono text-[0.72rem] font-bold uppercase tracking-[0.05em] text-ink truncate">{title}</span>
             </div>
           ) : null}
+          {badge && (
+            <span className="hidden md:inline-flex font-mono text-[0.53rem] font-extrabold uppercase tracking-[0.08em] bg-amber text-white rounded-pill px-2 py-0.5 flex-shrink-0 whitespace-nowrap">{badge}</span>
+          )}
         </div>
 
         {showSubmit && (

--- a/src/lib/signalId.test.ts
+++ b/src/lib/signalId.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { generateSignalId, SIGNAL_ID_LENGTH } from './signalId'
+
+test('generateSignalId returns a 10-char id', () => {
+  assert.equal(generateSignalId().length, SIGNAL_ID_LENGTH)
+  assert.equal(SIGNAL_ID_LENGTH, 10)
+})
+
+test('generateSignalId only uses base62 characters', () => {
+  for (let i = 0; i < 100; i++) {
+    assert.match(generateSignalId(), /^[0-9A-Za-z]{10}$/)
+  }
+})
+
+test('generateSignalId does not collide over 1000 generations', () => {
+  const seen = new Set<string>()
+  for (let i = 0; i < 1000; i++) {
+    seen.add(generateSignalId())
+  }
+  assert.equal(seen.size, 1000)
+})

--- a/src/lib/signalId.ts
+++ b/src/lib/signalId.ts
@@ -1,0 +1,30 @@
+/**
+ * SignalId — unguessable share keys for Pint Signals.
+ *
+ * 10 base62 chars = 62^10 ≈ 8.4e17 combinations, which is the only access
+ * control a signal link has (they're semi-private, noindexed URLs). Uses
+ * node:crypto so it works in Node route handlers with no new dependencies.
+ */
+import { randomBytes } from 'node:crypto'
+
+export const SIGNAL_ID_LENGTH = 10
+
+const ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+
+// Largest multiple of 62 that fits in a byte (62 * 4 = 248). Bytes >= 248 are
+// rejected so `byte % 62` stays uniform instead of biasing toward 0–7.
+const UNBIASED_LIMIT = 248
+
+/** Generate a 10-char base62 id using rejection sampling over random bytes. */
+export function generateSignalId(): string {
+  let id = ''
+  while (id.length < SIGNAL_ID_LENGTH) {
+    const bytes = randomBytes(SIGNAL_ID_LENGTH * 2)
+    for (let i = 0; i < bytes.length && id.length < SIGNAL_ID_LENGTH; i++) {
+      const byte = bytes[i]
+      if (byte >= UNBIASED_LIMIT) continue
+      id += ALPHABET[byte % ALPHABET.length]
+    }
+  }
+  return id
+}

--- a/src/lib/signals.test.ts
+++ b/src/lib/signals.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  expiresAtFrom,
+  formatClockLabel,
+  formatMeetTimeLabel,
+  formatTimeLeft,
+  isExpired,
+  isMeetAtInWindow,
+  MEET_AT_MAX_AHEAD_MS,
+  MEET_AT_PAST_GRACE_MS,
+  shortPubName,
+  SIGNAL_TTL_MS,
+} from './signals'
+
+test('expiresAtFrom adds exactly 3 hours to the meet time', () => {
+  const meetAt = new Date('2026-06-10T10:00:00.000Z')
+  assert.equal(expiresAtFrom(meetAt).toISOString(), '2026-06-10T13:00:00.000Z')
+  assert.equal(SIGNAL_TTL_MS, 3 * 60 * 60 * 1000)
+})
+
+test('isExpired flips exactly at expires_at', () => {
+  const signal = { expires_at: '2026-06-10T13:00:00.000Z' }
+  // One millisecond before expiry: still alive.
+  assert.equal(isExpired(signal, new Date('2026-06-10T12:59:59.999Z')), false)
+  // At the boundary: burned out.
+  assert.equal(isExpired(signal, new Date('2026-06-10T13:00:00.000Z')), true)
+  // After: burned out.
+  assert.equal(isExpired(signal, new Date('2026-06-10T13:00:00.001Z')), true)
+})
+
+test('isExpired treats unparseable expiry data as expired', () => {
+  assert.equal(isExpired({ expires_at: 'not-a-date' }), true)
+  assert.equal(isExpired({ expires_at: '' }), true)
+})
+
+test('isMeetAtInWindow allows now-15min through now+36h inclusive', () => {
+  const now = new Date('2026-06-10T08:00:00.000Z')
+  const at = (offsetMs: number) => new Date(now.getTime() + offsetMs)
+
+  assert.equal(isMeetAtInWindow(at(0), now), true)
+  // Past grace boundary.
+  assert.equal(isMeetAtInWindow(at(-MEET_AT_PAST_GRACE_MS), now), true)
+  assert.equal(isMeetAtInWindow(at(-MEET_AT_PAST_GRACE_MS - 1), now), false)
+  // Future boundary.
+  assert.equal(isMeetAtInWindow(at(MEET_AT_MAX_AHEAD_MS), now), true)
+  assert.equal(isMeetAtInWindow(at(MEET_AT_MAX_AHEAD_MS + 1), now), false)
+  // Garbage dates never pass.
+  assert.equal(isMeetAtInWindow(new Date('nope'), now), false)
+})
+
+test('formatMeetTimeLabel renders Perth wall-clock time', () => {
+  // 10:00 UTC = 6pm Perth (UTC+8, no DST).
+  assert.equal(formatMeetTimeLabel('2026-06-10T10:00:00.000Z'), '6pm')
+  // 09:30 UTC = 5.30pm Perth.
+  assert.equal(formatMeetTimeLabel('2026-06-10T09:30:00.000Z'), '5.30pm')
+  // 04:00 UTC = 12pm Perth (noon, not 0pm).
+  assert.equal(formatMeetTimeLabel('2026-06-10T04:00:00.000Z'), '12pm')
+  // 16:00 UTC = 12am Perth (midnight rollover to next day).
+  assert.equal(formatMeetTimeLabel('2026-06-10T16:00:00.000Z'), '12am')
+  assert.equal(formatMeetTimeLabel('garbage'), '')
+})
+
+test('formatClockLabel converts 24h DB times to short labels', () => {
+  assert.equal(formatClockLabel('18:00'), '6pm')
+  assert.equal(formatClockLabel('18:00:00'), '6pm')
+  assert.equal(formatClockLabel('17:30'), '5.30pm')
+  assert.equal(formatClockLabel('09:00'), '9am')
+  assert.equal(formatClockLabel('00:00'), '12am')
+  assert.equal(formatClockLabel('12:00'), '12pm')
+  assert.equal(formatClockLabel('25:00'), null)
+  assert.equal(formatClockLabel(''), null)
+  assert.equal(formatClockLabel(null), null)
+  assert.equal(formatClockLabel(undefined), null)
+})
+
+test('shortPubName strips "The" and generic suffixes without emptying the name', () => {
+  assert.equal(shortPubName('The Norfolk Hotel'), 'Norfolk')
+  assert.equal(shortPubName('The National Hotel'), 'National')
+  assert.equal(shortPubName('Dunsborough Tavern'), 'Dunsborough')
+  // Never strip down to nothing.
+  assert.equal(shortPubName('The Tavern'), 'Tavern')
+  assert.equal(shortPubName('Hotel'), 'Hotel')
+  // Non-suffix names pass through.
+  assert.equal(shortPubName('Bar Orient'), 'Bar Orient')
+  assert.equal(shortPubName('Little Creatures'), 'Little Creatures')
+})
+
+test('formatTimeLeft renders hours and zero-padded minutes, clamped at zero', () => {
+  assert.equal(formatTimeLeft(2 * 3600 * 1000 + 55 * 60 * 1000), '2h 55m left')
+  assert.equal(formatTimeLeft(5 * 60 * 1000), '0h 05m left')
+  assert.equal(formatTimeLeft(0), '0h 00m left')
+  assert.equal(formatTimeLeft(-5000), '0h 00m left')
+})

--- a/src/lib/signals.ts
+++ b/src/lib/signals.ts
@@ -1,0 +1,118 @@
+/**
+ * Pint Signal — shared types + pure helpers.
+ *
+ * One mate lights the signal (pub + time), the crew answers via the share
+ * link, and the signal burns out 3 hours after the meet time. Everything
+ * here is pure and clock-injected so the API routes and pages stay
+ * deterministic and testable. Schema: scripts/pint-signal-schema.sql.
+ */
+import { perthNow } from './perthClock'
+
+// ── Types (mirror the signals / signal_answers tables) ──────────────────────
+
+export interface Signal {
+  id: string
+  pub_slug: string
+  crew_name: string | null
+  lit_by: string
+  meet_at: string
+  expires_at: string
+  created_at: string
+}
+
+export type SignalAnswerValue = 'in' | 'out'
+
+export interface SignalAnswer {
+  id: string
+  signal_id: string
+  name: string
+  answer: SignalAnswerValue
+  note: string | null
+  created_at: string
+}
+
+// ── Lifetime ─────────────────────────────────────────────────────────────────
+
+/** Signals burn out 3 hours after the meet time. */
+export const SIGNAL_TTL_MS = 3 * 60 * 60 * 1000
+
+/** How far in the past a meet time may be when lighting ("Now" with clock skew). */
+export const MEET_AT_PAST_GRACE_MS = 15 * 60 * 1000
+
+/** How far ahead a signal can be lit — tonight or tomorrow, not next month. */
+export const MEET_AT_MAX_AHEAD_MS = 36 * 60 * 60 * 1000
+
+/** expires_at for a given meet time: meet_at + 3h. */
+export function expiresAtFrom(meetAt: Date): Date {
+  return new Date(meetAt.getTime() + SIGNAL_TTL_MS)
+}
+
+/**
+ * A signal is expired once `now` reaches expires_at. Unparseable or missing
+ * expiry data counts as expired — a signal that can't prove it's alive is dead.
+ */
+export function isExpired(signal: Pick<Signal, 'expires_at'>, now: Date = new Date()): boolean {
+  const expires = new Date(signal.expires_at).getTime()
+  if (!Number.isFinite(expires)) return true
+  return now.getTime() >= expires
+}
+
+/** Is a proposed meet time inside the allowed lighting window? (Inclusive bounds.) */
+export function isMeetAtInWindow(meetAt: Date, now: Date = new Date()): boolean {
+  const t = meetAt.getTime()
+  if (!Number.isFinite(t)) return false
+  return t >= now.getTime() - MEET_AT_PAST_GRACE_MS && t <= now.getTime() + MEET_AT_MAX_AHEAD_MS
+}
+
+// ── Formatters ───────────────────────────────────────────────────────────────
+
+function clockLabel(hours24: number, minutes: number): string {
+  const h12 = hours24 % 12 === 0 ? 12 : hours24 % 12
+  const ampm = hours24 < 12 ? 'am' : 'pm'
+  return minutes === 0 ? `${h12}${ampm}` : `${h12}.${String(minutes).padStart(2, '0')}${ampm}`
+}
+
+/** Perth wall-clock label for a meet instant: "6pm", "6.30pm", "12pm". */
+export function formatMeetTimeLabel(meetAt: string | Date): string {
+  const date = typeof meetAt === 'string' ? new Date(meetAt) : meetAt
+  if (!Number.isFinite(date.getTime())) return ''
+  const perth = perthNow(date)
+  return clockLabel(Math.floor(perth.minutesOfDay / 60), perth.minutesOfDay % 60)
+}
+
+/** "18:00" / "18:00:00" -> "6pm"; null when the string doesn't parse. */
+export function formatClockLabel(time: string | null | undefined): string | null {
+  if (!time) return null
+  const match = time.trim().match(/^(\d{1,2}):(\d{2})/)
+  if (!match) return null
+  const hours = parseInt(match[1], 10)
+  const minutes = parseInt(match[2], 10)
+  if (hours > 23 || minutes > 59) return null
+  return clockLabel(hours, minutes)
+}
+
+const PUB_NAME_SUFFIXES = new Set(['hotel', 'tavern', 'pub', 'inn', 'bar'])
+
+/**
+ * Short headline name for the signal card: "The Norfolk Hotel" -> "Norfolk".
+ * Strips a leading "The" and a single generic suffix word, but never shortens
+ * a name down to nothing.
+ */
+export function shortPubName(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean)
+  if (words.length === 0) return name.trim()
+  let start = 0
+  let end = words.length
+  if (words.length > 1 && words[0].toLowerCase() === 'the') start = 1
+  if (end - start > 1 && PUB_NAME_SUFFIXES.has(words[end - 1].toLowerCase())) end -= 1
+  const short = words.slice(start, end).join(' ')
+  return short || name.trim()
+}
+
+/** Burn-bar label: "2h 55m left" (minutes zero-padded, clamps at zero). */
+export function formatTimeLeft(msLeft: number): string {
+  const totalSeconds = Math.max(0, Math.floor(msLeft / 1000))
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  return `${hours}h ${String(minutes).padStart(2, '0')}m left`
+}


### PR DESCRIPTION
## What

**Pint Signal Phase 1** — one mate lights the signal (pub + time), the crew gets the link, everyone answers IN or OUT with one tap. Signals burn out 3 hours after the meet time. No accounts, no push: the group chat is the delivery mechanism (native share sheet). Built to `docs/pint-signal-plan.md` from the approved prototype.

### Pieces
- **Schema** — `scripts/pint-signal-schema.sql`: `signals` + `signal_answers`, RLS public-read, writes only via service-role API routes. ⚠️ **Must be run in the Supabase SQL editor before the feature works** — until then, signal pages render the graceful "No signal here" state.
- **API** — `POST /api/signal` (validates, 5/hour per IP hash, auto-INs the lighter), `GET /api/signal/[id]` (poll payload), `POST /api/signal/[id]/answer` (410 after expiry, one answer per IP with re-answer replacing).
- **`/signal/new`** — the lighting flow: search or pick from the 5 cheapest suggestions with live-happy-hour pubs first, Perth-time chips (past times disabled), name, big amber LIGHT THE SIGNAL.
- **`/signal/[id]`** — the answer page from the prototype: dark beacon card (stars, swaying beam, glowing pint glyph), "{Pub}. {time}." headline, draining-glass timer, I'M IN / CAN'T TONIGHT with inline name+note, WHO'S ANSWERED list with IN/OUT chips and "That's a table." at 4+, 30-second polling, share-to-group-chat, localStorage answer memory. `noindex` + `force-dynamic`.
- **Hygiene** — robots disallows `/signal/`; `SubPageNav` gains an optional amber `badge` prop (used for the BETA chip).

### Verification
- `npx tsc --noEmit` clean · **321 tests pass** (+14 new: signal ids, expiry windows, robots rules) · lint clean apart from the 3 pre-existing SunsetSippers warnings
- Playwright screenshots: `/signal/new` at 375 and 1280 (live data renders, HH-now ordering works, past chips disabled), and the no-table/no-signal graceful state
- Implemented by a subagent against the written spec; reviewed and independently verified by the orchestrating session

### After merge
1. Run `scripts/pint-signal-schema.sql` at https://supabase.com/dashboard/project/ifxkoblvgttelzboenpi/sql/new
2. Light a test signal at `/signal/new` and share it to a real group chat

https://claude.ai/code/session_01FCyEdyeKbWCHzQP5nyfNex

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCyEdyeKbWCHzQP5nyfNex)_