### PR TITLE
Pint Signal: answers no longer vanish + signals self-delete after a week

### DIFF
--- a/docs/PROJECT-STATUS.md
+++ b/docs/PROJECT-STATUS.md
@@ -10,6 +10,10 @@ Stack, database, routes, components, and lib files are documented in `CLAUDE.md`
 
 ## What's done recently
 
+### Pint Signal: stale-answer fix + weekly sweep (2026-06-11)
+- **Answers vanished after posting** — `force-dynamic` doesn't stop Next's data cache memoising supabase-js fetches, so the 30s poll served a stale answers list and wiped the optimistic row (the answer was always in the DB). `fetchCache = 'force-no-store'` on `/signal/[id]` page + GET route, `cache: 'no-store'` on the client poll.
+- **Signals now delete themselves** — the daily price-check cron sweeps signals whose `expires_at` is >7 days old (dead links show the burned-out state for a week, then the rows go). noindex + robots `Disallow: /signal/` confirmed already live.
+
 ### Pint Signal Phase 1 (2026-06-10)
 - **The feature:** one mate lights the signal (pub + time), the crew gets the link, everyone answers IN/OUT with one tap; signals burn out 3h after the meet time. No accounts, no push — the group chat is the delivery (share sheet). Plan: `docs/pint-signal-plan.md`; prototype: `docs/prototypes/pint-signal.html`.
 - **New:** `signals` + `signal_answers` schema (`scripts/pint-signal-schema.sql` — **must be run in the Supabase SQL editor before the feature works**), `signalId`/`signals` libs (+14 tests), `POST /api/signal` (5/hr per ip_hash, auto-INs the lighter), `GET/POST /api/signal/[id](/answer)` (410 after expiry, one answer per IP, 30s poll), `/signal/new` (price-aware picker, live-HH pubs first, Perth-time chips), `/signal/[id]` (the dark beacon card + draining-glass timer + crew list, noindex, force-dynamic, graceful burned-out/missing states), robots disallow `/signal/`, `SubPageNav` gains an optional Beta `badge` prop.

--- a/src/app/api/cron/price-check/route.ts
+++ b/src/app/api/cron/price-check/route.ts
@@ -30,6 +30,16 @@ export async function GET(request: NextRequest) {
 
   const supabase = serviceClient()
 
+  // Sweep burned-out signals: dead share links keep working for a week (the
+  // page shows the burned-out state), then the rows go. Best-effort — a
+  // failure here must never break the price check.
+  try {
+    const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
+    await supabase.from('signals').delete().lt('expires_at', cutoff)
+  } catch (err) {
+    console.error('Signal sweep failed:', err)
+  }
+
   try {
     // 1. Fetch current verified prices
     const { data: currentPubs, error: pubError } = await supabase

--- a/src/app/api/signal/[id]/route.ts
+++ b/src/app/api/signal/[id]/route.ts
@@ -3,6 +3,9 @@ import { anonClient } from '@/lib/supabaseGateway'
 import { isExpired, type Signal, type SignalAnswer } from '@/lib/signals'
 
 export const dynamic = 'force-dynamic'
+// Without this, Next's data cache memoises the supabase REST fetches and the
+// 30s poll serves stale answers (answers appeared, then vanished on poll).
+export const fetchCache = 'force-no-store'
 
 /**
  * GET /api/signal/[id] — the answer page polls this every 30s for fresh

--- a/src/app/signal/[id]/SignalClient.tsx
+++ b/src/app/signal/[id]/SignalClient.tsx
@@ -198,7 +198,7 @@ export default function SignalClient({ view, initialAnswers, state }: SignalClie
     if (state !== 'live' || !signalId) return
     const interval = setInterval(async () => {
       try {
-        const res = await fetch(`/api/signal/${signalId}`)
+        const res = await fetch(`/api/signal/${signalId}`, { cache: 'no-store' })
         if (res.status === 404 || res.status === 410) {
           setBurnedOut(true)
           return
@@ -247,7 +247,7 @@ export default function SignalClient({ view, initialAnswers, state }: SignalClie
   const refreshAnswers = useCallback(async () => {
     if (!signalId) return
     try {
-      const res = await fetch(`/api/signal/${signalId}`)
+      const res = await fetch(`/api/signal/${signalId}`, { cache: 'no-store' })
       if (!res.ok) return
       const data = await res.json()
       if (Array.isArray(data.answers)) setAnswers(data.answers)

--- a/src/app/signal/[id]/page.tsx
+++ b/src/app/signal/[id]/page.tsx
@@ -12,7 +12,11 @@ import {
 import SignalClient, { type SignalView } from './SignalClient'
 
 // Signals are live, semi-private objects — never cache, never index.
+// force-dynamic alone is not enough: supabase-js rides Next's patched fetch,
+// and the data cache will happily serve a stale answers list on a dynamic
+// route. force-no-store opts every fetch in this segment out of the cache.
 export const dynamic = 'force-dynamic'
+export const fetchCache = 'force-no-store'
 
 interface SignalPub {
   name: string


### PR DESCRIPTION
## What

Fixes the bug from tonight's first real signal, plus the lifecycle question:

**1. Your answer appeared then disappeared.** The answer was always in the database — the page was the liar. `dynamic = 'force-dynamic'` doesn't opt supabase-js requests out of Next's *data* cache (they ride Next's patched `fetch`), so the 30-second poll got a memoised stale answers list and replaced the optimistic row with it. Fix: `fetchCache = 'force-no-store'` on the `/signal/[id]` page and its GET route, plus `cache: 'no-store'` on the client poll.

**2. Signals now delete themselves.** The existing daily price-check cron sweeps signals whose `expires_at` is more than 7 days past — dead share links show the "burned out" state for a week, then the rows (and their answers, via cascade) are gone. Best-effort: a sweep failure can't break the price check.

Noindex was already in place and verified live: `<meta name="robots" content="noindex, nofollow">` on signal pages and `Disallow: /signal/` in robots.txt.

## Verification

- `npx tsc --noEmit` clean, 321 tests pass
- Confirmed the "vanishing" answer (name "hid") exists in `signal_answers` — data was never lost

https://claude.ai/code/session_01FCyEdyeKbWCHzQP5nyfNex

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCyEdyeKbWCHzQP5nyfNex)_