### PR TITLE
refactor: formatters seam + perthClock footgun + one snapshot accessor (#57 #58 #59)

### DIFF
--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { serviceClient } from '@/lib/supabaseGateway'
+import { fetchLatestPriceSnapshot } from '@/lib/priceSnapshots'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { timingSafeEqual } from 'crypto'
 
@@ -178,7 +179,7 @@ export async function GET(request: NextRequest) {
       // Total pubs and breakdown
       supabase.from('pubs').select('id, slug, name, price, suburb, price_verified, last_verified, last_updated, cozy_pub, sunset_spot, kid_friendly, has_tab, happy_hour_price, happy_hour_days, vibe_tag', { count: 'exact' }),
       // Latest snapshot
-      supabase.from('price_snapshots').select('*').order('snapshot_date', { ascending: false }).limit(1),
+      fetchLatestPriceSnapshot(supabase),
       // Recent price changes
       supabase.from('price_history').select('*', { count: 'exact' }).order('changed_at', { ascending: false }).limit(10),
       // Price reports (crowdsourced)
@@ -266,7 +267,7 @@ export async function GET(request: NextRequest) {
           createdAt: r.created_at,
         })),
       },
-      snapshot: snapshotResult.data?.[0] || null,
+      snapshot: snapshotResult || null,
       priceHistory: {
         totalChanges: priceHistoryResult.count || 0,
         recent: (priceHistoryResult.data || []).map((h: any) => {

--- a/src/app/api/pint-index/route.ts
+++ b/src/app/api/pint-index/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { getPintPriceStats } from '@/lib/pintPriceStats'
 import { supabase } from '@/lib/supabase'
 import { getCachedPubs } from '@/lib/cachedPubs'
+import { fetchPriceSnapshots } from '@/lib/priceSnapshots'
 
 export const revalidate = 3600
 
@@ -15,16 +16,8 @@ export async function GET() {
   const pubs = await getCachedPubs()
   const stats = getPintPriceStats(pubs)
 
-  const { data } = await supabase
-    .from('price_snapshots')
-    .select('avg_price, snapshot_date')
-    .order('snapshot_date', { ascending: false })
-    .limit(12)
-
-  const spark = (data ?? [])
-    .map((d: { avg_price: string | number }) => parseFloat(String(d.avg_price)))
-    .filter((n: number) => Number.isFinite(n))
-    .reverse()
+  const snapshots = await fetchPriceSnapshots(supabase, { ascending: false, limit: 12 })
+  const spark = snapshots.map((s) => s.avg_price).reverse()
 
   return NextResponse.json({
     price: stats.averagePrice ?? null,

--- a/src/app/insights/pint-index/data.csv/route.ts
+++ b/src/app/insights/pint-index/data.csv/route.ts
@@ -1,55 +1,29 @@
 import { buildPintIndexCsv, PintIndexCsvRow } from '@/lib/pintIndexCsv'
 import { supabase } from '@/lib/supabase'
+import { fetchPriceSnapshots, type PriceSnapshot } from '@/lib/priceSnapshots'
 
 export const revalidate = 3600
 
-interface SnapshotRow {
-  snapshot_date: string
-  avg_price: number | string
-  median_price: number | string
-  min_price: number | string
-  max_price: number | string
-  total_pubs: number
-  total_suburbs: number
-  cheapest_suburb: string | null
-  cheapest_suburb_avg: number | string | null
-  most_expensive_suburb: string | null
-  most_expensive_suburb_avg: number | string | null
-}
-
-function toNumber(value: number | string | null): number | null {
-  if (value === null) return null
-  const number = Number(value)
-  return Number.isFinite(number) ? number : null
-}
-
-function toCsvRow(row: SnapshotRow): PintIndexCsvRow {
+function toCsvRow(row: PriceSnapshot): PintIndexCsvRow {
   return {
     snapshotDate: row.snapshot_date,
-    averagePrice: toNumber(row.avg_price) ?? 0,
-    medianPrice: toNumber(row.median_price) ?? 0,
-    minPrice: toNumber(row.min_price) ?? 0,
-    maxPrice: toNumber(row.max_price) ?? 0,
+    averagePrice: row.avg_price,
+    medianPrice: row.median_price,
+    minPrice: row.min_price,
+    maxPrice: row.max_price,
     totalPubs: row.total_pubs,
     totalSuburbs: row.total_suburbs,
     cheapestSuburb: row.cheapest_suburb,
-    cheapestSuburbAverage: toNumber(row.cheapest_suburb_avg),
+    cheapestSuburbAverage: row.cheapest_suburb_avg,
     mostExpensiveSuburb: row.most_expensive_suburb,
-    mostExpensiveSuburbAverage: toNumber(row.most_expensive_suburb_avg),
+    mostExpensiveSuburbAverage: row.most_expensive_suburb_avg,
   }
 }
 
 export async function GET() {
-  const { data, error } = await supabase
-    .from('price_snapshots')
-    .select('snapshot_date, avg_price, median_price, min_price, max_price, total_pubs, total_suburbs, cheapest_suburb, cheapest_suburb_avg, most_expensive_suburb, most_expensive_suburb_avg')
-    .order('snapshot_date', { ascending: true })
+  const snapshots = await fetchPriceSnapshots(supabase, { ascending: true })
 
-  if (error) {
-    return new Response('Unable to build Pint Index export\n', { status: 500 })
-  }
-
-  return new Response(buildPintIndexCsv(((data || []) as SnapshotRow[]).map(toCsvRow)), {
+  return new Response(buildPintIndexCsv(snapshots.map(toCsvRow)), {
     headers: {
       'Content-Type': 'text/csv; charset=utf-8',
       'Content-Disposition': 'attachment; filename="perth-pint-index.csv"',

--- a/src/components/PintIndex.tsx
+++ b/src/components/PintIndex.tsx
@@ -3,22 +3,8 @@
 import { useEffect, useState, useRef } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { supabase } from '@/lib/supabase';
+import { fetchPriceSnapshots, type PriceSnapshot } from '@/lib/priceSnapshots';
 import { BarChart3 } from 'lucide-react';
-
-interface PriceSnapshot {
-  snapshot_date: string;
-  avg_price: number;
-  median_price: number;
-  min_price: number;
-  max_price: number;
-  total_pubs: number;
-  total_suburbs: number;
-  cheapest_suburb: string;
-  cheapest_suburb_avg: number;
-  most_expensive_suburb: string;
-  most_expensive_suburb_avg: number;
-  price_distribution: Record<string, number>;
-}
 
 interface TooltipState {
   x: number;
@@ -210,25 +196,7 @@ export default function PintIndex({ live }: { live: PintIndexLive }) {
   const [expanded, setExpanded] = useState(true);
 
   useEffect(() => {
-    async function fetchSnapshots() {
-      const { data, error } = await supabase
-        .from('price_snapshots')
-        .select('*')
-        .order('snapshot_date', { ascending: true });
-
-      if (data && !error) {
-        setSnapshots(data.map(d => ({
-          ...d,
-          avg_price: parseFloat(d.avg_price),
-          median_price: parseFloat(d.median_price),
-          min_price: parseFloat(d.min_price),
-          max_price: parseFloat(d.max_price),
-          cheapest_suburb_avg: parseFloat(d.cheapest_suburb_avg),
-          most_expensive_suburb_avg: parseFloat(d.most_expensive_suburb_avg),
-        })));
-      }
-    }
-    fetchSnapshots();
+    fetchPriceSnapshots(supabase).then(setSnapshots);
   }, []);
 
   // Displayed figures are always the live canonical stats; the weekly snapshot

--- a/src/formatPrice.test.ts
+++ b/src/formatPrice.test.ts
@@ -1,7 +1,0 @@
-import { strict as assert } from 'node:assert'
-import { test } from 'node:test'
-import { formatPrice } from './formatPrice.js'
-
-test('formatPrice formats integer cents to dollar string', () => {
-  assert.equal(formatPrice(450), '$4.50')
-})

--- a/src/formatPrice.ts
+++ b/src/formatPrice.ts
@@ -1,3 +1,0 @@
-export function formatPrice(cents: number): string {
-  return `$${(cents / 100).toFixed(2)}`
-}

--- a/src/lib/formatters.test.ts
+++ b/src/lib/formatters.test.ts
@@ -1,0 +1,21 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { formatPrice, getPriceLabel, getPriceDiff } from './formatters.js'
+
+test('formatPrice formats integer cents to dollar string', () => {
+  assert.equal(formatPrice(450), '$4.50')
+})
+
+test('getPriceLabel buckets price against the average', () => {
+  assert.equal(getPriceLabel(7, 9.20).type, 'bargain')
+  assert.equal(getPriceLabel(9, 9.20).type, 'fair')
+  assert.equal(getPriceLabel(12, 9.20).type, 'pricey')
+  assert.equal(getPriceLabel(null).type, null)
+})
+
+test('getPriceDiff describes distance from the average', () => {
+  assert.equal(getPriceDiff(9.20, 9.20), 'At avg')
+  assert.equal(getPriceDiff(8, 9.20), '$1.20 below avg')
+  assert.equal(getPriceDiff(11, 9.20), '$1.80 above avg')
+  assert.equal(getPriceDiff(null), '')
+})

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -1,3 +1,10 @@
+// Price formatting + labelling seam. Consolidated here (issue #57) so all
+// price presentation lives in one place rather than at the src/ root.
+
+export function formatPrice(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`
+}
+
 export type PriceLabelType = 'bargain' | 'fair' | 'pricey' | null
 
 export function getPriceLabel(price: number | null, avgPrice: number = 9.20): { label: string; type: PriceLabelType } {

--- a/src/lib/perthClock.test.ts
+++ b/src/lib/perthClock.test.ts
@@ -48,3 +48,28 @@ describe('perthToday', () => {
     assert.equal(perthToday(new Date('2026-03-01T17:00:00.000Z')), '2026-03-02')
   })
 })
+
+describe('host-timezone independence', () => {
+  it('produces identical fields regardless of the host TZ (proves no double-shift)', () => {
+    // Node re-reads process.env.TZ for Date operations created after it changes,
+    // so flipping it here exercises the exact host-dependent path the dropped
+    // `.date` field used to expose (issue #58) — within a single test run.
+    const instant = new Date('2026-01-15T20:00:00.000Z')
+    const original = process.env.TZ
+    try {
+      process.env.TZ = 'America/New_York' // UTC-5
+      const east = perthNow(instant)
+      process.env.TZ = 'Australia/Perth' // UTC+8
+      const perth = perthNow(instant)
+      process.env.TZ = 'UTC'
+      const utc = perthNow(instant)
+      assert.deepEqual(east, perth)
+      assert.deepEqual(perth, utc)
+      assert.equal(perth.ymd, '2026-01-16')
+      assert.equal(perth.minutesOfDay, 4 * 60)
+    } finally {
+      if (original === undefined) delete process.env.TZ
+      else process.env.TZ = original
+    }
+  })
+})

--- a/src/lib/perthClock.ts
+++ b/src/lib/perthClock.ts
@@ -16,11 +16,6 @@
 const PERTH_OFFSET_MS = 8 * 60 * 60 * 1000 // UTC+8, fixed (Western Australia has no DST)
 
 export interface PerthNow {
-  /**
-   * A Date whose UTC fields read as Perth wall-clock time.
-   * Prefer the structured fields below; if you must read this Date, use getUTC*.
-   */
-  date: Date
   /** Day of week in Perth: 0 = Sunday … 6 = Saturday. */
   dayOfWeek: number
   /** Minutes since Perth midnight, 0..1439. */
@@ -29,11 +24,17 @@ export interface PerthNow {
   ymd: string
 }
 
-/** Resolve the current Perth wall-clock fields for a given instant. */
+/**
+ * Resolve the current Perth wall-clock fields for a given instant.
+ *
+ * The +8h-shifted Date is intentionally kept private: exposing it invited
+ * callers to read local getters (getHours/getDate) off it, which double-shifts
+ * on a non-Perth host (issue #58). Only the derived numeric/string fields,
+ * which are host-timezone independent, leave this function.
+ */
 export function perthNow(now: Date = new Date()): PerthNow {
   const shifted = new Date(now.getTime() + PERTH_OFFSET_MS)
   return {
-    date: shifted,
     dayOfWeek: shifted.getUTCDay(),
     minutesOfDay: shifted.getUTCHours() * 60 + shifted.getUTCMinutes(),
     ymd: shifted.toISOString().slice(0, 10),

--- a/src/lib/priceSnapshots.ts
+++ b/src/lib/priceSnapshots.ts
@@ -1,0 +1,89 @@
+/**
+ * The single price_snapshots read seam (issue #59).
+ *
+ * Snapshots were fetched and coerced in several places with drifting idioms —
+ * different orderings, limits, and parseFloat handling. That drift caused the
+ * PintIndexBadge oldest-vs-newest bug. Every read now goes through here so the
+ * ordering, limit, and numeric coercion are defined once.
+ *
+ * Numeric columns arrive from PostgREST as strings (numeric type), so they are
+ * always coerced to numbers here; callers receive ready-to-use values.
+ */
+
+export interface PriceSnapshot {
+  snapshot_date: string
+  avg_price: number
+  median_price: number
+  min_price: number
+  max_price: number
+  total_pubs: number
+  total_suburbs: number
+  cheapest_suburb: string | null
+  cheapest_suburb_avg: number | null
+  most_expensive_suburb: string | null
+  most_expensive_suburb_avg: number | null
+  price_distribution: Record<string, number>
+}
+
+const SNAPSHOT_COLUMNS =
+  'snapshot_date, avg_price, median_price, min_price, max_price, total_pubs, total_suburbs, cheapest_suburb, cheapest_suburb_avg, most_expensive_suburb, most_expensive_suburb_avg, price_distribution'
+
+// Structural client type so anon, service, and browser supabase clients all fit
+// without fighting supabase-js generics.
+interface SnapshotQueryClient {
+  from: (table: string) => {
+    select: (columns: string) => {
+      order: (
+        column: string,
+        opts: { ascending: boolean },
+      ) => {
+        limit: (n: number) => PromiseLike<{ data: unknown[] | null; error: unknown }>
+      } & PromiseLike<{ data: unknown[] | null; error: unknown }>
+    }
+  }
+}
+
+function num(value: unknown): number {
+  const n = typeof value === 'number' ? value : parseFloat(String(value))
+  return Number.isFinite(n) ? n : 0
+}
+
+function numOrNull(value: unknown): number | null {
+  if (value === null || value === undefined) return null
+  const n = typeof value === 'number' ? value : parseFloat(String(value))
+  return Number.isFinite(n) ? n : null
+}
+
+export function coercePriceSnapshot(row: Record<string, unknown>): PriceSnapshot {
+  return {
+    snapshot_date: String(row.snapshot_date),
+    avg_price: num(row.avg_price),
+    median_price: num(row.median_price),
+    min_price: num(row.min_price),
+    max_price: num(row.max_price),
+    total_pubs: num(row.total_pubs),
+    total_suburbs: num(row.total_suburbs),
+    cheapest_suburb: (row.cheapest_suburb as string | null) ?? null,
+    cheapest_suburb_avg: numOrNull(row.cheapest_suburb_avg),
+    most_expensive_suburb: (row.most_expensive_suburb as string | null) ?? null,
+    most_expensive_suburb_avg: numOrNull(row.most_expensive_suburb_avg),
+    price_distribution: (row.price_distribution as Record<string, number>) ?? {},
+  }
+}
+
+/** Fetch coerced snapshots, oldest-first by default. Returns [] on error. */
+export async function fetchPriceSnapshots(
+  client: SnapshotQueryClient,
+  { ascending = true, limit }: { ascending?: boolean; limit?: number } = {},
+): Promise<PriceSnapshot[]> {
+  const ordered = client.from('price_snapshots').select(SNAPSHOT_COLUMNS).order('snapshot_date', { ascending })
+  const { data, error } = await (limit !== undefined ? ordered.limit(limit) : ordered)
+  if (error || !data) return []
+  return data.map((row) => coercePriceSnapshot(row as Record<string, unknown>))
+}
+
+/** The most recent snapshot, or null. */
+export async function fetchLatestPriceSnapshot(client: SnapshotQueryClient): Promise<PriceSnapshot | null> {
+  const rows = await fetchPriceSnapshots(client, { ascending: false, limit: 1 })
+  return rows[0] ?? null
+}


### PR DESCRIPTION
Closes #57, #58, #59 (Architecture Refactor milestone). Three self-contained refactors, behaviour-preserving, bundled because they're all small and verify together.

## #57 — Formatters seam
Consolidated price formatting into `src/lib/formatters.ts` (`formatPrice` + the `priceLabel` helpers). Deleted `src/formatPrice.ts` (odd home at the `src/` root) and `src/lib/priceLabel.ts`. Test moved to `src/lib/formatters.test.ts` with added coverage for the label/diff helpers.

Finding: both were near-dead — `formatPrice` (cents-based) was imported only by its own test, and `priceLabel` had **zero** importers (the dozen component-local `formatPrice` helpers are a different dollars-based signature, left untouched as out of scope). Relocated rather than pruned, to give the single seam the issue asked for.

## #58 — perthClock footgun
Dropped `PerthNow.date` — a Date whose UTC fields are pre-shifted to Perth wall-clock time, which double-shifts the moment a caller reads `.getHours()`/`.getDate()` off it on a non-Perth host. Audited all callers (signals, worldCup, happyHourLive, NewSignalClient): **none** read `.date`; they all use `ymd`/`minutesOfDay`/`dayOfWeek`. Added a test that flips `process.env.TZ` mid-run to assert host-timezone independence in a single pass (stronger than relying on the CI TZ matrix).

## #59 — One price_snapshots accessor
New `src/lib/priceSnapshots.ts` defines the ordering + limit + numeric coercion once (`fetchPriceSnapshots`, `fetchLatestPriceSnapshot`, `coercePriceSnapshot`). Routed all four readers through it — `PintIndex`, `admin/stats`, the `/api/pint-index` chip feed, and the CSV export — removing four divergent `parseFloat` idioms (the drift that caused the original PintIndexBadge oldest-vs-newest bug). Egress unchanged: every reader is ISR-cached hourly or admin/browser-only.

## Verification
- `tsc --noEmit` clean
- **324 tests pass** (+3), incl. the new TZ-independence test
- `next build` succeeds
- `next lint` clean on all touched files
- perthClock suite re-run green under `TZ=America/New_York`

https://claude.ai/code/session_01HRdu5eYTJoUZ5sPJqVUzkk

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRdu5eYTJoUZ5sPJqVUzkk)_